### PR TITLE
ci: build + smoke affected images at PR time (closes the base-image blind spot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.detect.outputs.code }}
+      images: ${{ steps.detect.outputs.images }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,12 +45,14 @@ jobs:
           if [ -z "$base" ] || [ -z "$head" ]; then
             echo "Non-PR event (or missing SHAs) — running full suite."
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "images=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           mb=$(git merge-base "$base" "$head" 2>/dev/null || echo "")
           if [ -z "$mb" ]; then
             echo "No merge-base found — running full suite to be safe."
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "images=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           changed=$(git diff --name-only "$mb" "$head")
@@ -66,6 +69,56 @@ jobs:
             echo "→ only workflow/docs changes; skipping heavy test jobs."
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # Which container images does this PR's diff affect? Dockerfiles are
+          # never built by the regular PR jobs (they run in PREBUILT images),
+          # so image changes get a dedicated build+smoke via image-build-check.
+          images=""
+          add() { case ",$images," in *",$1,"*) ;; *) images="${images:+$images,}$1";; esac; }
+          while IFS= read -r f; do
+            case "$f" in
+              Dockerfile.base|requirements-base.txt|requirements.txt) add base ;;
+              Dockerfile.ml-base|requirements-ml.txt) add ml-base ;;
+              Dockerfile.ci-base|requirements-dev.txt) add ci-base ;;
+              Dockerfile.processor|requirements-processor.txt) add processor ;;
+              Dockerfile.crawler|requirements-crawler.txt) add crawler ;;
+              Dockerfile.api|requirements-api.txt) add api ;;
+              Dockerfile.migrator|requirements-migrator.txt) add migrator ;;
+            esac
+          done <<< "$changed"
+          echo "→ images affected: ${images:-none}"
+          echo "images=$images" >> "$GITHUB_OUTPUT"
+
+  # PR CI runs tests INSIDE prebuilt images, so a PR that edits a Dockerfile
+  # or requirements file is never actually built here — the change would first
+  # execute in the post-merge production build. This job closes that gap:
+  # build the affected image(s) from the PR source in Cloud Build with a
+  # throwaway tag (nothing pushed) and smoke-test inside the fresh build.
+  image-build-check:
+    name: Image Build Check
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.images != ''
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build + smoke affected images from PR source
+        run: |
+          echo "Images affected by this PR: ${{ needs.changes.outputs.images }}"
+          gcloud builds submit \
+            --config gcp/cloudbuild/cloudbuild-pr-image-check.yaml \
+            --substitutions "_IMAGES=${{ needs.changes.outputs.images }}" \
+            --project mizzou-news-crawler \
+            .
 
   lint:
     name: Lint & Format Check

