### PR TITLE
perf(images): CPU-only torch — ml-base 4.1→1.6 GB (−62%)

### DIFF
--- a/Dockerfile.ci-base
+++ b/Dockerfile.ci-base
@@ -19,7 +19,14 @@ COPY requirements-dev.txt ./
 
 # Install test-only dependencies on top of production base
 # These are heavy packages only needed for tests (PyTorch, transformers, etc)
-RUN pip install --no-cache-dir torch>=2.1.0 transformers>=4.30.0 && \
+#
+# NOTE the quotes: the old unquoted `torch>=2.1.0` was shell REDIRECTION —
+# it installed unpinned latest torch (with 2.7GB of CUDA libs) and wrote a
+# stray file named '=2.1.0'. The CPU-only wheel index keeps CUDA out of an
+# image that runs tests on GPU-less CI runners; mirrors Dockerfile.ml-base
+# so CI type-checks/tests against the same torch build production uses.
+RUN pip install --no-cache-dir "torch>=2.1.0" --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir "transformers>=5.5.0" && \
     pip install --no-cache-dir -r requirements-dev.txt
 
 # Metadata

--- a/Dockerfile.ml-base
+++ b/Dockerfile.ml-base
@@ -14,7 +14,14 @@ COPY requirements-ml.txt ./
 
 # Install ML packages (this is the slow part)
 # Use --no-cache-dir to reduce image size
-RUN pip install --no-cache-dir -r requirements-ml.txt
+#
+# torch comes from the CPU-only wheel index FIRST: the default PyPI wheel
+# bundles ~2.7GB of NVIDIA CUDA libraries that can never run on our
+# GPU-less GKE nodes (the classifier runs device=-1/CPU). Installing the
+# +cpu build first satisfies requirements-ml.txt's torch floor, so the
+# CUDA build is never pulled. Saves ~4GB per image (ml-base, processor).
+RUN pip install --no-cache-dir "torch>=2.1.0" --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir -r requirements-ml.txt
 
 # Pre-download commonly used models to speed up first run
 # This is optional but helpful for faster cold starts


### PR DESCRIPTION
The default PyPI torch wheel bundles the NVIDIA CUDA runtime (~1.2GB torch + ~2.7GB `nvidia-*`) — never executed here: GKE nodes have no GPUs and the classifier runs `device=-1` (CPU) explicitly. Install torch from PyTorch's CPU wheel index **first**, so transformers/requirements see it satisfied and never pull the CUDA build.

**Also fixes a real bug:** `Dockerfile.ci-base`'s unquoted `torch>=2.1.0` was shell **redirection** — it installed unpinned latest CUDA torch (hence `2.13.0+cu130` in ci-base) and wrote a stray file named `=2.1.0`.

## Validated before touching any shared tag (Cloud Build `ml-base:cpu-test`)
- ✅ `torch 2.13.0+cpu`, CUDA not built
- ✅ real `productionmodel.pt` loads (`map_location=cpu`)
- ✅ BERT forward pass runs
- ✅ **4.11 GB → 1.57 GB compressed (−62%)**; build 15 min → 4 min

## Rollout on merge
The CD cascade (#334) rebuilds ml-base → processor automatically. I'll then rebuild ci-base and dispatch the GHCR mirror so CI pulls the slim image. Faster GKE cold-starts (the 5-min `ContainerCreating` shrinks proportionally), faster CI pulls, smaller registry.

If GPU nodes are ever added, revert the `--index-url` deliberately — that's the only capability removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)