### PR TITLE
fix(cd): stop deploying to the unused ci-cd-lab target (remove Cloud Deploy release steps)

### DIFF
--- a/.github/workflows/pre-deployment-validation.yml
+++ b/.github/workflows/pre-deployment-validation.yml
@@ -161,13 +161,14 @@ jobs:
           fi
           echo "✓ gcp/cloudbuild/cloudbuild-processor.yaml exists"
 
-          # Verify Skaffold rendering is enabled
-          if ! grep -q '\-\-skaffold\-file' gcp/cloudbuild/cloudbuild-processor.yaml; then
-            echo "❌ Cloud Build doesn't use Skaffold rendering!"
-            echo "   Add --skaffold-file=skaffold.yaml to release creation"
+          # Verify the processor Cloud Build deploys to production. Deployment is
+          # done directly with `kubectl set image` (Cloud Deploy release/Skaffold
+          # rendering was removed — it only fed the unused ci-cd-lab target).
+          if ! grep -q 'set image' gcp/cloudbuild/cloudbuild-processor.yaml; then
+            echo "❌ Cloud Build doesn't deploy to production (no 'kubectl set image')!"
             exit 1
           fi
-          echo "✓ Skaffold rendering enabled"
+          echo "✓ Production deploy (kubectl set image) present"
 
           echo ""
           echo "✅ Cloud Build configuration valid"

--- a/gcp/cloudbuild/cloudbuild-api.yaml
+++ b/gcp/cloudbuild/cloudbuild-api.yaml
@@ -28,62 +28,6 @@ steps:
       - '${_REGISTRY}/api'
     waitFor: ['build-api']
 
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: 'resolve-current-tags'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        DEFAULT_PROCESSOR="${_REGISTRY}/processor:latest"
-        DEFAULT_CRAWLER="${_REGISTRY}/crawler:latest"
-
-        LAST_RELEASE=$$(gcloud deploy releases list \
-          --delivery-pipeline=mizzou-news-crawler \
-          --region=us-central1 \
-          --sort-by="~createTime" \
-          --limit=1 \
-          --format="value(name)")
-
-        if [ -n "$${LAST_RELEASE}" ]; then
-          gcloud deploy releases describe "$${LAST_RELEASE}" \
-            --delivery-pipeline=mizzou-news-crawler \
-            --region=us-central1 \
-            --format=json > /workspace/last_release.json
-
-          python3 -c "import json, sys; from pathlib import Path; registry, default_processor, default_crawler = sys.argv[1:]; data=json.load(open('/workspace/last_release.json')); artifacts={item.get('image'): item.get('tag') for item in data.get('buildArtifacts', [])}; processor=artifacts.get('processor', default_processor); crawler=artifacts.get('crawler', default_crawler); Path('/workspace/current-tags.env').write_text(f'PROCESSOR_IMAGE={processor}\nCRAWLER_IMAGE={crawler}\n')" "${_REGISTRY}" "$${DEFAULT_PROCESSOR}" "$${DEFAULT_CRAWLER}"
-        else
-          printf 'PROCESSOR_IMAGE=%s\nCRAWLER_IMAGE=%s\n' "$${DEFAULT_PROCESSOR}" "$${DEFAULT_CRAWLER}" > /workspace/current-tags.env
-        fi
-
-        echo "Resolved tags:" && cat /workspace/current-tags.env
-    waitFor: ['push-api']
-
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: 'create-release'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        source /workspace/current-tags.env
-
-        API_IMAGE="${_REGISTRY}/api:${SHORT_SHA}"
-
-        echo "Creating Cloud Deploy release with:"
-        echo "  API: $${API_IMAGE}"
-        echo "  Processor: $${PROCESSOR_IMAGE}"
-        echo "  Crawler: $${CRAWLER_IMAGE}"
-
-        gcloud deploy releases create api-${SHORT_SHA} \
-          --delivery-pipeline=mizzou-news-crawler \
-          --region=us-central1 \
-          --annotations=commitId=${REVISION_ID},service=api \
-          --images=api=$${API_IMAGE},processor=$${PROCESSOR_IMAGE},crawler=$${CRAWLER_IMAGE}
-
-        echo "✅ Created Cloud Deploy release for API"
-    waitFor: ['resolve-current-tags']
-
   # Force pod update by setting image directly
   # This is the fix - Cloud Deploy doesn't update hardcoded tags in YAML
   # kubectl set image modifies deployment spec -> triggers NEW ReplicaSet -> rolling update
@@ -96,7 +40,7 @@ steps:
       - 'get-credentials'
       - 'mizzou-cluster'
       - '--zone=us-central1-a'
-    waitFor: ['create-release']
+    waitFor: ['push-api']
 
   - name: 'gcr.io/cloud-builders/kubectl'
     id: 'force-api-update'

