### PR TITLE
ci: quick-test pulls ci-base from GHCR mirror

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -52,17 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure Docker for GCP Artifact Registry
-        run: |
-          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull base image
-        run: docker pull us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest
+        run: docker pull ghcr.io/localnewsimpact/mizzou-ci-base:latest
 
       - name: Run specified tests
         env:
@@ -88,7 +82,7 @@ jobs:
             -w /workspace \
             -e TEST_DATABASE_URL="${TEST_DATABASE_URL}" \
             -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json \
-            us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/ci-base:latest \
+            ghcr.io/localnewsimpact/mizzou-ci-base:latest \
             /bin/bash -c "
               python -m pytest ${TEST_PATH} \
                 ${{ github.event.inputs.pytest_args }} \


### PR DESCRIPTION
Completes the GHCR conversion (#351): quick-test.yml was the last workflow pulling ci-base from Artifact Registry. Dispatch-only and rarely used, but now zero paths back to AR egress remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)