### PR TITLE
ci: make the lint gate real + pin the toolchain for local/CI parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,12 @@ jobs:
               python -m ruff check . &&
               python -m black --check src/ tests/ web/ &&
               python -m isort --check-only --profile black src/ tests/ web/ &&
-              python -m mypy src/ --ignore-missing-imports || true
+              (python -m mypy src/ --ignore-missing-imports || true)
             "
+            # NOTE: only mypy is advisory here (the strict gate is the separate
+            # mypy-strict job). Without the parentheses the trailing '|| true'
+            # rescued the WHOLE && chain, so ruff/black/isort could never fail
+            # this job — black had been printing failures into green runs.
 
       - name: Validate deployment configurations
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,11 +13,15 @@ testcontainers>=3.7.0  # Docker container management for tests
 sphinx>=7.1.0
 sphinx-rtd-theme>=1.3.0
 
-# Code quality
-ruff>=0.13.0  # Fast Python linter
-black>=24.0.0  # Code formatter
-isort>=5.13.0  # Import sorter
-mypy>=1.5.0  # Type checker
+# Code quality — EXACT pins so local dev and the ci-base image resolve the
+# SAME tool versions. Floor pins caused an 8-month drift (CI black 25.11 vs
+# local black 26.1 disagreed on ~100 files). If something passes locally it
+# must pass in CI and vice-versa; bump these deliberately, in lockstep with a
+# ci-base rebuild.
+ruff==0.14.14  # Fast Python linter
+black==26.1.0  # Code formatter
+isort==7.0.0  # Import sorter
+mypy==1.19.1  # Type checker
 bandit>=1.7.5  # Security linting
 safety>=2.3.0  # Dependency vulnerability scanning
 pre-commit>=3.5.0  # Git hooks for code quality

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -3619,14 +3619,16 @@ class NewsDiscovery:
         )
 
         if self.telemetry and source_id and operation_id:
+            # Distinct name from the `status` HTTP-code int used earlier in
+            # this function — reusing it retypes the variable (mypy error).
             if len(discovered_articles) > 0:
-                status = DiscoveryMethodStatus.SUCCESS
+                method_status = DiscoveryMethodStatus.SUCCESS
             elif feeds_tried == 0:
-                status = DiscoveryMethodStatus.NO_FEED
+                method_status = DiscoveryMethodStatus.NO_FEED
             elif feeds_successful == 0:
-                status = DiscoveryMethodStatus.NO_FEED
+                method_status = DiscoveryMethodStatus.NO_FEED
             else:
-                status = DiscoveryMethodStatus.PARSE_ERROR
+                method_status = DiscoveryMethodStatus.PARSE_ERROR
 
             status_codes = []
             if feeds_tried > 0:
@@ -3640,7 +3642,7 @@ class NewsDiscovery:
                     source_id=source_id,
                     source_url=source_url,
                     discovery_method=DiscoveryMethod.RSS_FEED,
-                    status=status,
+                    status=method_status,
                     articles_found=len(discovered_articles),
                     response_time_ms=discovery_time * 1000,
                     status_codes=status_codes,

--- a/src/services/url_verification.py
+++ b/src/services/url_verification.py
@@ -23,6 +23,7 @@ import requests
 import urllib3
 from requests import Session
 from requests.exceptions import RequestException, Timeout
+from requests.structures import CaseInsensitiveDict
 
 # Suppress InsecureRequestWarning for proxies without SSL certs
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -232,12 +233,12 @@ class URLVerificationService:
 
         session_headers = getattr(self.http_session, "headers", None)
         if session_headers is None:
-            self.http_session.headers = dict(self.http_headers)
+            self.http_session.headers = CaseInsensitiveDict(self.http_headers)
             return
 
         if not hasattr(session_headers, "setdefault"):
             # Unexpected type; fall back to a fresh mapping.
-            self.http_session.headers = dict(self.http_headers)
+            self.http_session.headers = CaseInsensitiveDict(self.http_headers)
             return
 
         for key, value in self.http_headers.items():
