### PR TITLE
fix(ci): image-build-check staging bucket + entrypoint-safe smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
             --config gcp/cloudbuild/cloudbuild-pr-image-check.yaml \
             --substitutions "_IMAGES=${{ needs.changes.outputs.images }}" \
             --project mizzou-news-crawler \
+            --gcs-source-staging-dir gs://mizzou-news-crawler-pr-staging/source \
             .
 
   lint:

--- a/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
+++ b/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
@@ -60,9 +60,13 @@ steps:
         }
 
         smoke() {
+          # --entrypoint override: some images (migrator) have entrypoints
+          # that validate runtime env vars before executing anything — the
+          # smoke must run the probe command directly.
           local img="$$1"; shift
+          local ep="$$1"; shift
           echo "🧪 Smoke: $$img"
-          docker run --rm "$$img:pr-check" "$$@"
+          docker run --rm --entrypoint "$$ep" "$$img:pr-check" "$$@"
         }
 
         # ---- canonical build order ----


### PR DESCRIPTION
The two fixes proven by live-fire test #355 (which goes green with these): dedicated PR staging bucket (default _cloudbuild bucket rejects the github-actions SA — legacy robot ACLs) and --entrypoint override so env-gated entrypoints (migrator) don't swallow smoke probes. Live-fire: skip on #354 ✓, fire+build+smoke on #355 in 3m05s ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)