--- a/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
+++ b/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
@@ -1,0 +1,126 @@
+# PR-time image build check.
+#
+# The regular CI jobs run tests INSIDE prebuilt images — a PR that edits a
+# Dockerfile or requirements file is never actually built by PR CI; the change
+# would first execute in the post-merge production build. This config closes
+# that gap: ci.yml's image-build-check job submits it with _IMAGES set to the
+# comma-separated list of affected images. Each is built from the PR source
+# with a throwaway local tag (NOTHING is pushed — no `images:` section) and
+# then smoke-tested inside the fresh build.
+#
+# Dependency-aware: images are built in canonical order (base -> ml-base ->
+# the rest), and when a parent was built in this same run its local pr-check
+# tag is used as the child's base — so a PR changing base + processor tests
+# the processor ON the new base.
+
+substitutions:
+  _IMAGES: ''  # e.g. "ml-base,ci-base" — set by ci.yml from the changes job
+  _REGISTRY: 'us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler'
+
+steps:
+  # Model file is a build input for ml-base (COPY models/productionmodel.pt)
+  - id: 'download-model'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        case ",${_IMAGES}," in
+          *,ml-base,*)
+            mkdir -p models
+            gsutil cp gs://mizzou-news-crawler-models/productionmodel.pt models/productionmodel.pt
+            ;;
+          *) echo "ml-base not in scope; skipping model download" ;;
+        esac
+
+  - id: 'build-and-smoke'
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    waitFor: ['download-model']
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+
+        REG="${_REGISTRY}"
+        # parent images default to current :latest; overridden when the
+        # parent itself is rebuilt in this run
+        BASE_IMG="$$REG/base:latest"
+        MLBASE_IMG="$$REG/ml-base:latest"
+
+        want() { case ",${_IMAGES}," in *",$$1,"*) return 0;; *) return 1;; esac; }
+
+        build() {
+          local img="$$1"; shift
+          echo ""
+          echo "=========================================="
+          echo "🔨 Building $$img from PR source"
+          echo "=========================================="
+          docker build -f "Dockerfile.$$img" -t "$$img:pr-check" "$$@" .
+        }
+
+        smoke() {
+          local img="$$1"; shift
+          echo "🧪 Smoke: $$img"
+          docker run --rm "$$img:pr-check" "$$@"
+        }
+
+        # ---- canonical build order ----
+
+        if want base; then
+          build base
+          BASE_IMG="base:pr-check"
+          smoke base python -c "import spacy, nltk, sqlalchemy, requests; print('base OK')"
+        fi
+
+        if want ml-base; then
+          build ml-base --build-arg "BASE_IMAGE=$$BASE_IMG"
+          MLBASE_IMG="ml-base:pr-check"
+          smoke ml-base python -c "
+        import torch
+        assert '+cpu' in torch.__version__, f'CUDA torch crept back in: {torch.__version__}'
+        assert not torch.backends.cuda.is_built()
+        ckpt = torch.load('/app/models/productionmodel.pt', map_location='cpu', weights_only=False)
+        import transformers
+        print('ml-base OK:', torch.__version__, type(ckpt).__name__)
+        "
+        fi
+
+        if want ci-base; then
+          build ci-base --build-arg "BASE_IMAGE=$$BASE_IMG"
+          smoke ci-base bash -c "
+            python -m pytest --version && python -m ruff --version &&
+            python -m black --version && python -m mypy --version &&
+            python -c \"import torch; assert '+cpu' in torch.__version__; print('ci-base OK')\"
+          "
+        fi
+
+        if want processor; then
+          build processor --build-arg "ML_BASE_IMAGE=$$MLBASE_IMG"
+          smoke processor python -c "from src.ml.article_classifier import ArticleClassifier; print('processor OK')"
+        fi
+
+        if want crawler; then
+          build crawler --build-arg "BASE_IMAGE=$$BASE_IMG"
+          smoke crawler bash -c "python -c 'import selenium, undetected_chromedriver' && (chromium --version || google-chrome --version) && echo 'crawler OK'"
+        fi
+
+        if want api; then
+          build api --build-arg "BASE_IMAGE=$$BASE_IMG"
+          smoke api python -c "import fastapi, uvicorn; print('api OK')"
+        fi
+
+        if want migrator; then
+          build migrator
+          smoke migrator python -c "import alembic; print('migrator OK')"
+        fi
+
+        echo ""
+        echo "✅ All affected images (${_IMAGES}) build and pass smoke."
+
+timeout: 2700s
+options:
+  machineType: 'N1_HIGHCPU_8'
+  diskSizeGb: 100
+  logging: CLOUD_LOGGING_ONLY
+  substitutionOption: 'ALLOW_LOOSE'


### PR DESCRIPTION
Closes the gap discussed today: **PR CI never builds Dockerfiles** — jobs run inside prebuilt images, so image changes first executed in the post-merge production build. (#353's CPU-torch change was only pre-validated by a manual Cloud Build smoke.)

## How it works
- The `changes` job now also emits `images`: changed `Dockerfile.*`/`requirements*` files mapped to affected images.
- A conditional `image-build-check` job (skipped on non-image PRs — zero cost to the common case) submits the **PR source** to Cloud Build: each affected image builds with a throwaway local tag (**nothing pushed** — no `images:` section) and is smoke-tested inside the fresh build.
- **Dependency-aware:** canonical order `base → ml-base → rest`; a parent built in the same run becomes the child's `--build-arg` base, so a PR touching base+processor tests processor *on the new base*.
- Smokes: ml-base asserts `+cpu` torch **and loads the real productionmodel.pt**; ci-base checks the pinned lint/type toolchain; crawler checks selenium+Chrome; base/api/processor/migrator import checks.

## Validation
This PR touches no Dockerfile, so the job **skips on its own CI** (`images=` empty — which itself validates the gate). After merge: throwaway comment-only Dockerfile PR to watch it fire end-to-end, then closed unmerged.

Cost: only on image PRs; ~4–15 min Cloud Build (≈$0.10–0.25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)