### PR TITLE
fix: always allow_build=True for newspaper4k when RSS fails

### DIFF
--- a/src/crawler/source_processing.py
+++ b/src/crawler/source_processing.py
@@ -1526,12 +1526,15 @@ class SourceProcessor:
         articles: list[dict[str, Any]] = []
         try:
             self.discovery_methods_attempted.append("newspaper4k")
+            # When RSS is skipped/failed, we NEED full newspaper build to
+            # discover articles via sections and homepage crawling.
+            # allow_build=True always - newspaper4k is our fallback method.
             articles = self.discovery.discover_with_newspaper4k(
                 self.source_url,
                 self.source_id,
                 self.operation_id,
                 source_meta=self.source_meta,
-                allow_build=(not skip_rss),
+                allow_build=True,
                 rss_already_attempted=rss_attempted,
             )
             logger.info(

--- a/tests/crawler/test_discovery_helpers.py
+++ b/tests/crawler/test_discovery_helpers.py
@@ -1159,7 +1159,8 @@ def test_source_processor_skips_rss_when_recently_missing(
     assert "newspaper4k" in result.metadata["methods_attempted"]
 
     assert newspaper_calls, "newspaper4k should run when RSS is skipped"
-    assert newspaper_calls[0]["allow_build"] is False
+    # When RSS is skipped, newspaper4k should still do full build to discover via sections
+    assert newspaper_calls[0]["allow_build"] is True
 
     assert len(store_calls) == 1
     assert store_calls[0]["url"] == "https://example.com/newspaper"

--- a/tests/crawler/test_section_wire_filtering.py
+++ b/tests/crawler/test_section_wire_filtering.py
@@ -1159,7 +1159,8 @@ def test_source_processor_skips_rss_when_recently_missing(
     assert "newspaper4k" in result.metadata["methods_attempted"]
 
     assert newspaper_calls, "newspaper4k should run when RSS is skipped"
-    assert newspaper_calls[0]["allow_build"] is False
+    # When RSS is skipped, newspaper4k should still do full build to discover via sections
+    assert newspaper_calls[0]["allow_build"] is True
 
     assert len(store_calls) == 1
     assert store_calls[0]["url"] == "https://example.com/newspaper"


### PR DESCRIPTION
When RSS is skipped/missing, we NEED full newspaper build to discover articles via sections and homepage crawling. The previous logic (allow_build=not skip_rss) was backwards - it disabled discovery exactly when we needed it most.

Updated tests to expect correct behavior (allow_build=True).