### PR TITLE
fix(db): articles.url unique constraint + statement_timeout hardening

### DIFF
--- a/alembic/versions/c4e8a1f52b7d_add_unique_index_articles_url.py
+++ b/alembic/versions/c4e8a1f52b7d_add_unique_index_articles_url.py
@@ -1,0 +1,60 @@
+"""Add unique constraint on articles.url
+
+Production had NO uniqueness on articles.url — a 2025-11-20 commit claimed to
+add it but never reached prod (schema drift). Real duplicate extractions
+accumulated (377 URL groups, 380 excess rows) until the smoke test's first
+actual run caught it on 2026-07-18. Production was deduped and the constraint
+created there manually on 2026-07-19 (CREATE UNIQUE INDEX CONCURRENTLY, then
+ALTER TABLE ... ADD CONSTRAINT ... USING INDEX so it registers in
+information_schema.table_constraints). This migration codifies it for
+dev/test databases.
+
+The extraction insert path already uses ON CONFLICT DO NOTHING, written in
+anticipation of exactly this constraint.
+
+Revision ID: c4e8a1f52b7d
+Revises: b2d9f4c7e1a3
+Create Date: 2026-07-19
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c4e8a1f52b7d"
+down_revision = "b2d9f4c7e1a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # Idempotent: production already carries the constraint (created
+        # out-of-band via CONCURRENTLY + USING INDEX to avoid table locks).
+        op.execute(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'uq_articles_url'
+                ) THEN
+                    ALTER TABLE articles
+                        ADD CONSTRAINT uq_articles_url UNIQUE (url);
+                END IF;
+            END $$;
+            """
+        )
+    else:
+        # SQLite (unit-test databases): a unique index is the equivalent.
+        op.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_articles_url ON articles (url)"
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE articles DROP CONSTRAINT IF EXISTS uq_articles_url")
+    else:
+        op.execute("DROP INDEX IF EXISTS uq_articles_url")


### PR DESCRIPTION
Repo half of this morning's production DB hardening (tasks 1+2 of the plan). All production changes already applied and verified live.

## 1. `articles.url` uniqueness (production surgery ✅ done)
Prod had **no uniqueness** on `articles.url` — the 2025-11-20 commit claiming to add it never reached prod (the ORM has declared `unique=True` all along; classic schema drift). The smoke test's first real run caught **377 duplicate groups / 380 excess rows**.

Surgery (no jobs running; **pre-surgery backup taken — automated backups were found DISABLED and are now enabled + PITR**):
- Deduped 380 rows: keeper = labeled-then-oldest; **140 orphan entities repointed to keepers**; 355 labels + 6,642 entities deleted as parallel copies; `ml_results`/`locations` unaffected (dry-run verified first)
- `CREATE UNIQUE INDEX CONCURRENTLY` → `ALTER TABLE ADD CONSTRAINT ... USING INDEX` (registers in `information_schema.table_constraints`, where the smoke test looks)
- **Both smoke-test checks now pass in prod**; insert path already used `ON CONFLICT DO NOTHING`

**This PR**: migration `c4e8a1f52b7d` codifying the constraint for dev/test DBs (dialect-aware, idempotent — prod already carries it).

## 2. `statement_timeout` (production ✅ done)
Was `0` — any query could hang pipeline pods forever. Now `ALTER ROLE mizzou_user SET statement_timeout='120s'` (verified in a fresh session). Migrations share that role and legitimately run long, so **this PR** adds an `env.py` session-level `SET statement_timeout=0` (postgres-guarded; verified `alembic upgrade head` still green on scratch SQLite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)