### PR TITLE
fix(ci): treat scaled-to-zero production as a skip, not a smoke-test failure

### DIFF
--- a/.github/workflows/production-smoke-tests.yml
+++ b/.github/workflows/production-smoke-tests.yml
@@ -46,12 +46,31 @@ jobs:
             --zone us-central1-a
 
       - name: Wait for deployments to be ready
+        id: wait_ready
         run: |
           echo "⏳ Verifying deployments are healthy and ready..."
           echo ""
 
           TIMEOUT=600  # 10 minutes
           SERVICES=(mizzou-api mizzou-processor work-queue)
+
+          # Production is sometimes deliberately scaled to zero between crawl
+          # waves. If EVERY service has 0 desired replicas, that's a pause,
+          # not a failure — skip the smoke tests with a notice. (A mixed
+          # state — some scaled up, some not — still fails below, since
+          # rollout status on the scaled-up ones must succeed.)
+          TOTAL_DESIRED=0
+          for service in "${SERVICES[@]}"; do
+            desired=$(kubectl get deployment/$service -n production \
+              -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 0)
+            TOTAL_DESIRED=$((TOTAL_DESIRED + ${desired:-0}))
+          done
+          if [ "$TOTAL_DESIRED" -eq 0 ]; then
+            echo "::notice::Production is scaled to zero (all deployments have 0 desired replicas) — skipping smoke tests."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
           for service in "${SERVICES[@]}"; do
             echo "Checking $service deployment..."
@@ -89,6 +108,7 @@ jobs:
 
       - name: Run smoke tests
         id: smoke_tests
+        if: steps.wait_ready.outputs.skip != 'true'
         run: |
           echo "🧪 Running production smoke tests..."
           echo ""
@@ -146,7 +166,9 @@ jobs:
       - name: Report results
         if: always()
         run: |
-          if [ "${{ steps.smoke_tests.outcome }}" == "success" ]; then
+          if [ "${{ steps.wait_ready.outputs.skip }}" == "true" ]; then
+            echo "⏸️  Production scaled to zero — smoke tests skipped (not a failure)."
+          elif [ "${{ steps.smoke_tests.outcome }}" == "success" ]; then
             echo "✅ All smoke tests passed!"
           else
             echo "❌ Smoke tests failed!"


### PR DESCRIPTION
Production is deliberately scaled to zero between crawl waves. The smoke test failed confusingly in that state: `kubectl rollout status` trivially passes on 0-replica deployments, then the pod-exec step finds no processor pod (`array index out of bounds`).

Now: if **all** monitored deployments have 0 desired replicas → `::notice::` + skip + green. A **mixed** state still validates scaled-up services and fails on real problems. "Report results" distinguishes ⏸️ skipped / ✅ passed / ❌ failed.

Workflow-only change → heavy CI skips via the changes-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)