### PR TITLE
fix(ml): restore article classifier under transformers v5 (top_k=None)

### DIFF
--- a/src/ml/article_classifier.py
+++ b/src/ml/article_classifier.py
@@ -115,7 +115,7 @@ class ArticleClassifier:
                         "text-classification",
                         model=model,
                         tokenizer=tokenizer,
-                        return_all_scores=True,
+                        top_k=None,  # return all label scores per text (List[List[dict]]); transformers v5 removed return_all_scores
                         device=self.device,
                     )
                     self.model_identifier = candidate
@@ -183,8 +183,11 @@ class ArticleClassifier:
 
         predictions: list[list[Prediction]] = []
         for output in raw_outputs:
+            # top_k=None yields List[dict] per text; guard against a bare dict
+            # (top_k=1 shape) so a pipeline-default change can't crash the batch.
+            scores = output if isinstance(output, list) else [output]
             sorted_scores = sorted(
-                output,
+                scores,
                 key=lambda item: item.get("score", 0),
                 reverse=True,
             )
@@ -301,7 +304,7 @@ def _load_pt_classifier(
         "text-classification",
         model=model,
         tokenizer=tokenizer,
-        return_all_scores=True,
+        top_k=None,  # return all label scores per text (List[List[dict]]); transformers v5 removed return_all_scores
         device=device,
     )
 

--- a/tests/ml/test_article_classifier_core.py
+++ b/tests/ml/test_article_classifier_core.py
@@ -88,10 +88,11 @@ def test_article_classifier_falls_back_to_pretrained_dir(
             captured["model_name"] = name
             return DummyModel()
 
-    def fake_pipeline(task, *, model, tokenizer, return_all_scores, device):
+    def fake_pipeline(task, *, model, tokenizer, top_k, device):
         captured["pipeline_device"] = device
         assert task == "text-classification"
-        assert return_all_scores is True
+        # transformers v5 removed return_all_scores; top_k=None returns all labels
+        assert top_k is None
         assert model is not None
         assert tokenizer is not None
 
@@ -122,6 +123,36 @@ def test_article_classifier_falls_back_to_pretrained_dir(
     preds = classifier.predict_batch(["a", "b"], top_k=1)
     assert len(preds) == 2
     assert preds[0][0].label == "label"
+
+
+def test_predict_batch_handles_single_dict_output(tmp_path, monkeypatch):
+    """Regression: transformers v5 removed ``return_all_scores``.
+
+    When a pipeline yields one bare dict per text (the ``top_k=1`` shape)
+    instead of ``List[List[dict]]``, ``predict_batch`` must not crash with
+    ``'str' object has no attribute 'get'`` (iterating a dict yields its
+    string keys). This reproduced the production classifier outage where
+    every batch logged ``labeled=0 errors=N``.
+    """
+
+    def fake_load_pt(_path, _device):
+        def runner(texts, truncation=True):
+            # top_k=1 / legacy default: one dict per text, NOT wrapped in a list
+            return [_make_prediction_dict("politics", 0.9) for _ in texts]
+
+        return runner, "id", "ver"
+
+    monkeypatch.setattr(article_classifier, "_load_pt_classifier", fake_load_pt)
+
+    checkpoint = tmp_path / "checkpoint.pt"
+    checkpoint.write_text("data")
+    classifier = article_classifier.ArticleClassifier(checkpoint)
+
+    preds = classifier.predict_batch(["a", "b"], top_k=2)
+
+    assert len(preds) == 2
+    assert preds[0][0].label == "politics"
+    assert preds[0][0].score == pytest.approx(0.9)
 
 
 def test_predict_batch_validates_input(tmp_path, monkeypatch):
@@ -203,10 +234,11 @@ def test_load_pt_classifier_normalizes_state_dict(tmp_path, monkeypatch):
 
     pipeline_calls: dict[str, object] = {}
 
-    def fake_pipeline(task, *, model, tokenizer, return_all_scores, device):
+    def fake_pipeline(task, *, model, tokenizer, top_k, device):
         pipeline_calls["task"] = task
         pipeline_calls["tokenizer"] = tokenizer
         pipeline_calls["device"] = device
+        assert top_k is None
 
         def runner(texts, truncation=True):
             return [[_make_prediction_dict("label", 0.8)]] * len(texts)


### PR DESCRIPTION
## Problem

Article classification has been failing on **every batch** in the production processor (`labeled=0, errors=N` each cycle) since the `transformers>=5.5.0` floor bump deployed. The running image has **transformers 5.14.1**.

```
File "/app/src/ml/article_classifier.py", line 188, in <lambda>
    key=lambda item: item.get("score", 0),
AttributeError: 'str' object has no attribute 'get'
```

**Root cause:** transformers v5 **removed the `return_all_scores` pipeline argument**. Both text-classification pipelines still passed `return_all_scores=True`, so it was silently ignored, the pipeline defaulted to `top_k=1`, and returned one bare `dict` per text instead of `List[List[dict]]`. `predict_batch` then iterated a dict — which yields its string keys — and raised on every item.

## Fix

- Both `pipeline(...)` calls: `return_all_scores=True` → `top_k=None` (the v5-correct way to request all label scores per text).
- Hardened `predict_batch` to wrap a bare-dict output in a list, so a future pipeline-default change can't crash the whole batch again.

## Tests

- The two mock `fake_pipeline` signatures asserted `return_all_scores is True` — which is **why the tests stayed green through a real prod outage**. They now take `top_k` and assert `None`.
- Added `test_predict_batch_handles_single_dict_output`, reproducing the exact v5 `top_k=1` return shape and asserting no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)