### PR TITLE
ci: on-demand Claude PR review (@claude review)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,37 +1,40 @@
 name: Claude PR Review
 
-# Automated code review by Claude on every pull request to main.
-# Replaces the retired GitHub Copilot review.
+# On-demand code review by Claude. Comment "@claude review" on a pull request
+# and Claude reviews it. Because it only runs when explicitly invoked, it never
+# blocks unrelated PRs. Replaces the retired GitHub Copilot review.
 #
 # Prerequisites (one-time, repo admin — see PR description):
 #   1. Install the Claude GitHub App:  https://github.com/apps/claude
 #   2. Add repo secret ANTHROPIC_API_KEY (Settings -> Secrets and variables ->
-#      Actions).  Value is an Anthropic API key (sk-ant-...).
+#      Actions). Value is an Anthropic API key (sk-ant-...).
 #
-# Note: on pull_request events GitHub uses the workflow file from the BASE
-# branch (main), so this only takes effect once merged to main.
+# Comment-triggered workflows run from the DEFAULT branch, so this takes effect
+# once merged to main (then works on any open PR, including older ones).
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
 
-# Avoid stacking reviews when a PR is updated rapidly: cancel an in-progress
-# review for the same PR when a new commit arrives.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: claude-review-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   review:
-    # Skip draft PRs; they get reviewed once marked ready_for_review.
-    if: github.event.pull_request.draft == false
+    # Only when a comment on a PR (not a plain issue) contains "@claude review".
+    if: >-
+      contains(github.event.comment.body, '@claude review')
+      && (github.event.issue.pull_request != null
+          || github.event_name == 'pull_request_review_comment')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +51,7 @@ jobs:
             Review this pull request for the MizzouNewsCrawler repository.
 
             Repository: ${{ github.repository }}
-            PR #${{ github.event.pull_request.number }}
+            PR #${{ github.event.issue.number || github.event.pull_request.number }}
 
             Prioritize correctness. In order of importance, look for:
             1. Correctness bugs — wrong conditions, off-by-one, null/None

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,76 @@
+name: Claude PR Review
+
+# Automated code review by Claude on every pull request to main.
+# Replaces the retired GitHub Copilot review.
+#
+# Prerequisites (one-time, repo admin — see PR description):
+#   1. Install the Claude GitHub App:  https://github.com/apps/claude
+#   2. Add repo secret ANTHROPIC_API_KEY (Settings -> Secrets and variables ->
+#      Actions).  Value is an Anthropic API key (sk-ant-...).
+#
+# Note: on pull_request events GitHub uses the workflow file from the BASE
+# branch (main), so this only takes effect once merged to main.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+
+# Avoid stacking reviews when a PR is updated rapidly: cancel an in-progress
+# review for the same PR when a new commit arrives.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip draft PRs; they get reviewed once marked ready_for_review.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          use_sticky_comment: true
+          prompt: |
+            Review this pull request for the MizzouNewsCrawler repository.
+
+            Repository: ${{ github.repository }}
+            PR #${{ github.event.pull_request.number }}
+
+            Prioritize correctness. In order of importance, look for:
+            1. Correctness bugs — wrong conditions, off-by-one, null/None
+               dereferences, missing awaits, swallowed errors, copy-paste
+               mistakes, behavior changes from deleted/replaced code, and broken
+               call sites for changed functions.
+            2. Security issues — especially credential handling, secrets in logs,
+               SQL injection, and unsafe subprocess/shell usage.
+            3. Performance — redundant I/O or DB queries, work added to hot paths,
+               and expensive operations without caching.
+            4. Reuse & simplification — new code that duplicates an existing
+               helper, or unnecessary complexity.
+
+            Give a concise summary comment, and post line-specific findings as
+            inline comments. Be specific: for each issue name a concrete failure
+            scenario. Do not flag pure style. If the diff looks clean, say so
+            briefly rather than inventing findings.
+
+            Post all feedback to GitHub:
+            - `gh pr comment` for the summary.
+            - `mcp__github_inline_comment__create_inline_comment` (with
+              `confirmed: true`) for line-specific issues.
+            Do not print review text to the run log — only post to GitHub.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## What
Adds `.github/workflows/claude-pr-review.yml` — an **on-demand** Claude code review, replacing the retired GitHub Copilot review.

**Trigger:** comment `@claude review` on any open PR. It runs only when invoked, so it never blocks unrelated PRs. (Requesting the Claude GitHub App as a formal *reviewer* isn't a supported trigger, so a comment mention is the recommended manual invocation.)

Posts a correctness-focused review as a sticky summary comment plus inline comments.

## ⚠️ Required before it works (one-time, repo admin)
1. **Install the Claude GitHub App** → https://github.com/apps/claude
2. **Add repo secret `ANTHROPIC_API_KEY`** → Settings → Secrets and variables → Actions.

## Notes
- Comment-triggered workflows run from the **default branch**, so this takes effect once merged to `main`, then works on any open PR (including older ones).
- The two failing test checks on this PR (`Integration & Coverage`, `Integration Tests (PostgreSQL)`) are **pre-existing `main` breakage**, fixed by PR #328 — not by this workflow-only change. They'll go green here once #328 merges to `main` and this branch is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)