### PR TITLE
fix: Always run RSS + homepage/section discovery for all sources

### DIFF
--- a/src/crawler/source_processing.py
+++ b/src/crawler/source_processing.py
@@ -993,41 +993,25 @@ class SourceProcessor:
             except Exception as e:
                 logger.error(f"Proxy scraping failed for {self.source_name}: {e}")
 
-        if DiscoveryMethod.RSS_FEED in self.effective_methods:
-            (
-                rss_articles,
-                rss_summary,
-                rss_attempted,
-                skip_rss,
-            ) = self._try_rss()
-            self.rss_summary = rss_summary
-            all_discovered.extend(rss_articles)
-            # Removed early return: allow newspaper4k to run even when RSS
-            # yields articles so tests expecting expired classification from
-            # secondary methods remain valid and we can pick up additional
-            # duplicates/expired articles for telemetry.
-        else:
-            logger.info(
-                "Skipping RSS discovery for %s (historically ineffective)",
-                self.source_name,
-            )
+        # Method 1: RSS feeds - always try regardless of historical effectiveness
+        (
+            rss_articles,
+            rss_summary,
+            rss_attempted,
+            skip_rss,
+        ) = self._try_rss()
+        self.rss_summary = rss_summary
+        all_discovered.extend(rss_articles)
+        # Note: Don't return early - always continue to homepage/section discovery
 
-        # If RSS found a healthy volume, skip slower methods.
-        if len(all_discovered) >= self.discovery.max_articles_per_source // 2:
-            logger.info(
-                "RSS found sufficient articles, skipping slower methods",
-            )
-            return all_discovered
+        # ALWAYS run homepage/section discovery after RSS - don't skip based on
+        # RSS article count. This ensures we catch articles that aren't in RSS feeds.
+        # The deduplication in _store_candidates handles overlapping URLs.
 
-        # Method 2: newspaper4k
-        if DiscoveryMethod.NEWSPAPER4K in self.effective_methods:
-            newspaper_articles = self._try_newspaper(skip_rss, rss_attempted)
-            all_discovered.extend(newspaper_articles)
-        else:
-            logger.info(
-                "Skipping newspaper4k for %s (historically ineffective)",
-                self.source_name,
-            )
+        # Method 2: newspaper4k (homepage and section crawling)
+        # Always run regardless of historical effectiveness - we want comprehensive discovery
+        newspaper_articles = self._try_newspaper(skip_rss, rss_attempted)
+        all_discovered.extend(newspaper_articles)
 
         # Method 3: storysniffer
         # Note: StorySniffer is a URL classifier (returns boolean), not a
@@ -1038,40 +1022,6 @@ class SourceProcessor:
                 "StorySniffer in effective methods but cannot discover URLs "
                 "from homepages (it's a classifier, not a crawler). Skipping."
             )
-        # Legacy code path kept for reference but effectively disabled
-        # as discover_with_storysniffer now returns empty list immediately
-
-        # FALLBACK: If effective methods produced 0 articles, try skipped methods
-        # This prevents single-point-of-failure when historical effectiveness
-        # data is stale or when RSS feeds return 0 results due to filtering.
-        if len(all_discovered) == 0:
-            logger.warning(
-                "Effective methods found 0 articles for %s, trying fallback methods",
-                self.source_name,
-            )
-
-            # Try newspaper4k if it was skipped
-            effective_methods = getattr(self, "effective_methods", [])
-            if DiscoveryMethod.NEWSPAPER4K not in effective_methods:
-                logger.info(
-                    "Fallback: trying newspaper4k for %s despite historical ineffectiveness",
-                    self.source_name,
-                )
-                try:
-                    newspaper_articles = self._try_newspaper(skip_rss, rss_attempted)
-                    if newspaper_articles:
-                        logger.info(
-                            "Fallback newspaper4k found %d articles for %s",
-                            len(newspaper_articles),
-                            self.source_name,
-                        )
-                        all_discovered.extend(newspaper_articles)
-                except Exception as e:
-                    logger.warning(
-                        "Fallback newspaper4k failed for %s: %s",
-                        self.source_name,
-                        e,
-                    )
 
         return all_discovered
 

--- a/src/crawler/source_processing.py
+++ b/src/crawler/source_processing.py
@@ -993,7 +993,7 @@ class SourceProcessor:
             except Exception as e:
                 logger.error(f"Proxy scraping failed for {self.source_name}: {e}")
 
-        # Method 1: RSS feeds - always try regardless of historical effectiveness
+        # Method 1: RSS feeds (respects rss_missing flag - skips if feed broken)
         (
             rss_articles,
             rss_summary,
@@ -1002,14 +1002,13 @@ class SourceProcessor:
         ) = self._try_rss()
         self.rss_summary = rss_summary
         all_discovered.extend(rss_articles)
-        # Note: Don't return early - always continue to homepage/section discovery
 
         # ALWAYS run homepage/section discovery after RSS - don't skip based on
         # RSS article count. This ensures we catch articles that aren't in RSS feeds.
         # The deduplication in _store_candidates handles overlapping URLs.
 
         # Method 2: newspaper4k (homepage and section crawling)
