### PR TITLE
fix(ci): install gke-gcloud-auth-plugin for kubectl in GKE workflows

### DIFF
--- a/.github/workflows/production-smoke-tests.yml
+++ b/.github/workflows/production-smoke-tests.yml
@@ -35,6 +35,10 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+        with:
+          # kubectl against modern GKE needs the auth plugin (not bundled by default):
+          # "exec: executable gke-gcloud-auth-plugin not found"
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/staging-rollout.yml
+++ b/.github/workflows/staging-rollout.yml
@@ -58,6 +58,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ inputs.gcp-project }}
+          # kubectl against modern GKE needs the auth plugin (not bundled by default)
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Configure Docker for Artifact Registry
         run: |


### PR DESCRIPTION
The smoke test's chain of failures is peeling back one layer at a time — #336 fixed the fake cluster name, and the workflow now reaches the **real** cluster, where kubectl dies on:

```
getting credentials: exec: executable gke-gcloud-auth-plugin not found
```

Modern GKE kubeconfigs authenticate via the `gke-gcloud-auth-plugin` exec plugin, which `setup-gcloud@v2` doesn't bundle by default. Add `install_components: 'gke-gcloud-auth-plugin'` to both workflows that run kubectl after setup-gcloud:
- `production-smoke-tests.yml` (the failing run: [29661138319](https://github.com/LocalNewsImpact/MizzouNewsCrawler/actions/runs/29661138319))
- `staging-rollout.yml` (identical latent bug — same pattern, would fail the same way when dispatched)

After merge I'll dispatch Production Smoke Tests manually to confirm kubectl connects and the pytest suite actually runs in the processor pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)