--- a/gcp/cloudbuild/cloudbuild-processor.yaml
+++ b/gcp/cloudbuild/cloudbuild-processor.yaml
@@ -43,73 +43,6 @@ steps:
     waitFor:
       - 'build-processor'
 
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: 'resolve-current-tags'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        DEFAULT_API="${_REGISTRY}/api:latest"
-        DEFAULT_CRAWLER="${_REGISTRY}/crawler:latest"
-
-        LAST_RELEASE=$$(gcloud deploy releases list \
-          --delivery-pipeline=mizzou-news-crawler \
-          --region=us-central1 \
-          --sort-by="~createTime" \
-          --limit=1 \
-          --format="value(name)")
-
-        if [ -n "$${LAST_RELEASE}" ]; then
-          gcloud deploy releases describe "$${LAST_RELEASE}" \
-            --delivery-pipeline=mizzou-news-crawler \
-            --region=us-central1 \
-            --format=json > /workspace/last_release.json
-
-          python3 -c "import json, sys; from pathlib import Path; registry, default_api, default_crawler = sys.argv[1:]; data=json.load(open('/workspace/last_release.json')); artifacts={item.get('image'): item.get('tag') for item in data.get('buildArtifacts', [])}; api=artifacts.get('api', default_api); crawler=artifacts.get('crawler', default_crawler); Path('/workspace/current-tags.env').write_text(f'API_IMAGE={api}\nCRAWLER_IMAGE={crawler}\n')" "${_REGISTRY}" "$${DEFAULT_API}" "$${DEFAULT_CRAWLER}"
-        else
-          printf 'API_IMAGE=%s\nCRAWLER_IMAGE=%s\n' "$${DEFAULT_API}" "$${DEFAULT_CRAWLER}" > /workspace/current-tags.env
-        fi
-
-        echo "Resolved tags:" && cat /workspace/current-tags.env
-    waitFor: ['push-processor']
-
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: 'create-release'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        source /workspace/current-tags.env
-
-        # Allow an optional override tag for the release name to avoid duplicates on re-runs
-        RELEASE_NAME="processor-${_IMAGE_TAG:-${SHORT_SHA}}"
-        PROCESSOR_IMAGE="${_REGISTRY}/processor:${SHORT_SHA}"
-
-        echo "Preparing Cloud Deploy release: $${RELEASE_NAME}"
-        echo "  Processor: $${PROCESSOR_IMAGE}"
-        echo "  API: $${API_IMAGE}"
-        echo "  Crawler: $${CRAWLER_IMAGE}"
-
-        # If a release with this name already exists, treat as idempotent and exit successfully
-        if gcloud deploy releases describe "$${RELEASE_NAME}" \
-              --delivery-pipeline=mizzou-news-crawler \
-              --region=us-central1 >/dev/null 2>&1; then
-          echo "Release $${RELEASE_NAME} already exists; skipping create (idempotent)."
-          exit 0
-        fi
-
-        gcloud deploy releases create "$${RELEASE_NAME}" \
-          --delivery-pipeline=mizzou-news-crawler \
-          --region=us-central1 \
-          --annotations=commitId=${REVISION_ID},service=processor \
-          --skaffold-file=skaffold.yaml \
-          --images=processor=$${PROCESSOR_IMAGE},api=$${API_IMAGE},crawler=$${CRAWLER_IMAGE}
-
-        echo "✅ Created Cloud Deploy release $${RELEASE_NAME} for Processor"
-    waitFor: ['resolve-current-tags']
-
   # Force pod update by setting image directly
   # This is the fix - Cloud Deploy doesn't update hardcoded tags in YAML
   # kubectl set image modifies deployment spec -> triggers NEW ReplicaSet -> rolling update
@@ -122,7 +55,7 @@ steps:
       - 'get-credentials'
       - 'mizzou-cluster'
       - '--zone=us-central1-a'
-    waitFor: ['create-release']
+    waitFor: ['push-processor']
 
   - name: 'gcr.io/cloud-builders/kubectl'
     id: 'force-processor-update'


### PR DESCRIPTION
## What
`cloudbuild-processor.yaml` and `cloudbuild-api.yaml` created a Cloud Deploy release on every build, which deployed to the pipeline's first stage — the **`ci-cd-lab`** target we never use. This removes that vestigial path.

- Delete the `resolve-current-tags` + `create-release` steps from both configs.
- Rewire `get-gke-credentials` to `waitFor` the image push (`push-processor` / `push-api`) instead of the removed `create-release`.
- `crawler` was already kubectl-only — unchanged.

## Production image tags are unchanged (the important part)
Each service's production deployment is still set by its own untouched step:
- `kubectl set image deployment/mizzou-processor processor=…:${SHORT_SHA} --namespace=production` (+ mizzou-cli, + rollout restart)
- `kubectl set image deployment/mizzou-api api=…:${SHORT_SHA} --namespace=production`

Each uses the freshly-built `${SHORT_SHA}` and touches only its own deployment. `resolve-current-tags` only existed to stop the *Cloud Deploy* release from resetting sibling services' tags — a concern that only applied to that (now-removed) path.

## Verified
- No dangling references to removed steps/vars; all `waitFor` edges valid; YAML parses.
- Full local pre-push suite passed (lint, mypy, unit+integration, PostgreSQL, coverage).

## Follow-ups (not in this PR)
- `gcp/clouddeploy.yaml` is now unused **and** still has invalid schema (`defaultTargetId`/`render`) — delete or fix separately.
- The GCP Cloud Deploy pipeline + `ci-cd-lab` target still exist but will no longer receive releases; can be removed later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)