-        # Always run regardless of historical effectiveness - we want comprehensive discovery
+        # Always run after RSS - ensures comprehensive discovery even when RSS is active
         newspaper_articles = self._try_newspaper(skip_rss, rss_attempted)
         all_discovered.extend(newspaper_articles)
 

--- a/tests/crawler/test_discovery_fallback_methods.py
+++ b/tests/crawler/test_discovery_fallback_methods.py
@@ -285,7 +285,11 @@ def test_fallback_when_articles_discovered_but_all_filtered(
 def test_no_fallback_when_effective_methods_succeed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that fallback is NOT triggered when effective methods succeed."""
+    """Test that BOTH RSS and newspaper4k always run (no fallback logic).
+
+    Per requirement: we should always use RSS first and then homepage/section
+    discovery regardless of whether RSS found articles.
+    """
     instance = _make_discovery_stub()
     instance.database_url = "sqlite://"
     instance.max_articles_per_source = 50
@@ -362,8 +366,8 @@ def test_no_fallback_when_effective_methods_succeed(
     # Verify RSS was tried
     assert len(rss_calls) == 1
 
-    # Verify newspaper4k was NOT tried (RSS succeeded, no fallback needed)
-    assert len(newspaper_calls) == 0
+    # Verify newspaper4k WAS tried (always runs for comprehensive discovery)
+    assert len(newspaper_calls) == 1
 
     # Verify article was stored from RSS
     assert len(stored_candidates) == 1

--- a/tests/crawler/test_discovery_helpers.py
+++ b/tests/crawler/test_discovery_helpers.py
@@ -1807,7 +1807,8 @@ def test_source_processor_stores_when_publish_date_parse_fails(
     assert result.outcome == DiscoveryOutcome.NEW_ARTICLES_FOUND
     assert result.articles_new == 1
     assert result.metadata["stored_count"] == 1
-    assert result.metadata["methods_attempted"] == ["rss_feed"]
+    # Both RSS and newspaper4k are always attempted for comprehensive discovery
+    assert result.metadata["methods_attempted"] == ["rss_feed", "newspaper4k"]
 
     assert len(store_calls) == 1
     stored = store_calls[0]
@@ -1937,7 +1938,8 @@ def test_source_processor_continues_when_upsert_raises(
     assert result.outcome == DiscoveryOutcome.NEW_ARTICLES_FOUND
     assert result.articles_new == 2
     assert result.metadata["stored_count"] == 1
-    assert result.metadata["methods_attempted"] == ["rss_feed"]
+    # Both RSS and newspaper4k are always attempted for comprehensive discovery
+    assert result.metadata["methods_attempted"] == ["rss_feed", "newspaper4k"]
 
     assert len(store_calls) == 1
     assert store_calls[0]["url"] == "https://example.com/good"

--- a/tests/crawler/test_section_wire_filtering.py
+++ b/tests/crawler/test_section_wire_filtering.py
@@ -1807,7 +1807,8 @@ def test_source_processor_stores_when_publish_date_parse_fails(
     assert result.outcome == DiscoveryOutcome.NEW_ARTICLES_FOUND
     assert result.articles_new == 1
     assert result.metadata["stored_count"] == 1
-    assert result.metadata["methods_attempted"] == ["rss_feed"]
+    # Both RSS and newspaper4k are always attempted for comprehensive discovery
+    assert result.metadata["methods_attempted"] == ["rss_feed", "newspaper4k"]
 
     assert len(store_calls) == 1
     stored = store_calls[0]
@@ -1937,7 +1938,8 @@ def test_source_processor_continues_when_upsert_raises(
     assert result.outcome == DiscoveryOutcome.NEW_ARTICLES_FOUND
     assert result.articles_new == 2
     assert result.metadata["stored_count"] == 1
-    assert result.metadata["methods_attempted"] == ["rss_feed"]
+    # Both RSS and newspaper4k are always attempted for comprehensive discovery
+    assert result.metadata["methods_attempted"] == ["rss_feed", "newspaper4k"]
 
     assert len(store_calls) == 1
     assert store_calls[0]["url"] == "https://example.com/good"

--- a/tests/test_prioritization.py
+++ b/tests/test_prioritization.py
@@ -44,5 +44,10 @@ def test_prioritize_last_successful_method(monkeypatch):
 
     discovery.process_source(src, dataset_label="test", operation_id=None)
 
-    # The first attempted method should be the preferred one
-    assert call_order[0] == "newspaper4k"
+    # Both RSS and newspaper4k should be called for comprehensive discovery
+    # RSS is always attempted first, then newspaper4k
+    assert "rss" in call_order
+    assert "newspaper4k" in call_order
+    # RSS runs first, then newspaper4k
+    assert call_order[0] == "rss"
+    assert call_order[1] == "newspaper4k"


### PR DESCRIPTION
Previously, discovery would skip homepage/section crawling if RSS found 'enough' articles (>= max_articles/2). This caused missed articles that weren't in RSS feeds.

Changes:
- Remove early return when RSS finds sufficient articles
- Always run newspaper4k (homepage/section discovery) after RSS
- Always run RSS regardless of historical effectiveness
- Deduplication in _store_candidates handles overlapping URLs

This ensures comprehensive discovery on every run.