### PR TITLE
ci: skip GCP-triggers validation on Dependabot PRs

### DIFF
--- a/.github/workflows/validate-gcp-triggers.yml
+++ b/.github/workflows/validate-gcp-triggers.yml
@@ -15,7 +15,15 @@ jobs:
   validate-triggers:
     name: Validate GCP Cloud Build Triggers
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    # Validates that prod GCP Cloud Build triggers EXIST — unrelated to the code
+    # under review, and requires prod GCP access via GCP_SA_KEY. Dependabot runs
+    # in an isolated secrets context without that secret, so this job can never
+    # authenticate there; skip it for Dependabot (the dependency change itself is
+    # still built + smoke-tested by the Image Build Check job, which authenticates
+    # via the Dependabot secret store).
+    if: >-
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
+      && github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

All 9 open Dependabot PRs (#364–#372) fail the **Validate GCP Cloud Build Triggers** check identically, in 6–10s:

```
google-github-actions/auth failed: must specify exactly one of
"workload_identity_provider" or "credentials_json"!
By default, secrets are not passed to workflows triggered from forks, including Dependabot.
```

Dependabot runs in an isolated secrets context that does not receive `GCP_SA_KEY`, so this job can never authenticate on a Dependabot PR — it blocks the whole batch regardless of what was bumped.

## What this changes

Skip **only** the triggers-existence job for Dependabot (`github.actor != 'dependabot[bot]'`). It validates that prod Cloud Build triggers *exist* — nothing about the code under review — and a skipped job satisfies required-check gates.

## What this deliberately does NOT change

**Image Build Check keeps running on Dependabot PRs.** A dependency change is exactly what needs image build + smoke testing. It currently fails for the same missing-secret reason; the fix for that is operational, not code:

```
gh secret set GCP_SA_KEY --app dependabot --repo LocalNewsImpact/MizzouNewsCrawler < sa-key.json
```

(Dependabot has its own secret store; the same `${{ secrets.GCP_SA_KEY }}` reference resolves once set there.) With branch protection requiring review/approval on every merge, nothing Dependabot builds can reach production on its own — and the PR image-check pushes no images (throwaway `pr-check` tags only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)