### PR TITLE
CRITICAL: Fix Argo workflow update script and build orchestration

### DIFF
--- a/gcp/cloudbuild/update-workflow-template.sh
+++ b/gcp/cloudbuild/update-workflow-template.sh
@@ -19,7 +19,7 @@ echo "🏷️  SHA: $NEW_SHA"
 echo "🔄 Updating Argo WorkflowTemplate..."
 
 # Use Python to update the workflow template
-python3 << 'PYTHON_EOF'
+python3 << 'PYTHON_EOF' "$SERVICE_TYPE" "$NEW_SHA" "$REGISTRY"
 import subprocess, json, sys, os
 
 service_type = sys.argv[1] if len(sys.argv) > 1 else os.environ.get('SERVICE_TYPE', '')
@@ -82,7 +82,7 @@ try:
 except Exception as e:
     print(f"❌ Error applying workflow: {e}")
     sys.exit(1)
-PYTHON_EOF "$SERVICE_TYPE" "$NEW_SHA" "$REGISTRY"
+PYTHON_EOF
 
 echo "✅ Argo WorkflowTemplate updated successfully"
 echo "   Next workflow run will use ${SERVICE_TYPE}:${NEW_SHA}"


### PR DESCRIPTION
## Critical Fix: Build and Deploy Orchestration

This PR contains two critical fixes:

### 1. GitHub Actions Workflow Improvements (build-and-deploy-services.yml)
- Added `wait-for-builds` job to poll Cloud Build status until completion
- Prevents e2e tests from running before services are deployed
- Detects failed builds immediately

### 2. Argo Workflow Template Update Script (update-workflow-template.sh)
- **CRITICAL FIX**: Corrected Python here-document syntax error
- Removed errant line causing "invalid syntax" errors in Cloud Build
- Enables automatic Argo workflow image updates

### 3. Production Smoke Tests Enhancement (production-smoke-tests.yml)
- Proper deployment readiness verification using `kubectl rollout status`
- Detects pod crashes before running tests
- Better error reporting

## Why This Is Urgent
The Argo workflow template update step is **failing on every build** because of the Python syntax error. This blocks:
- Automatic image version updates in Argo workflows
- E2E test execution
- Full deployment pipeline

## Testing Status
- Syntax fix verified locally
- Argo workflow images manually updated to latest versions
- Ready for merge and rebuild