### PR TITLE
security: remove embedded proxy credentials and add secure secret man…

### DIFF
--- a/.decodo-credentials.example
+++ b/.decodo-credentials.example
@@ -1,0 +1,17 @@
+# Example Decodo proxy credentials file
+# Copy this to .decodo-credentials and fill in your actual credentials
+# For production, use GCP Secret Manager instead (see CONTRIBUTING.md)
+
+# Individual environment variables (recommended for local dev)
+DECODO_USERNAME=your-decodo-username
+DECODO_PASSWORD=your-decodo-password
+DECODO_HOST=isp.decodo.com
+DECODO_COUNTRY=us
+
+# Or full proxy URL (alternative)
+FULL_PROXY_URL=https://your-username:your-password@isp.decodo.com:10000
+
+# For GCP Secret Manager (production recommended)
+# Set DECODO_SECRET_NAME=decodo-proxy-creds
+# Secret payload should be JSON: {"username":"...","password":"...","host":"isp.decodo.com","country":"us"}
+# Or plain full proxy URL string

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,49 @@ REQUEST_DELAY=1.0
 
 # Kubernetes-specific context (optional)
 KUBERNETES_NAMESPACE=
+
+# Proxy Configuration
+# See docs/PROXY_CONFIGURATION.md for details
+
+# Master proxy provider switch
+PROXY_PROVIDER=origin  # Options: origin, direct, decodo, brightdata, etc.
+
+# Origin proxy (default)
+ORIGIN_PROXY_URL=http://proxy.kiesow.net:23432
+PROXY_USERNAME=
+PROXY_PASSWORD=
+
+# Decodo ISP proxy (requires credentials)
+# Option A: Individual environment variables (recommended for local dev)
+DECODO_USERNAME=your-decodo-username
+DECODO_PASSWORD=your-decodo-password
+DECODO_HOST=isp.decodo.com
+DECODO_PORT=10000
+DECODO_COUNTRY=us
+DECODO_ROTATE_IP=true
+
+# Option B: GCP Secret Manager (recommended for production)
+# Set DECODO_SECRET_NAME to the secret ID (e.g., decodo-proxy-creds)
+# Secret payload should be JSON: {"username":"...","password":"...","host":"isp.decodo.com","country":"us"}
+# Or plain full proxy URL: https://username:password@isp.decodo.com:10000
+DECODO_SECRET_NAME=
+
+# Other proxy providers (optional)
+STANDARD_PROXY_URL=
+STANDARD_PROXY_USERNAME=
+STANDARD_PROXY_PASSWORD=
+
+SOCKS5_PROXY_URL=
+SOCKS5_PROXY_USERNAME=
+SOCKS5_PROXY_PASSWORD=
+
+BRIGHTDATA_PROXY_URL=
+BRIGHTDATA_USERNAME=
+BRIGHTDATA_PASSWORD=
+BRIGHTDATA_ZONE=residential
+
+SCRAPERAPI_KEY=
+
+SMARTPROXY_URL=
+SMARTPROXY_USERNAME=
+SMARTPROXY_PASSWORD=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,12 @@ pytest -q
 1. Security & sensitive data
 
 1. Never commit secrets (API keys, credentials). Use environment variables
-   and secrets management for CI.
+   and secrets management for CI/production.
+1. For proxy credentials (Decodo, etc.), use one of these methods:
+   - **Local development**: Set `DECODO_USERNAME` and `DECODO_PASSWORD` environment variables.
+   - **Production**: Use GCP Secret Manager by setting `DECODO_SECRET_NAME` to the secret ID.
+     Create the secret with JSON payload: `{"username":"...","password":"...","host":"isp.decodo.com","country":"us"}`
+     or plain full proxy URL.
 1. If you find a security vulnerability, follow SECURITY.md to report it.
 
 1. Thank you

