### PR TITLE
Fix extraction slowness: remove 20-min remaining count query

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -784,55 +784,23 @@ def handle_extraction_command(args) -> int:
             articles_processed = result["processed"]
             total_processed += articles_processed
 
-            # Query remaining articles for progress visibility
+            # Log batch completion with status counts (skip expensive remaining count)
+            # The remaining count query was causing 20+ minute delays due to
+            # expensive LEFT JOIN even with proper indexing
             try:
-                # Expire all objects and close transaction to get fresh count
                 db.session.expire_all()
                 db.session.commit()
-                db.session.close()
 
-                # Build count query matching the extraction filters
-                dataset_uuid = getattr(args, "dataset", None)
-                if dataset_uuid:
-                    # Filter by specific dataset UUID
-                    query = text(
-                        "SELECT COUNT(*) FROM candidate_links cl "
-                        "LEFT JOIN sources s ON cl.source_id = s.id "
-                        "WHERE cl.status = 'article' "
-                        "AND cl.dataset_id = :dataset "
-                        "AND (s.status IS NULL OR s.status = 'active') "
-                        "AND cl.id NOT IN "
-                        "(SELECT candidate_link_id FROM articles "
-                        "WHERE candidate_link_id IS NOT NULL)"
-                    )
-                    count_result = safe_session_execute(
-                        db.session, query, {"dataset": dataset_uuid}
-                    )
-                    remaining_count = _to_int(count_result.scalar(), 0)
-                else:
-                    # Count all remaining articles
-                    query = text(
-                        "SELECT COUNT(*) FROM candidate_links cl "
-                        "LEFT JOIN sources s ON cl.source_id = s.id "
-                        "WHERE cl.status = 'article' "
-                        "AND (s.status IS NULL OR s.status = 'active') "
-                        "AND cl.id NOT IN "
-                        "(SELECT candidate_link_id FROM articles "
-                        "WHERE candidate_link_id IS NOT NULL)"
-                    )
-                    count_result = safe_session_execute(db.session, query)
-                    remaining_count = _to_int(count_result.scalar(), 0)
+                # Get status breakdown (fast GROUP BY query)
+                status_counts = _get_status_counts(args, db.session)
+                remaining_estimate = status_counts.get("article", "?")
 
                 print(
                     f"✓ Batch {batch_num} complete: {articles_processed} "
-                    f"articles extracted ({remaining_count} remaining "
-                    f"with status='article')"
+                    f"articles extracted (~{remaining_estimate} remaining)"
                 )
 
-                # Get and display status breakdown
-                status_counts = _get_status_counts(args, db.session)
                 if status_counts:
-                    # Focus on key statuses
                     key_statuses = [
                         "article",
                         "extracted",
@@ -856,7 +824,6 @@ def handle_extraction_command(args) -> int:
                         )
 
             except Exception as e:
-                # Fallback if query fails
                 logger.warning("Failed to get status counts: %s", e)
                 print(
                     f"✓ Batch {batch_num} complete: "

--- a/src/services/work_queue.py
+++ b/src/services/work_queue.py
@@ -385,6 +385,10 @@ class WorkQueueCoordinator:
     def update_worker_heartbeat(self, worker_id: str) -> None:
         """Update worker last_seen timestamp.
 
+        If worker is unknown (e.g., after work-queue restart), re-register it
+        with empty domain set. This prevents workers from being marked stale
+        when work-queue loses state.
+
         Args:
             worker_id: Worker sending heartbeat
         """
@@ -392,6 +396,13 @@ class WorkQueueCoordinator:
             if worker_id in self.worker_domains:
                 self.worker_domains[worker_id]["last_seen"] = time.time()
                 logger.debug(f"Heartbeat received from worker {worker_id}")
+            else:
+                # Re-register unknown worker (survives work-queue restart)
+                self.worker_domains[worker_id] = {
+                    "domains": set(),
+                    "last_seen": time.time(),
+                }
+                logger.info(f"Re-registered unknown worker {worker_id} via heartbeat")
 
     def report_failure(self, worker_id: str, domain: str) -> None:
         """Report a domain failure (rate limit, bot protection, etc.).

--- a/tests/services/test_work_queue.py
+++ b/tests/services/test_work_queue.py
@@ -358,13 +358,40 @@ def test_heartbeat_prevents_worker_timeout(coordinator):
     assert "worker-1" in coordinator.worker_domains
 
 
-def test_heartbeat_unknown_worker_ignored(coordinator):
-    """Heartbeat from unknown worker handled gracefully."""
+def test_heartbeat_unknown_worker_reregisters(coordinator):
+    """Heartbeat from unknown worker re-registers it with empty domains.
+
+    This is important for recovering after work-queue restarts - workers
+    that were mid-batch when work-queue restarted can re-register via
+    heartbeat instead of being marked stale.
+    """
+    # Ensure worker doesn't exist
+    assert "worker-999" not in coordinator.worker_domains
+
     # Send heartbeat for non-existent worker
     coordinator.update_worker_heartbeat("worker-999")
 
-    # Assert no error and worker not added
-    assert "worker-999" not in coordinator.worker_domains
+    # Assert worker is now registered with empty domain set
+    assert "worker-999" in coordinator.worker_domains
+    assert coordinator.worker_domains["worker-999"]["domains"] == set()
+    assert coordinator.worker_domains["worker-999"]["last_seen"] >= time.time() - 1
+
+
+def test_heartbeat_reregistered_worker_survives_cleanup(coordinator):
+    """Worker re-registered via heartbeat should not be immediately cleaned up."""
+    from src.services.work_queue import WORKER_TIMEOUT_SECONDS
+
+    # Re-register unknown worker via heartbeat
+    coordinator.update_worker_heartbeat("worker-new")
+
+    # Verify registered
+    assert "worker-new" in coordinator.worker_domains
+
+    # Run cleanup - worker should survive (just registered)
+    coordinator._cleanup_stale_workers()
+
+    # Assert worker still exists
+    assert "worker-new" in coordinator.worker_domains
 
 
 def test_single_domain_per_request_enforced(coordinator):


### PR DESCRIPTION
Root cause: The remaining count query used NOT IN subquery against 130K+ articles table, taking 20+ minutes per batch even with proper indexes. This exceeded the 10-minute worker heartbeat timeout, causing workers to be marked stale.

Changes:
- extraction.py: Remove expensive remaining count query, use status_counts estimate instead (fast GROUP BY query)
- work_queue.py: Heartbeats now re-register unknown workers (survives work-queue restart)
- test_work_queue.py: Updated tests for new heartbeat behavior