### PR TITLE
security(deps): clear the last two Dependabot alerts

### DIFF
--- a/gcp_functions/weekly_source_health_check/requirements.txt
+++ b/gcp_functions/weekly_source_health_check/requirements.txt
@@ -3,9 +3,13 @@ google-cloud-secret-manager==2.16.0
 sqlalchemy==2.0.23
 pg8000==1.31.5
 cloud-sql-python-connector==1.20.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 
 # Gmail API dependencies for delegated send
 google-api-python-client==2.129.0
 google-auth-httplib2==0.2.0
 psycopg2-binary==2.9.9
+
+# Transitive floor: the pinned google-* libs resolve an older protobuf;
+# 5.29.6 fixes a JSON recursion-depth bypass (Dependabot #175)
+protobuf>=5.29.6


### PR DESCRIPTION
Clears the final 2 of the original 147 open Dependabot alerts.

## Why the list \"never cleared\" (root cause, already remediated)
The **Dependency Submission** workflow — which feeds the dependency graph that Dependabot recomputes alerts from — had been **failing every weekly run since at least May 11** (the old requirements couldn't `pip install`) and was then **auto-disabled by GitHub (`disabled_inactivity`)** on June 8. So the graph was frozen from before the security fixes: the fixes on main were real, but Dependabot never saw them.

Re-enabling and running the workflow (done — succeeded in 2m51s) dropped open alerts **147 → 2** with no code change.

## The last 2 (this PR)
`gcp_functions/weekly_source_health_check/requirements.txt`:
- **#77 (high→medium)** `python-dotenv` 1.0.0 → **1.2.2** (symlink-following file overwrite in `set_key`)
- **#175 (high)** add **`protobuf>=5.29.6`** floor (JSON recursion-depth bypass; transitive via the pinned `google-*` clients)

## Keeping it fixed
The workflow is re-enabled and its weekly cron + `requirements.txt`-push triggers are intact. If the repo goes quiet for 60 days GitHub may auto-disable it again — the run history now shows a green baseline to notice that against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)