### PR TITLE
fix: Update scikit-learn to >=1.7.2 to match StorySniffer model version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -32,7 +32,7 @@ nltk>=3.8
 textblob>=0.17.0
 ftfy>=6.1.0
 python-dateutil>=2.8.0
-scikit-learn>=1.5.1,<1.7  # Compatible with StorySniffer 1.0.9+ skops models
+scikit-learn>=1.7.2,<1.8  # Compatible with StorySniffer 1.0.9+ skops models (model trained with 1.7.2)
 
 # Testing
 pytest>=7.4.0

--- a/requirements-crawler.txt
+++ b/requirements-crawler.txt
@@ -12,7 +12,7 @@ newspaper4k>=0.9.2  # Use newspaper4k (modern fork)
 feedparser>=6.0.10
 
 # Article classification
-scikit-learn>=1.5.1,<1.7  # Compatible with StorySniffer 1.0.9+ skops models
+scikit-learn>=1.7.2,<1.8  # Compatible with StorySniffer 1.0.9+ skops models (model trained with 1.7.2)
 storysniffer>=1.0.9  # News article classification (skops-based models)
 
 # Anti-bot bypass

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -7,7 +7,7 @@ torch>=2.1.0  # PyTorch for deep learning models
 transformers>=4.30.0  # HuggingFace transformers for NLP
 
 # ML utilities
-scikit-learn>=1.5.1,<1.7  # Compatible with StorySniffer 1.0.9+ skops models
+scikit-learn>=1.7.2,<1.8  # Compatible with StorySniffer 1.0.9+ skops models (model trained with 1.7.2)
 storysniffer>=1.0.9  # News article classification (skops-based models)
 
 # Crawler dependencies for article extraction (processor CLI imports crawler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ papermill>=2.4.0
 jupyterlab>=4.0.0
 
 # ML/NLP
-scikit-learn>=1.5.1,<1.7  # Compatible with StorySniffer 1.0.9+ skops models
+scikit-learn>=1.7.2,<1.8  # Compatible with StorySniffer 1.0.9+ skops models (model trained with 1.7.2)
 spacy>=3.8.0  # Python 3.11+ supports latest spacy with numpy 2.x
 transformers>=4.30.0
 nltk>=3.8


### PR DESCRIPTION
The StorySniffer 1.0.9 model was trained with scikit-learn 1.7.2, but our requirements capped it at <1.7, causing version mismatch warnings in production. Update to require >=1.7.2,<1.8 to match the model.