### PR TITLE
fix(ci): copy smoke test into the pod — production images don't ship tests/

### DIFF
--- a/.github/workflows/production-smoke-tests.yml
+++ b/.github/workflows/production-smoke-tests.yml
@@ -143,8 +143,15 @@ jobs:
           echo ""
           echo "Running test suite..."
 
-          # Build pytest command
-          PYTEST_CMD="pytest tests/e2e/test_production_smoke.py -v --tb=short --color=yes"
+          # The production image ships src/ but (correctly) not tests/, so
+          # copy the smoke test from this checkout into the pod. This also
+          # means each run tests the repo-current version of the test file.
+          kubectl cp tests/e2e/test_production_smoke.py \
+            "production/$POD_NAME:/tmp/test_production_smoke.py"
+
+          # Build pytest command. `cd /app && python -m pytest` puts /app on
+          # sys.path so the test's `from src.models...` imports resolve.
+          PYTEST_CMD="cd /app && python -m pytest /tmp/test_production_smoke.py -v --tb=short --color=yes -p no:cacheprovider"
 
           # Add test filter if provided
           if [ -n "${{ github.event.inputs.test_filter }}" ]; then


### PR DESCRIPTION
Final plumbing layer of the smoke-test repair chain (#336 cluster config → #345 GKE auth plugin → #346 zero-replica skip → this).

`pytest tests/e2e/test_production_smoke.py` exited 4 inside the pod: the processor image (correctly) ships `src/` but not `tests/`. Fix: `kubectl cp` the test file from the workflow checkout into the pod and run `cd /app && python -m pytest /tmp/test_production_smoke.py` (puts `/app` on `sys.path` for the `from src.models...` imports). Bonus: each run tests the **repo-current** version of the test file — no image rebuild coupling.

**Verified live against production before opening this PR:** 34 tests execute in 73s — 15 pass, 19 fail on *content*, split into:
- freshness assertions ("no articles extracted in last 24h") — artifacts of the deliberate scale-to-zero pause, will pass as the resumed pipeline produces data
- schema drift (`column "status_updated_at" does not exist`) — the test's SQL disagrees with the live schema; needs triage as its own piece of work

🤖 Generated with [Claude Code](https://claude.com/claude-code)