--- a/DEP_LICENSES.md
+++ b/DEP_LICENSES.md
@@ -1,0 +1,347 @@
+| Name                             | Version        | License                                                                                          |
+|----------------------------------|----------------|--------------------------------------------------------------------------------------------------|
+| Authlib                          | 1.6.5          | BSD License                                                                                      |
+| Jinja2                           | 3.1.6          | BSD License                                                                                      |
+| Mako                             | 1.3.10         | MIT License                                                                                      |
+| MarkupSafe                       | 3.0.2          | BSD License                                                                                      |
+| PySocks                          | 1.7.1          | BSD                                                                                              |
+| PyYAML                           | 6.0.2          | MIT License                                                                                      |
+| Pygments                         | 2.19.2         | BSD License                                                                                      |
+| RapidFuzz                        | 3.14.1         | MIT                                                                                              |
+| SQLAlchemy                       | 2.0.43         | MIT                                                                                              |
+| Send2Trash                       | 1.8.3          | BSD License                                                                                      |
+| Sphinx                           | 7.4.7          | BSD License                                                                                      |
+| accessible-pygments              | 0.0.5          | BSD License                                                                                      |
+| aiofiles                         | 24.1.0         | Apache Software License                                                                          |
+| aiohappyeyeballs                 | 2.6.1          | Python Software Foundation License                                                               |
+| aiohttp                          | 3.13.0         | Apache-2.0 AND MIT                                                                               |
+| aiosignal                        | 1.4.0          | Apache Software License                                                                          |
+| alabaster                        | 0.7.16         | BSD License                                                                                      |
+| alembic                          | 1.16.5         | MIT                                                                                              |
+| annotated-types                  | 0.7.0          | MIT License                                                                                      |
+| ansicolors                       | 1.1.8          | ISC License (ISCL)                                                                               |
+| anyio                            | 4.10.0         | MIT                                                                                              |
+| appnope                          | 0.1.4          | BSD License                                                                                      |
+| argon2-cffi                      | 25.1.0         | MIT                                                                                              |
+| argon2-cffi-bindings             | 25.1.0         | MIT                                                                                              |
+| arrow                            | 1.3.0          | Apache Software License                                                                          |
+| asn1crypto                       | 1.5.1          | MIT License                                                                                      |
+| asttokens                        | 3.0.0          | Apache 2.0                                                                                       |
+| async-lru                        | 2.0.5          | MIT License                                                                                      |
+| async-timeout                    | 5.0.1          | Apache Software License                                                                          |
+| attrs                            | 25.3.0         | MIT                                                                                              |
+| babel                            | 2.17.0         | BSD License                                                                                      |
+| backports-datetime-fromisoformat | 2.0.3          | MIT License                                                                                      |
+| backports.asyncio.runner         | 1.2.0          | Python Software Foundation License                                                               |
+| bandit                           | 1.8.6          | Apache-2.0                                                                                       |
+| beautifulsoup4                   | 4.13.5         | MIT License                                                                                      |
+| black                            | 25.1.0         | MIT                                                                                              |
+| bleach                           | 6.2.0          | Apache Software License                                                                          |
+| blis                             | 1.3.0          | BSD License                                                                                      |
+| cachetools                       | 6.2.0          | MIT License                                                                                      |
+| catalogue                        | 2.0.10         | MIT License                                                                                      |
+| cattrs                           | 25.2.0         | MIT License                                                                                      |
+| certifi                          | 2025.8.3       | Mozilla Public License 2.0 (MPL 2.0)                                                             |
+| cffi                             | 2.0.0          | MIT                                                                                              |
+| cfgv                             | 3.4.0          | MIT License                                                                                      |
+| charset-normalizer               | 3.4.3          | MIT                                                                                              |
+| click                            | 8.3.0          | BSD-3-Clause                                                                                     |
+| cloud-sql-python-connector       | 1.18.5         | Apache-2.0                                                                                       |
+| cloudpathlib                     | 0.22.0         | MIT License                                                                                      |
+| cloudscraper                     | 1.2.71         | MIT License                                                                                      |
+| comm                             | 0.2.3          | BSD License                                                                                      |
+| confection                       | 0.1.5          | MIT License                                                                                      |
+| coverage                         | 7.10.6         | Apache-2.0                                                                                       |
+| cramjam                          | 2.11.0         | MIT                                                                                              |
+| cryptography                     | 46.0.3         | Apache-2.0 OR BSD-3-Clause                                                                       |
+| cymem                            | 2.0.11         | MIT License                                                                                      |
+| debugpy                          | 1.8.17         | MIT License                                                                                      |
+| decorator                        | 5.2.1          | BSD License                                                                                      |
+| defusedxml                       | 0.7.1          | Python Software Foundation License                                                               |
+| distlib                          | 0.4.0          | Python Software Foundation License                                                               |
+| dnspython                        | 2.8.0          | ISC License (ISCL)                                                                               |
+| docker                           | 7.1.0          | Apache-2.0                                                                                       |
+| docutils                         | 0.21.2         | BSD License; GNU General Public License (GPL); Public Domain; Python Software Foundation License |
+| dparse                           | 0.6.4          | MIT License                                                                                      |
+| entrypoints                      | 0.4            | MIT License                                                                                      |
+| exceptiongroup                   | 1.3.0          | MIT License                                                                                      |
+| execnet                          | 2.1.1          | MIT                                                                                              |
+| executing                        | 2.2.1          | MIT License                                                                                      |
+| fastapi                          | 0.119.0        | MIT License                                                                                      |
+| fastjsonschema                   | 2.21.2         | BSD License                                                                                      |
+| fastparquet                      | 2024.11.0      | Apache Software License                                                                          |
+| feedparser                       | 6.0.12         | BSD License                                                                                      |
+| filelock                         | 3.19.1         | Unlicense                                                                                        |
+| flake8                           | 7.3.0          | MIT License                                                                                      |
+| fqdn                             | 1.5.1          | Mozilla Public License 2.0 (MPL 2.0)                                                             |
+| frozenlist                       | 1.8.0          | Apache-2.0                                                                                       |
+| fsspec                           | 2025.9.0       | BSD-3-Clause                                                                                     |
+| ftfy                             | 6.3.1          | Apache-2.0                                                                                       |
+| google-auth                      | 2.41.1         | Apache Software License                                                                          |
+| h11                              | 0.16.0         | MIT License                                                                                      |
+| hf-xet                           | 1.1.10         | Apache-2.0                                                                                       |
+| httpcore                         | 1.0.9          | BSD-3-Clause                                                                                     |
+| httptools                        | 0.6.4          | MIT License                                                                                      |
+| httpx                            | 0.28.1         | BSD License                                                                                      |
+| huggingface-hub                  | 0.35.0         | Apache Software License                                                                          |
+| identify                         | 2.6.14         | MIT                                                                                              |
+| idna                             | 3.10           | BSD License                                                                                      |
+| imagesize                        | 1.4.1          | MIT License                                                                                      |
+| importlib_metadata               | 8.7.0          | Apache Software License                                                                          |
+| iniconfig                        | 2.1.0          | MIT                                                                                              |
+| ipykernel                        | 6.30.1         | BSD 3-Clause License                                                                             |
+|                                  |                |                                                                                                  |
+|                                  |                | Copyright (c) 2015, IPython Development Team                                                     |
+|                                  |                |                                                                                                  |
+|                                  |                | All rights reserved.                                                                             |
+|                                  |                |                                                                                                  |
+|                                  |                | Redistribution and use in source and binary forms, with or without                               |
+|                                  |                | modification, are permitted provided that the following conditions are met:                      |
+|                                  |                |                                                                                                  |
+|                                  |                | 1. Redistributions of source code must retain the above copyright notice, this                   |
+|                                  |                |    list of conditions and the following disclaimer.                                              |
+|                                  |                |                                                                                                  |
+|                                  |                | 2. Redistributions in binary form must reproduce the above copyright notice,                     |
+|                                  |                |    this list of conditions and the following disclaimer in the documentation                     |
+|                                  |                |    and/or other materials provided with the distribution.                                        |
+|                                  |                |                                                                                                  |
+|                                  |                | 3. Neither the name of the copyright holder nor the names of its                                 |
+|                                  |                |    contributors may be used to endorse or promote products derived from                          |
+|                                  |                |    this software without specific prior written permission.                                      |
+|                                  |                |                                                                                                  |
+|                                  |                | THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"                      |
+|                                  |                | AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE                        |
+|                                  |                | IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                   |
+|                                  |                | DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE                     |
+|                                  |                | FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL                       |
+|                                  |                | DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR                       |
+|                                  |                | SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                       |
+|                                  |                | CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,                    |
+|                                  |                | OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE                    |
+|                                  |                | OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                             |
+| ipython                          | 8.37.0         | BSD License                                                                                      |
+| isoduration                      | 20.11.0        | ISC License (ISCL)                                                                               |
+| isort                            | 6.0.1          | MIT                                                                                              |
+| jedi                             | 0.19.2         | MIT License                                                                                      |
+| joblib                           | 1.5.2          | BSD License                                                                                      |
+| json5                            | 0.12.1         | Apache Software License                                                                          |
+| jsonpointer                      | 3.0.0          | BSD License                                                                                      |
+| jsonschema                       | 4.25.1         | MIT                                                                                              |
+| jsonschema-specifications        | 2025.9.1       | MIT                                                                                              |
+| jupyter-book                     | 1.0.4.post1    | BSD License                                                                                      |
+| jupyter-cache                    | 1.0.1          | MIT License                                                                                      |
+| jupyter-events                   | 0.12.0         | BSD License                                                                                      |
+| jupyter-lsp                      | 2.3.0          | BSD License                                                                                      |
+| jupyter_client                   | 8.6.3          | BSD License                                                                                      |
+| jupyter_core                     | 5.8.1          | BSD-3-Clause                                                                                     |
+| jupyter_server                   | 2.17.0         | BSD License                                                                                      |
+| jupyter_server_terminals         | 0.5.3          | BSD License                                                                                      |
+| jupyterlab                       | 4.4.7          | BSD License                                                                                      |
+| jupyterlab_pygments              | 0.3.0          | BSD License                                                                                      |
+| jupyterlab_server                | 2.27.3         | BSD License                                                                                      |
+| langcodes                        | 3.5.0          | MIT License                                                                                      |
+| language_data                    | 1.3.0          | MIT License                                                                                      |
+| lark                             | 1.2.2          | MIT License                                                                                      |
+| latexcodec                       | 3.0.1          | MIT License                                                                                      |
+| linkify-it-py                    | 2.0.3          | MIT License                                                                                      |
+| lxml                             | 6.0.1          | BSD License                                                                                      |
+| lxml_html_clean                  | 0.4.3          | BSD-3-Clause                                                                                     |
+| marisa-trie                      | 1.3.1          | MIT AND (BSD-2-Clause OR LGPL-2.1-or-later)                                                      |
+| markdown-it-py                   | 3.0.0          | MIT License                                                                                      |
+| marshmallow                      | 4.0.1          | MIT License                                                                                      |
+| matplotlib-inline                | 0.1.7          | BSD License                                                                                      |
+| mccabe                           | 0.7.0          | MIT License                                                                                      |
+| mdit-py-plugins                  | 0.5.0          | MIT License                                                                                      |
+| mdurl                            | 0.1.2          | MIT License                                                                                      |
+| memory-profiler                  | 0.61.0         | BSD License                                                                                      |
+| mirakuru                         | 2.6.1          | LGPL-3.0-or-later                                                                                |
+| mistune                          | 3.1.4          | BSD License                                                                                      |
+| mpmath                           | 1.3.0          | BSD License                                                                                      |
+| multidict                        | 6.7.0          | Apache License 2.0                                                                               |
+| murmurhash                       | 1.0.13         | MIT License                                                                                      |
+| mypy                             | 1.18.2         | MIT License                                                                                      |
+| mypy_extensions                  | 1.1.0          | MIT                                                                                              |
+| myst-nb                          | 1.3.0          | UNKNOWN                                                                                          |
+| myst-parser                      | 3.0.1          | MIT License                                                                                      |
+| nbclient                         | 0.10.2         | BSD License                                                                                      |
+| nbconvert                        | 7.16.6         | BSD License                                                                                      |
+| nbformat                         | 5.10.4         | BSD License                                                                                      |
+| nbstripout                       | 0.8.1          | License :: OSI Approved :: MIT License                                                           |
+| nest-asyncio                     | 1.6.0          | BSD License                                                                                      |
+| networkx                         | 3.4.2          | BSD License                                                                                      |
+| newspaper4k                      | 0.9.3          | MIT License                                                                                      |
+| nltk                             | 3.9.2          | Apache Software License                                                                          |
+| nodeenv                          | 1.9.1          | BSD License                                                                                      |
+| notebook_shim                    | 0.2.4          | BSD License                                                                                      |
+| numpy                            | 2.2.6          | BSD License                                                                                      |
+| outcome                          | 1.3.0.post0    | Apache Software License; MIT License                                                             |
+| overrides                        | 7.7.0          | Apache License, Version 2.0                                                                      |
+| packaging                        | 25.0           | Apache Software License; BSD License                                                             |
+| pandas                           | 2.3.2          | BSD License                                                                                      |
+| pandocfilters                    | 1.5.1          | BSD License                                                                                      |
+| papermill                        | 2.6.0          | BSD License                                                                                      |
+| parso                            | 0.8.5          | MIT License                                                                                      |
+| pathspec                         | 0.12.1         | Mozilla Public License 2.0 (MPL 2.0)                                                             |
+| pexpect                          | 4.9.0          | ISC License (ISCL)                                                                               |
+| pg8000                           | 1.31.5         | BSD License                                                                                      |
+| pillow                           | 11.3.0         | MIT-CMU                                                                                          |
+| platformdirs                     | 4.4.0          | MIT                                                                                              |
+| pluggy                           | 1.6.0          | MIT License                                                                                      |
+| port-for                         | 1.0.0          | MIT License                                                                                      |
+| pre_commit                       | 4.3.0          | MIT                                                                                              |
+| preshed                          | 3.0.10         | MIT License                                                                                      |
+| prometheus_client                | 0.23.1         | Apache-2.0 AND BSD-2-Clause                                                                      |
+| prompt_toolkit                   | 3.0.52         | BSD License                                                                                      |
+| propcache                        | 0.4.0          | Apache Software License                                                                          |
+| psutil                           | 7.1.0          | BSD-3-Clause                                                                                     |
+| psycopg                          | 3.2.10         | GNU Lesser General Public License v3 (LGPLv3)                                                    |
+| psycopg2-binary                  | 2.9.10         | GNU Library or Lesser General Public License (LGPL)                                              |
+| ptyprocess                       | 0.7.0          | ISC License (ISCL)                                                                               |
+| pure_eval                        | 0.2.3          | MIT License                                                                                      |
+| py-spy                           | 0.4.1          | MIT License                                                                                      |
+| pyarrow                          | 21.0.0         | Apache Software License                                                                          |
+| pyasn1                           | 0.6.1          | BSD License                                                                                      |
+| pyasn1_modules                   | 0.4.2          | BSD License                                                                                      |
+| pybtex                           | 0.25.1         | MIT                                                                                              |
+| pybtex-docutils                  | 1.0.3          | MIT License                                                                                      |
+| pycodestyle                      | 2.14.0         | MIT                                                                                              |
+| pycparser                        | 2.23           | BSD License                                                                                      |
+| pydantic                         | 2.11.9         | MIT                                                                                              |
+| pydantic_core                    | 2.33.2         | MIT License                                                                                      |
+| pydata-sphinx-theme              | 0.15.4         | BSD License                                                                                      |
+| pyflakes                         | 3.4.0          | MIT License                                                                                      |
+| pyparsing                        | 3.2.5          | MIT                                                                                              |
+| pytest                           | 8.4.2          | MIT License                                                                                      |
+| pytest-asyncio                   | 1.2.0          | Apache-2.0                                                                                       |
+| pytest-cov                       | 7.0.0          | MIT                                                                                              |
+| pytest-mock                      | 3.15.1         | MIT License                                                                                      |
+| pytest-postgresql                | 7.0.2          | GNU Lesser General Public License v3 or later (LGPLv3+)                                          |
+| pytest-xdist                     | 3.8.0          | MIT                                                                                              |
+| python-dateutil                  | 2.9.0.post0    | Apache Software License; BSD License                                                             |
+| python-dotenv                    | 1.1.1          | BSD License                                                                                      |
+| python-json-logger               | 3.3.0          | BSD License                                                                                      |
+| pytz                             | 2025.2         | MIT License                                                                                      |
+| pyzmq                            | 27.1.0         | BSD License                                                                                      |
+| referencing                      | 0.36.2         | MIT                                                                                              |
+| regex                            | 2025.9.1       | Apache-2.0 AND CNRI-Python                                                                       |
+| requests                         | 2.32.5         | Apache Software License                                                                          |
+| requests-cache                   | 1.2.1          | BSD License                                                                                      |
+| requests-file                    | 3.0.0          | Apache Software License                                                                          |
+| requests-mock                    | 1.12.1         | Apache Software License                                                                          |
+| requests-toolbelt                | 1.0.0          | Apache Software License                                                                          |
+| rfc3339-validator                | 0.1.4          | MIT License                                                                                      |
+| rfc3986-validator                | 0.1.1          | MIT License                                                                                      |
+| rfc3987-syntax                   | 1.1.0          | MIT                                                                                              |
+| rich                             | 14.1.0         | MIT License                                                                                      |
+| rpds-py                          | 0.27.1         | MIT                                                                                              |
+| rsa                              | 4.9.1          | Apache Software License                                                                          |
+| ruamel.yaml                      | 0.18.15        | MIT License                                                                                      |
+| ruamel.yaml.clib                 | 0.2.14         | MIT License                                                                                      |
+| ruff                             | 0.13.1         | MIT License                                                                                      |
+| safetensors                      | 0.6.2          | Apache Software License                                                                          |
+| safety                           | 3.6.2          | MIT                                                                                              |
+| safety-schemas                   | 0.0.16         | MIT License                                                                                      |
+| scikit-learn                     | 1.5.1          | BSD License                                                                                      |
+| scipy                            | 1.15.3         | BSD License                                                                                      |
+| scramp                           | 1.4.6          | MIT No Attribution License (MIT-0)                                                               |
+| selenium                         | 4.35.0         | Apache-2.0                                                                                       |
+| selenium-stealth                 | 1.0.6          | MIT License                                                                                      |
+| sgmllib3k                        | 1.0.0          | BSD License                                                                                      |
+| shellingham                      | 1.5.4          | ISC License (ISCL)                                                                               |
+| six                              | 1.17.0         | MIT License                                                                                      |
+| skops                            | 0.13.0         | The MIT License (MIT)                                                                            |
+|                                  |                |                                                                                                  |
+|                                  |                | Copyright (C) 2021 Hugging Face Inc.                                                             |
+|                                  |                |                                                                                                  |
+|                                  |                | Permission is hereby granted, free of charge, to any person obtaining a copy                     |
+|                                  |                | of this software and associated documentation files (the "Software"), to deal                    |
+|                                  |                | in the Software without restriction, including without limitation the rights                     |
+|                                  |                | to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                        |
+|                                  |                | copies of the Software, and to permit persons to whom the Software is                            |
+|                                  |                | furnished to do so, subject to the following conditions:                                         |
+|                                  |                |                                                                                                  |
+|                                  |                | The above copyright notice and this permission notice shall be included in                       |
+|                                  |                | all copies or substantial portions of the Software.                                              |
+|                                  |                |                                                                                                  |
+|                                  |                | THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                       |
+|                                  |                | IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                         |
+|                                  |                | FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                      |
+|                                  |                | AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                           |
+|                                  |                | LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                    |
+|                                  |                | OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                        |
+|                                  |                | THE SOFTWARE.                                                                                    |
+| smart_open                       | 7.3.1          | MIT License                                                                                      |
+| sniffio                          | 1.3.1          | Apache Software License; MIT License                                                             |
+| snowballstemmer                  | 3.0.1          | BSD License                                                                                      |
+| sortedcontainers                 | 2.4.0          | Apache Software License                                                                          |
+| soupsieve                        | 2.8            | MIT                                                                                              |
+| spacy                            | 3.8.7          | MIT License                                                                                      |
+| spacy-legacy                     | 3.0.12         | MIT License                                                                                      |
+| spacy-loggers                    | 1.0.5          | MIT                                                                                              |
+| sphinx-book-theme                | 1.1.4          | BSD License                                                                                      |
+| sphinx-comments                  | 0.0.3          | MIT License                                                                                      |
+| sphinx-copybutton                | 0.5.2          | MIT License                                                                                      |
+| sphinx-jupyterbook-latex         | 1.0.0          | BSD License                                                                                      |
+| sphinx-multitoc-numbering        | 0.1.3          | MIT                                                                                              |
+| sphinx-rtd-theme                 | 3.0.2          | MIT License                                                                                      |
+| sphinx-thebe                     | 0.3.1          | MIT                                                                                              |
+| sphinx-togglebutton              | 0.3.2          | MIT License                                                                                      |
+| sphinx_design                    | 0.6.1          | MIT License                                                                                      |
+| sphinx_external_toc              | 1.0.1          | MIT License                                                                                      |
+| sphinxcontrib-applehelp          | 2.0.0          | BSD License                                                                                      |
+| sphinxcontrib-bibtex             | 2.6.5          | BSD-2-Clause                                                                                     |
+| sphinxcontrib-devhelp            | 2.0.0          | BSD License                                                                                      |
+| sphinxcontrib-htmlhelp           | 2.1.0          | BSD License                                                                                      |
+| sphinxcontrib-jquery             | 4.1            | BSD License                                                                                      |
+| sphinxcontrib-jsmath             | 1.0.1          | BSD License                                                                                      |
+| sphinxcontrib-qthelp             | 2.0.0          | BSD License                                                                                      |
+| sphinxcontrib-serializinghtml    | 2.0.0          | BSD License                                                                                      |
+| srsly                            | 2.5.1          | MIT License                                                                                      |
+| stack-data                       | 0.6.3          | MIT License                                                                                      |
+| starlette                        | 0.48.0         | BSD-3-Clause                                                                                     |
+| stevedore                        | 5.5.0          | Apache Software License                                                                          |
+| storysniffer                     | 1.0.7          | MIT License                                                                                      |
+| structlog                        | 25.4.0         | MIT OR Apache-2.0                                                                                |
+| sympy                            | 1.14.0         | BSD License                                                                                      |
+| tabulate                         | 0.9.0          | MIT License                                                                                      |
+| tenacity                         | 9.1.2          | Apache Software License                                                                          |
+| terminado                        | 0.18.1         | BSD License                                                                                      |
+| testcontainers                   | 4.13.2         | Apache Software License                                                                          |
+| textblob                         | 0.19.0         | MIT License                                                                                      |
+| thinc                            | 8.3.6          | MIT License                                                                                      |
+| threadpoolctl                    | 3.6.0          | BSD License                                                                                      |
+| tinycss2                         | 1.4.0          | BSD License                                                                                      |
+| tldextract                       | 5.3.0          | BSD License                                                                                      |
+| tokenizers                       | 0.22.0         | Apache Software License                                                                          |
+| tomlkit                          | 0.13.3         | MIT License                                                                                      |
+| torch                            | 2.8.0          | BSD License                                                                                      |
+| tornado                          | 6.5.2          | Apache Software License                                                                          |
+| tqdm                             | 4.67.1         | MIT License; Mozilla Public License 2.0 (MPL 2.0)                                                |
+| traitlets                        | 5.14.3         | BSD License                                                                                      |
+| transformers                     | 4.56.1         | Apache Software License                                                                          |
+| trio                             | 0.30.0         | MIT OR Apache-2.0                                                                                |
+| trio-websocket                   | 0.12.2         | MIT License                                                                                      |
+| typer                            | 0.17.4         | MIT License                                                                                      |
+| types-python-dateutil            | 2.9.0.20250822 | Apache-2.0                                                                                       |
+| typing-inspection                | 0.4.1          | MIT                                                                                              |
+| typing_extensions                | 4.14.1         | PSF-2.0                                                                                          |
+| tzdata                           | 2025.2         | Apache Software License                                                                          |
+| uc-micro-py                      | 1.0.3          | MIT License                                                                                      |
+| undetected-chromedriver          | 3.5.5          | GNU General Public License v3 (GPLv3)                                                            |
+| uri-template                     | 1.3.0          | MIT License                                                                                      |
+| url-normalize                    | 2.2.1          | MIT                                                                                              |
+| urllib3                          | 2.5.0          | MIT                                                                                              |
+| uvicorn                          | 0.37.0         | BSD-3-Clause                                                                                     |
+| uvloop                           | 0.21.0         | Apache Software License; MIT License                                                             |
+| virtualenv                       | 20.34.0        | MIT                                                                                              |
+| wasabi                           | 1.1.3          | MIT                                                                                              |
+| watchfiles                       | 1.1.1          | MIT License                                                                                      |
+| weasel                           | 0.4.1          | MIT License                                                                                      |
+| webcolors                        | 24.11.1        | BSD License                                                                                      |
+| webencodings                     | 0.5.1          | BSD License                                                                                      |
+| websocket-client                 | 1.8.0          | Apache Software License                                                                          |
+| websockets                       | 15.0.1         | BSD License                                                                                      |
+| wrapt                            | 1.17.3         | BSD License                                                                                      |
+| wsproto                          | 1.2.0          | MIT License                                                                                      |
+| yarl                             | 1.22.0         | Apache Software License                                                                          |
+| zipp                             | 3.23.0         | MIT                                                                                              |

