### PR TITLE
chore(deps): complete task-5 — dependabot.yml + evict black + sync floors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,113 @@
+# Dependabot configuration.
+#
+# Before this file, Dependabot only saw the root requirements.txt (+ the
+# resubmitted graph), so ~15 production packages that live ONLY in the
+# per-image requirements files (tls-client, mediacloud, warcio, fastapi,
+# uvicorn, google-cloud-*, etc.) had NO vulnerability scanning. Registering
+# every manifest below closes that gap while keeping the per-image files as
+# the single source of truth — no root "union" to maintain.
+#
+# Updates are grouped per ecosystem to keep PR volume sane; security updates
+# still open individually and promptly.
+version: 2
+updates:
+  # --- Python: all pip manifests (root per-image files + services + GCP fns)
+  - package-ecosystem: pip
+    directory: "/"            # requirements.txt + requirements-*.txt (base/api/crawler/processor/ml/migrator/dev)
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      python-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: "/backend"
+    schedule:
+      interval: weekly
+    groups:
+      backend-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: "/gcp/functions/daily-report"
+    schedule:
+      interval: weekly
+    groups:
+      daily-report-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: "/gcp/functions/weekly-health-check"
+    schedule:
+      interval: weekly
+    groups:
+      weekly-health-check-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: "/gcp_functions/daily_sheet_export"
+    schedule:
+      interval: weekly
+    groups:
+      daily-sheet-export-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: "/gcp_functions/weekly_source_health_check"
+    schedule:
+      interval: weekly
+    groups:
+      source-health-check-deps:
+        patterns: ["*"]
+
+  # --- Go: root module + vendored utls copies (source of the x/crypto alerts)
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: "/utls"
+    schedule:
+      interval: weekly
+    groups:
+      utls-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: "/third_party/utls"
+    schedule:
+      interval: weekly
+    groups:
+      third-party-utls-deps:
+        patterns: ["*"]
+
+  # --- JavaScript: root + frontend (legacy frontend intentionally omitted)
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      npm-root-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: "/web/frontend"
+    schedule:
+      interval: weekly
+    groups:
+      frontend-deps:
+        patterns: ["*"]
+
+  # --- GitHub Actions: keep action versions current (Node20->24 churn, etc.)
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-deps:
+        patterns: ["*"]

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -28,7 +28,7 @@ cloudscraper>=1.2.71  # Needed by tests
 
 # NLP and text processing
 spacy>=3.8.0  # Python 3.11+ supports latest spacy with numpy 2.x
-nltk>=3.8
+nltk>=3.9.4
 textblob>=0.17.0
 ftfy>=6.1.0
 python-dateutil>=2.8.0
@@ -44,7 +44,6 @@ httpx  # Needed for FastAPI TestClient
 
 # Development
 pre-commit>=3.3.0
-black>=23.0.0
 isort>=5.12.0
 flake8>=6.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,12 +39,12 @@ cloudscraper>=1.2.71  # Bypass Cloudflare protection
 
 # Content extraction & processing (mcmetadata dependencies)
 readability-lxml>=0.8.1  # Article content extraction
-trafilatura>=1.6.0  # Web content extraction
+trafilatura>=1.6.3  # Web content extraction
 boilerpy3>=1.0.6  # Boilerplate removal (1.0.7 is the latest release; >=1.0.8 broke installs)
-goose3>=3.1.9  # Content extraction
-htmldate>=1.4.0  # HTML date extraction
-py3langid>=0.2.2  # Language detection
-dateparser>=1.1.0  # Flexible date parsing
+goose3>=3.1.12  # Content extraction
+htmldate>=1.5.0  # HTML date extraction
+py3langid>=0.3.0  # Language detection
+dateparser>=1.2.0  # Flexible date parsing
 url-normalize>=1.4.3  # URL normalization
 furl>=2.1.3  # URL manipulation
 requests-mock


### PR DESCRIPTION
#362 accidentally merged **only the two file deletions** — the `git add` of the content files had aborted on the already-`git rm`'d `Dockerfile.unified` pathspec, so `dependabot.yml` and the requirements edits were never staged. This commits the intended content:

- **`.github/dependabot.yml`** (12 manifest entries) — the actual dependency-scanning-gap fix
- **evict `black` from `requirements-base.txt`** — was shipping in every prod image
- **sync 7 drifted floors** (root ↔ per-image)

On merge this also correctly triggers the base rebuild #362 was meant to: detect-changes sees `requirements-base.txt` → cascades base → ml-base → dependents, finally evicting black from the running images.

(Note: there was no CD bug — the earlier "detect-changes missed the change" was a misread; the commit genuinely only had 2 files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)