### PR TITLE
ci: pull job images from GHCR mirror (~$45/mo AR egress → $0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,24 +84,22 @@ jobs:
       - name: Clean Python bytecode cache
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: |
-          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Run linting in container
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "
               git config --global --add safe.directory /workspace &&
               python -m ruff check . &&
@@ -147,23 +145,22 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Run mypy (fail on errors) in container
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && python -m mypy src/ --ignore-missing-imports"
 
   security:
@@ -178,23 +175,22 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Run bandit security scan in container
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && python -m bandit -r src/ -ll -f txt || true" && \
           echo "Bandit found issues but not failing build (review recommended)"
 
@@ -203,7 +199,7 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && python -m safety check --json || true" && \
           echo "Safety check completed (review recommended)"
         continue-on-error: true
@@ -237,16 +233,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Create data directory for tests
         run: mkdir -p data
@@ -260,7 +255,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -e DATABASE_URL="$DATABASE_URL" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && alembic upgrade head"
 
       - name: Run unit tests in container
@@ -276,7 +271,7 @@ jobs:
             -e DATABASE_URL="$DATABASE_URL" \
             -e TELEMETRY_DATABASE_URL="$TELEMETRY_DATABASE_URL" \
             -e TEST_DATABASE_URL="$TEST_DATABASE_URL" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "
               git config --global --add safe.directory /workspace &&
               python3 scripts/validate_workflow_templates.py &&
@@ -313,16 +308,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Create data directory for tests
         run: mkdir -p data
@@ -336,7 +330,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -e DATABASE_URL="$DATABASE_URL" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && alembic upgrade head"
 
       - name: Quick validator and targeted tests in container
@@ -354,7 +348,7 @@ jobs:
             -e TELEMETRY_DATABASE_URL="$TELEMETRY_DATABASE_URL" \
             -e TEST_DATABASE_URL="$TEST_DATABASE_URL" \
             -e PYTEST_ADDOPTS="$PYTEST_ADDOPTS" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "
               git config --global --add safe.directory /workspace &&
               python3 scripts/validate_workflow_templates.py &&
@@ -391,16 +385,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Create data directory for tests
         run: mkdir -p data
@@ -414,7 +407,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -e DATABASE_URL="$DATABASE_URL" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && alembic upgrade head"
 
       - name: Run proxy stack smoke tests in container
@@ -430,7 +423,7 @@ jobs:
             -e DATABASE_URL="$DATABASE_URL" \
             -e TELEMETRY_DATABASE_URL="$TELEMETRY_DATABASE_URL" \
             -e TEST_DATABASE_URL="$TEST_DATABASE_URL" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "set -euo pipefail; git config --global --add safe.directory /workspace && pytest -q --maxfail=1 -o addopts= tests/backend/test_lifecycle.py tests/test_deployment_requirements.py"
 
   selenium-headful:
@@ -447,16 +440,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull crawler image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-crawler:latest
 
       - name: Run Selenium regression tests (headful-first)
         env:
@@ -467,7 +459,7 @@ jobs:
             --network host \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:latest \
+            ghcr.io/localnewsimpact/mizzou-crawler:latest \
             /bin/bash -c "
               set -euo pipefail
               if ! command -v Xvfb >/dev/null; then
@@ -520,16 +512,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Create data directory for tests
         run: mkdir -p data
@@ -555,7 +546,7 @@ jobs:
             -e DATABASE_NAME="$DATABASE_NAME" \
             -e DATABASE_USER="$DATABASE_USER" \
             -e DATABASE_PASSWORD="$DATABASE_PASSWORD" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && alembic upgrade head"
 
       - name: Run all integration tests with PostgreSQL in container
@@ -585,7 +576,7 @@ jobs:
             -e DATABASE_NAME="$DATABASE_NAME" \
             -e DATABASE_USER="$DATABASE_USER" \
             -e DATABASE_PASSWORD="$DATABASE_PASSWORD" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && pytest -v -m integration --ignore=tests/docker --ignore=tests/scripts --ignore=tests/backfill/test_backfill_article_entities.py --ignore=tests/cli/commands/test_test_domain_command.py --ignore=tests/cli/test_manual_enqueue.py --ignore=tests/test_actual_telemetry.py --ignore=tests/test_chrome_bin_default.py --ignore=tests/test_gazetteer_telemetry.py --ignore=tests/test_geocode_cache.py --ignore=tests/test_launch_dataset_job.py --ignore=tests/test_gazetteer_integration.py --ignore=tests/test_smoke_test_migrations.py --ignore=tests/test_migrator_image.py --ignore=tests/test_sync_decodo_credentials.py --ignore=tests/utils/test_run_scrapfly_tests_pod.py --ignore=tests/utils/test_script_import_safety.py --tb=short --no-cov"
 
   integration:
@@ -606,16 +597,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Create data directory for tests
         run: mkdir -p data
@@ -625,7 +615,7 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && pytest -m 'not postgres and not docker and not local_scripts' --ignore=tests/docker --ignore=tests/scripts --ignore=tests/backfill/test_backfill_article_entities.py --ignore=tests/cli/commands/test_test_domain_command.py --ignore=tests/cli/test_manual_enqueue.py --ignore=tests/test_actual_telemetry.py --ignore=tests/test_chrome_bin_default.py --ignore=tests/test_gazetteer_telemetry.py --ignore=tests/test_geocode_cache.py --ignore=tests/test_launch_dataset_job.py --ignore=tests/test_gazetteer_integration.py --ignore=tests/test_smoke_test_migrations.py --ignore=tests/test_migrator_image.py --ignore=tests/test_sync_decodo_credentials.py --ignore=tests/utils/test_run_scrapfly_tests_pod.py --ignore=tests/utils/test_script_import_safety.py --cov=src --cov-report=xml --cov-report=html --cov-report=term-missing --cov-fail-under=78"
 
       - name: Generate coverage summary
@@ -634,7 +624,7 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && python tools/generate_coverage_summary.py coverage.xml coverage-summary.md"
 
   quick-checks-integration:
@@ -668,16 +658,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Wait for Postgres
         run: |
@@ -710,7 +699,7 @@ jobs:
             -e DATABASE_NAME="$DATABASE_NAME" \
             -e DATABASE_USER="$DATABASE_USER" \
             -e DATABASE_PASSWORD="$DATABASE_PASSWORD" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && pytest -vv tests/alembic/test_resync_sequence_postgres.py -c /dev/null" 2>&1 | tee ci-logs/resync-test.log
 
       - name: Upload logs on failure
@@ -759,16 +748,15 @@ jobs:
         run: find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        # Images are mirrored AR->GHCR (mirror-images.yml); pulls from GHCR to
+        # GitHub-hosted runners are free and fast, vs ~$0.35-0.50 of Artifact
+        # Registry egress per multi-GB pull. GITHUB_TOKEN can read packages
+        # pushed by this repo's workflows.
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Run migrations in container
         env:
@@ -779,7 +767,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -e DATABASE_URL="$DATABASE_URL" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && alembic upgrade head"
 
       - name: Run stress tests with RUN_STRESS_TESTS=1 in container
@@ -797,5 +785,5 @@ jobs:
             -e TELEMETRY_DATABASE_URL="$TELEMETRY_DATABASE_URL" \
             -e TEST_DATABASE_URL="$TEST_DATABASE_URL" \
             -e RUN_STRESS_TESTS="$RUN_STRESS_TESTS" \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "git config --global --add safe.directory /workspace && pytest --override-ini addopts='-q' tests/test_versioning_concurrent_stress.py"


### PR DESCRIPTION
Second half of the GHCR mirror (#349/#350 shipped the mirror; both images are on ghcr, digest-verified).

- 29 image refs → `ghcr.io/localnewsimpact/mizzou-{ci-base,crawler}:latest`
- 11 GCP auth+docker-config step pairs → one `docker login ghcr` with `GITHUB_TOKEN` (repo-linked package read). **GCP_SA_KEY no longer touches test jobs at all** — a nice security bonus.
- **This PR's own CI is the live validation**: every job pulls from GHCR. Watch the pull-step durations vs the ~48–102s AR baseline.

Freshness contract: mirror runs on dispatch + daily cron + main-pushes touching Dockerfiles/requirements, and is digest-compared. If ci-base is rebuilt out-of-band, run the mirror workflow before relying on CI (or it uses the previous image until the nightly sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)