--- a/docs/PROXY_CONFIGURATION.md
+++ b/docs/PROXY_CONFIGURATION.md
@@ -96,14 +96,14 @@ SMARTPROXY_PASSWORD=password
 
 ```bash
 PROXY_PROVIDER=decodo
-DECODO_USERNAME=user-sp8z2fzi1e-country-us  # Default provided
-DECODO_PASSWORD=qg_hJ7reok8e5F7BHg          # Default provided
-DECODO_HOST=isp.decodo.com                   # Default provided
-DECODO_PORT=10000                            # Default provided
-DECODO_COUNTRY=us                            # Target country
+DECODO_USERNAME=your-decodo-username  # Set via env var or GCP Secret Manager
+DECODO_PASSWORD=your-decodo-password  # Set via env var or GCP Secret Manager
+DECODO_HOST=isp.decodo.com            # Default provided
+DECODO_PORT=10000                     # Default provided
+DECODO_COUNTRY=us                     # Target country
 ```
 
-**Note:** Decodo has default credentials built-in, so it's ready to test immediately with just `PROXY_PROVIDER=decodo`.
+**Note:** Set credentials via environment variables or GCP Secret Manager. Decodo provider is disabled if no credentials are provided.
 
 ---
 

--- a/docs/PROXY_CONFIGURATION_CRITICAL.md
+++ b/docs/PROXY_CONFIGURATION_CRITICAL.md
@@ -57,8 +57,8 @@ From `src/crawler/proxy_config.py`:
 
 ```python
 # Decodo ISP proxy - ALWAYS AVAILABLE
-decodo_username = os.getenv("DECODO_USERNAME", "user-sp8z2fzi1e-country-us")
-decodo_password = os.getenv("DECODO_PASSWORD", "qg_hJ7reok8e5F7BHg")
+decodo_username = os.getenv("DECODO_USERNAME", "your-decodo-username")
+decodo_password = os.getenv("DECODO_PASSWORD", "your-decodo-password")
 decodo_host = os.getenv("DECODO_HOST", "isp.decodo.com")
 decodo_port = os.getenv("DECODO_PORT", "10000")
 decodo_url = f"https://{decodo_username}:{decodo_password}@{decodo_host}:{decodo_port}"

--- a/docs/features/DECODO_PROXY_INTEGRATION.md
+++ b/docs/features/DECODO_PROXY_INTEGRATION.md
@@ -95,11 +95,11 @@ PROXY_PROVIDER=decodo
 If you need to customize:
 
 ```bash
