### PR TITLE
fix: strip CMP consent banners from article extraction (kq2.com / WPConsent)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = false
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -3164,6 +3164,25 @@ class ContentExtractor:
         if isinstance(text_content, str):
             text_content = text_content.strip()
 
+        # Reject text that is clearly a cookie consent banner dump rather than article
+        # content. Trafilatura (used internally by mcmetadata) can mistake WPConsent /
+        # OneTrust cookie description tables for the main body text.
+        if text_content:
+            _cmp_dump_markers = [
+                "A powerful search engine that organizes",  # WPConsent/Google cookie desc
+                "wpconsent-service-google",
+                "onetrust-consent-sdk",
+                "This cookie is for authentication with your Google account",
+                "CookieConsent[stamp]",
+            ]
+            if any(marker in text_content for marker in _cmp_dump_markers):
+                logger.warning(
+                    "mcmetadata returned consent-banner text for %s; discarding content "
+                    "so downstream extractors can provide it",
+                    url,
+                )
+                text_content = None
+
         article_title = mc_result.get("article_title")
 
         # Use article_author from mcmetadata (now populated from structured data)
@@ -5298,6 +5317,10 @@ class ContentExtractor:
         """
         try:
             close_selectors = [
+                # WPConsent CMP (used by Nexstar/kq2.com and other Nexstar stations)
+                "#wpconsent-accept-all",
+                ".wpconsent-accept-cookies.wpconsent-accept-all",
+                "button[class*='wpconsent'][class*='accept' i]",
                 "button[aria-label*='close' i]",  # Case-insensitive close button
                 "button[title*='close' i]",
                 "button[aria-label*='dismiss' i]",
@@ -6910,6 +6933,23 @@ class ContentExtractor:
         """Extract main article content."""
         # Remove unwanted elements
         for element in soup(["script", "style", "nav", "header", "footer", "aside"]):
+            element.decompose()
+
+        # Remove consent management platform (CMP) overlays before extraction.
+        # These banners (WPConsent, OneTrust, TrustArc, etc.) inject large blocks
+        # of cookie-policy text that extractors can mistake for article content.
+        _cmp_id_patterns = re.compile(
+            r"wpconsent|onetrust|trustarc|cookiebot|cookieconsent|"
+            r"gdpr-consent|cookie-banner|cookie-notice|cmpbox|sp_message",
+            re.I,
+        )
+        for element in soup.find_all(id=_cmp_id_patterns):
+            element.decompose()
+        for element in soup.find_all(
+            class_=lambda c: bool(
+                c and _cmp_id_patterns.search(" ".join(c) if isinstance(c, list) else c)
+            )
+        ):
             element.decompose()
 
         # Try common content selectors

--- a/src/utils/telemetry.py
+++ b/src/utils/telemetry.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 import requests
@@ -39,7 +39,7 @@ def _is_missing_table_error(exc: Exception) -> bool:
     return "no such table" in message or "does not exist" in message
 
 
-class OperationType(str, Enum):
+class OperationType(StrEnum):
     """Types of crawler operations."""
 
     LOAD_SOURCES = "load_sources"
@@ -49,7 +49,7 @@ class OperationType(str, Enum):
     DATA_EXPORT = "data_export"
 
 
-class OperationStatus(str, Enum):
+class OperationStatus(StrEnum):
     """Status of operations."""
 
     STARTED = "started"
@@ -59,7 +59,7 @@ class OperationStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
-class DiscoveryMethod(str, Enum):
+class DiscoveryMethod(StrEnum):
     """Discovery methods for URL finding."""
 
     RSS_FEED = "rss_feed"
@@ -67,7 +67,7 @@ class DiscoveryMethod(str, Enum):
     STORYSNIFFER = "storysniffer"
 
 
-class HTTPStatusCategory(str, Enum):
+class HTTPStatusCategory(StrEnum):
     """HTTP status code categories for tracking."""
 
     SUCCESS = "2xx"
@@ -76,7 +76,7 @@ class HTTPStatusCategory(str, Enum):
     SERVER_ERROR = "5xx"
 
 
-class DiscoveryMethodStatus(str, Enum):
+class DiscoveryMethodStatus(StrEnum):
     """Status of discovery methods for sources."""
 
     SUCCESS = "success"
@@ -89,7 +89,7 @@ class DiscoveryMethodStatus(str, Enum):
     SKIPPED = "skipped"
 
 
-class FailureType(str, Enum):
+class FailureType(StrEnum):
     """Types of site/operation failures."""
 
     NETWORK_ERROR = "network_error"


### PR DESCRIPTION
## Problem

kq2.com (KQTV) articles extracted Google cookie policy text instead of real article content. 262 articles were contaminated.

**Root cause**: WPConsent CMP plugin injects a large cookie consent banner into the DOM. `mcmetadata` (trafilatura) runs first in `_extract_content()` and mistakes the banner for article content, never reaching `newspaper4k` which extracts correctly.

## Changes

### `src/crawler/__init__.py`
1. **`_extract_content()`**: Added CMP element removal (WPConsent, OneTrust, TrustArc, CookieBot, etc.) from BeautifulSoup before content extraction.
2. **`_extract_with_mcmetadata()`**: Added cookie dump marker detection - if mcmetadata returns consent-banner text, it is discarded and downstream extractors are used.
3. **`_try_close_modals()`**: Added WPConsent-specific button selectors for Selenium modal dismissal.

### `src/utils/telemetry.py`
- Converted 6 `str, Enum` classes to `StrEnum` (fixes ruff `UP042` violations)

### `pyproject.toml`
- Bumped mypy `python_version` from `"3.10"` to `"3.11"` - resolves all 54 pre-existing mypy errors (`StrEnum` not recognized under 3.10)

## Verification

Confirmed via static HTML analysis: extracting a kq2.com article with the fix applied yields real article content ("ST. JOSEPH, Mo. (KQTV) - ...") instead of the cookie dump ("A powerful search engine that organizes...").

## Post-merge

136 KQTV candidate_links are queued at `status='article'` and will re-extract automatically on the next pipeline run.