@@ -414,7 +415,9 @@ class URLVerificationService:
         status_code: int | None = None
 
         # Save original headers so we can restore them after attempts
-        original_headers = dict(getattr(self.http_session, "headers", {}) or {})
+        original_headers = CaseInsensitiveDict(
+            getattr(self.http_session, "headers", {}) or {}
+        )
 
         for attempt in range(1, _GET_FALLBACK_ATTEMPTS + 1):
             try:

--- a/tests/services/test_url_verification.py
+++ b/tests/services/test_url_verification.py
@@ -634,7 +634,9 @@ def test_prepare_http_session_initializes_missing_headers() -> None:
     service = url_verification.URLVerificationService(http_session=session)
 
     assert service.http_session.headers is session.headers
-    assert isinstance(session.headers, dict)
+    # requests types Session.headers as CaseInsensitiveDict; the service now
+    # installs exactly that (a dict is not case-insensitive for header keys).
+    assert isinstance(session.headers, requests.structures.CaseInsensitiveDict)
     for key, value in url_verification._DEFAULT_HTTP_HEADERS.items():
         assert session.headers[key] == value
 
@@ -645,7 +647,9 @@ def test_prepare_http_session_replaces_non_mapping_headers() -> None:
 
     service = url_verification.URLVerificationService(http_session=session)
 
-    assert isinstance(service.http_session.headers, dict)
+    assert isinstance(
+        service.http_session.headers, requests.structures.CaseInsensitiveDict
+    )
     for key in url_verification._DEFAULT_HTTP_HEADERS:
         assert key in service.http_session.headers
 


### PR DESCRIPTION
**Merge promptly after CI goes green** — the rebuilt `ci-base` image is already live, and its mypy 1.19.1 will fail the (real) `Mypy (strict)` job on any branch that doesn't carry this PR's type fixes.

## Problem: "passes locally" and "passes in CI" were different questions
1. **The lint gate was fake.** The job ran `ruff && black && isort && mypy || true` — the trailing `|| true` rescues the **whole `&&` chain**, so ruff/black/isort/mypy could never fail the job. Black had been printing "would reformat: 64 files" into green runs.
2. **Floor pins (`>=`) guaranteed toolchain drift.** The ci-base image (built 2025-11-23) carried black 25.11 / ruff 0.14.6 / mypy 1.18.2 while local dev resolved black 26.1 / ruff 0.14.14 / mypy 1.19.1 — and black 25 vs 26 disagree on ~100 files in this repo.

## Fix
- `ci.yml`: `ruff && black && isort && (mypy || true)` — only mypy stays advisory (the strict gate is the separate mypy-strict job). Ruff/black/isort become a real gate for the first time.
- `requirements-dev.txt`: the four lint/type tools pinned **exactly** (`ruff==0.14.14`, `black==26.1.0`, `isort==7.0.0`, `mypy==1.19.1`), with a comment mandating deliberate lockstep bumps with a ci-base rebuild.
- **ci-base already rebuilt** with these pins (Cloud Build `ca2cd2c6`, SUCCESS) and verified in-container: versions match the pins exactly.
- **9 latent type errors** surfaced by pinned mypy 1.19.1 fixed before letting the gate loose:
  - `url_verification`: `Session.headers` is a `CaseInsensitiveDict` in requests' types; plain-dict assignments fixed (also a behavior nit — plain dicts aren't case-insensitive for header keys). Two over-specific `isinstance(..., dict)` test assertions updated.
  - `discovery.discover_with_rss_feeds`: `status` reused as both HTTP-code int and `DiscoveryMethodStatus` enum → enum renamed `method_status`.

## Verified
- Full repo passes ruff/black/isort/mypy under the pinned toolchain, **both locally and inside the rebuilt image** (the exact CI execution environment).
- `url_verification` suite: 27 passed. Full pre-push hook: main 2652 passed, postgres 288 passed, coverage 80%.

## Known remaining gaps (deliberate follow-ups, documented not hidden)
- Python 3.11 (image) vs 3.12 (local venv).
- `pytest --ignore` lists differ between ci.yml jobs and the pre-push hook (local currently runs a superset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)