-DECODO_USERNAME=user-sp8z2fzi1e-country-us  # Default provided
-DECODO_PASSWORD=qg_hJ7reok8e5F7BHg          # Default provided
-DECODO_HOST=isp.decodo.com                   # Default provided
-DECODO_PORT=10000                            # Default provided
-DECODO_COUNTRY=us                            # Target country
+DECODO_USERNAME=your-decodo-username  # Set via env var or GCP Secret Manager
+DECODO_PASSWORD=your-decodo-password  # Set via env var or GCP Secret Manager
+DECODO_HOST=isp.decodo.com            # Default provided
+DECODO_PORT=10000                     # Default provided
+DECODO_COUNTRY=us                     # Target country
 ```
 
 ---
@@ -213,7 +213,7 @@ kubectl exec -n production deployment/mizzou-processor -- \
 # Expected output:
 # Active Provider: decodo
 # Status: enabled
-# URL: http://user-sp8z2fzi1e-country-us:***@isp.decodo.com:10000
+# URL: http://your-username:***@isp.decodo.com:10000
 # Health: (will build over time)
 ```
 

--- a/docs/troubleshooting/PROXY_FIXES_COMPLETE.md
+++ b/docs/troubleshooting/PROXY_FIXES_COMPLETE.md
@@ -42,7 +42,7 @@ python3 -c "from src.crawler.proxy_config import ProxyManager; \
 
 **Problem:**
 ```
-http://user-sp8z2fzi1e-country-us:qg_hJ7reok8e5F7BHg@user-sp8z2fzi1e-country-us:qg_hJ7reok8e5F7BHg@isp.decodo.com:10000
+http://your-username:your-password@your-username:your-password@isp.decodo.com:10000
                                                        ^^^ DUPLICATED ^^^
 ```
 
