### PR TITLE
fix(ci): mirror images with crane (streamed registry copy)

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -27,6 +27,7 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false  # one image's failure shouldn't cancel the other
       matrix:
         image: [ci-base, crawler]
     steps:


### PR DESCRIPTION
docker push to ghcr failed with 'unknown blob' (and pull+push would exhaust runner disk on the 9GB ci-base). crane streams registry-to-registry with no local storage and preserves digests. + fail-fast: false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)