### PR TITLE
fix(ci): broaden @claude review trigger to match natural phrasings

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -39,11 +39,14 @@ concurrency:
 
 jobs:
   review:
-    # Only when a TRUSTED user comments "@claude review" on a PR (not a plain
-    # issue). The author_association guard blocks outside contributors from
-    # spending the subscription or triggering the workflow with our credentials.
+    # Only when a TRUSTED user asks Claude to review a PR (not a plain issue).
+    # Match any comment that mentions @claude AND "review" so natural phrasings
+    # all work ("@claude review", "@claude code review", "@claude please review").
+    # The author_association guard blocks outside contributors from spending the
+    # subscription or triggering the workflow with our credentials.
     if: >-
-      contains(github.event.comment.body, '@claude review')
+      contains(github.event.comment.body, '@claude')
+      && contains(github.event.comment.body, 'review')
       && (github.event.issue.pull_request != null
           || github.event_name == 'pull_request_review_comment')
       && (github.event.comment.author_association == 'OWNER'


### PR DESCRIPTION
## Problem
Commenting **`@claude code review`** on a PR did nothing — no review, no error. The `Claude PR Review` workflow *triggered* but its guard required the exact substring `@claude review`, and `@claude code review` doesn't contain it (the word "code" sits between). The run skipped in ~2s, which reads as "the bot ignored me."

## Fix
Match any comment that mentions **`@claude`** AND **`review`**, so all natural phrasings work:
- `@claude review`
- `@claude code review`
- `@claude please review`

## Security unchanged
Still gated by the `author_association` check (OWNER / MEMBER / COLLABORATOR only). This changes *how* a trusted user can phrase the request, not *who* can trigger it or spend the subscription.

## Note on rollout
Comment-triggered workflows run from the **default branch**, so this only takes effect once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)