@@ -94,7 +94,7 @@ decodo_url = f"https://{username}:{password}@{host}:{port}"
 ```bash
 python3 -c "import requests; \
   requests.get('https://ip.decodo.com/json', \
-    proxies={'https': 'https://user-sp8z2fzi1e-country-us:qg_hJ7reok8e5F7BHg@isp.decodo.com:10000'}, \
+    proxies={'https': 'https://your-username:your-password@isp.decodo.com:10000'}, \
     timeout=10)"
 # Output: 200 OK
 ```
@@ -121,7 +121,7 @@ All tests passed locally:
 ✅ HTTPS proxy connection successful
 
 # Test 5: Proxy URLs correct
-✅ https://user-sp8z2fzi1e-country-us:qg_hJ7reok8e5F7BHg@isp.decodo.com:10000
+✅ https://your-username:your-password@isp.decodo.com:10000
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-[tool.pytest.ini_options]
 [project]
 name = "mizzou-news-crawler-scripts"
 version = "1.3.1"

--- a/scripts/debug/test_decodo_proxy.py
+++ b/scripts/debug/test_decodo_proxy.py
@@ -9,8 +9,8 @@ def test_decodo_proxy():
     """Test the Decodo proxy configuration."""
     
     # Decodo configuration
-    username = os.getenv('DECODO_USERNAME', 'user-sp8z2fzi1e-country-us')
-    password = os.getenv('DECODO_PASSWORD', 'qg_hJ7reok8e5F7BHg')
+    username = os.getenv('DECODO_USERNAME', 'your-decodo-username')
+    password = os.getenv('DECODO_PASSWORD', 'your-decodo-password')
     host = os.getenv('DECODO_HOST', 'isp.decodo.com')
     port = os.getenv('DECODO_PORT', '10000')
     


### PR DESCRIPTION
…agement

- Remove hard-coded Decodo credentials from src/crawler/proxy_config.py
- Add GCP Secret Manager support with env var fallback
- Remove .decodo-credentials file and create .decodo-credentials.example
- Sanitize docs to use placeholders instead of real credentials
- Update .env.example with proxy configuration guidance
- Expand CONTRIBUTING.md security section with secret management instructions
- Create GCP Secret Manager secret 'decodo-proxy-creds' with rotated credentials