### PR TITLE
security(deps): black 26.1.0 → 26.3.1 (lockstep bump, Dependabot #176)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ sphinx-rtd-theme>=1.3.0
 # must pass in CI and vice-versa; bump these deliberately, in lockstep with a
 # ci-base rebuild.
 ruff==0.14.14  # Fast Python linter
-black==26.1.0  # Code formatter
+black==26.3.1  # Code formatter
 isort==7.0.0  # Import sorter
 mypy==1.19.1  # Type checker
 bandit>=1.7.5  # Security linting


### PR DESCRIPTION
Dependabot #176 flagged `black==26.1.0` (fixed in 26.3.1) — hours after #343 pinned it. This is the first exercise of the lockstep protocol the pin comment mandates:

1. ✅ Local venv bumped to 26.3.1 — verified it formats the repo **identically** (446 files unchanged), so no reformat fallout and no local/CI disagreement window.
2. ✅ `requirements-dev.txt` pin bumped (this PR).
3. 🔄 ci-base rebuilding with this pin (completes before merge).

One-line change; the (real) lint gate on this PR runs black itself as final proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)