### PR TITLE
Add git to ci-base Docker image for isort compatibility

### DIFF
--- a/Dockerfile.ci-base
+++ b/Dockerfile.ci-base
@@ -8,6 +8,12 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
+# Install git (required for isort to work with .gitignore)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy test-only requirements
 COPY requirements-dev.txt ./
 


### PR DESCRIPTION
## Summary
Adds `git` to the ci-base Docker image so that `isort` can properly use `.gitignore` rules when running in containerized environments.

## Problem
- `isort --check-only` fails in Docker containers without git installed
- Local CI testing with `test-ci-locally.sh` was failing on isort checks
- GitHub Actions CI works because git is available in the runner environment

## Solution
- Install git in `Dockerfile.ci-base` using apt-get
- Clean up apt lists to keep image size minimal
- Ensures local Docker CI environment matches GitHub Actions exactly

## Impact
- Enables `isort` to work properly in local CI testing
- Makes local pre-push hook testing match production CI exactly
- No impact on production services (only affects CI/test image)

## Testing
Once merged and the ci-base image is rebuilt, `test-ci-locally.sh` will run isort successfully.