### PR TITLE
Refactor article detection in check_is_article function of url_filters.py

### DIFF
--- a/src/pipeline/url_filters.py
+++ b/src/pipeline/url_filters.py
@@ -73,9 +73,8 @@ def check_is_article(url, discovery_method="unknown"):
         if re.search(pattern, url_lower):
             return True
 
-    # commented out below code, cuz could cause false positives
-    # if re.search(r"/\d{3,}", url_lower):
-    #     return True
+    if re.search(r"/\d{3,}", url_lower):
+        return True
 
     # commented out below code, cuz newspaper4k discovered urls are no different than others
     # if discovery_method == "newspaper4k":


### PR DESCRIPTION
Updated article detection logic by normalizing URLs and removing certain non-article patterns to reduce false negatives. Adjusted handling of audio patterns and changed the method from is_article_url to guess in StorySniffer.

The issue is that "is_article_url" doesn't exist in the storysniffer Python library; as a result, it throws False from the try-except block, even for a legit news page URL. Corrected it with the "guess" method, which is the right one to use.