### PR TITLE
fix(cleaning): key boilerplate patterns by source UUID, not URL/domain

### DIFF
--- a/scripts/backfill_boilerplate_source_id.py
+++ b/scripts/backfill_boilerplate_source_id.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Backfill persistent_boilerplate_patterns.source_id from the URL/domain key.
+
+Boilerplate patterns were historically keyed by the URL-derived ``domain``
+string, which is inconsistent (``www.``-prefixed for most rows, bare for
+others) and not 1:1 with a source. As a result, learned patterns frequently
+never matched at clean time (stored under one domain form, looked up under
+another) and two sources sharing a domain collided into one bucket.
+
+This one-off backfill:
+  1. Adds the ``source_id`` column to the prod table if missing (Postgres
+     ``ADD COLUMN IF NOT EXISTS`` — idempotent, safe to re-run).
+  2. Populates ``source_id`` from ``candidate_links``, mapping each pattern's
+     stored ``domain`` to a source hostname while tolerating the www/bare
+     mismatch. Only domains that map to EXACTLY ONE source are backfilled;
+     ambiguous domains (a handful map to 2 sources) are left NULL so they keep
+     falling back to domain-keyed lookup rather than being mis-assigned.
+
+Usage:
+  python scripts/backfill_boilerplate_source_id.py --dry-run
+  python scripts/backfill_boilerplate_source_id.py
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from sqlalchemy import text
+
+from src.models.database import DatabaseManager
+
+ADD_COLUMN_SQL = text(
+    "ALTER TABLE persistent_boilerplate_patterns "
+    "ADD COLUMN IF NOT EXISTS source_id TEXT"
+)
+
+CREATE_INDEX_SQL = text(
+    "CREATE INDEX IF NOT EXISTS idx_persistent_patterns_source "
+    "ON persistent_boilerplate_patterns(source_id, is_active)"
+)
+
+# Map each pattern.domain to a source_id via the hostnames seen in that
+# source's candidate_links, matching www/bare variants both directions.
+# Only unambiguous hosts (exactly one source) are used.
+BACKFILL_SQL = text("""
+WITH host_src AS (
+    SELECT DISTINCT
+        lower(split_part(regexp_replace(url, '^https?://', ''), '/', 1)) AS host,
+        source_id
+    FROM candidate_links
+    WHERE source_id IS NOT NULL
+),
+host_unique AS (
+    SELECT host, MIN(source_id::text) AS src
+    FROM host_src
+    GROUP BY host
+    HAVING COUNT(DISTINCT source_id) = 1
+)
+UPDATE persistent_boilerplate_patterns p
+SET source_id = h.src
+FROM host_unique h
+WHERE p.source_id IS NULL
+  AND (
+        lower(p.domain) = h.host
+     OR 'www.' || lower(p.domain) = h.host
+     OR lower(p.domain) = 'www.' || h.host
+  )
+""")
+
+
+def _scalar(conn, sql: str) -> int:
+    return conn.execute(text(sql)).scalar() or 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing (skips ALTER + UPDATE).",
+    )
+    args = parser.parse_args()
+
+    engine = DatabaseManager().engine
+    with engine.begin() as conn:
+        total = _scalar(conn, "SELECT COUNT(*) FROM persistent_boilerplate_patterns")
+        before_null = _scalar(
+            conn,
+            "SELECT COUNT(*) FROM persistent_boilerplate_patterns "
+            "WHERE source_id IS NULL",
+        )
+        print(f"patterns total={total}  source_id NULL (before)={before_null}")
+
+        if args.dry_run:
+            # Count how many NULL rows WOULD map to a unique source.
+            would = conn.execute(text("""
+                WITH host_src AS (
+                    SELECT DISTINCT
+                        lower(split_part(regexp_replace(url,'^https?://',''),'/',1)) AS host,
+                        source_id
+                    FROM candidate_links WHERE source_id IS NOT NULL
+                ),
+                host_unique AS (
+                    SELECT host, MIN(source_id::text) AS src FROM host_src
+                    GROUP BY host HAVING COUNT(DISTINCT source_id) = 1
+                )
+                SELECT COUNT(*) FROM persistent_boilerplate_patterns p
+                JOIN host_unique h ON (
+                    lower(p.domain) = h.host
+                    OR 'www.' || lower(p.domain) = h.host
+                    OR lower(p.domain) = 'www.' || h.host
+                )
+                WHERE p.source_id IS NULL
+            """)).scalar() or 0
+            print(
+                f"DRY RUN: would backfill {would} rows; "
+                f"{before_null - would} would remain NULL (ambiguous/unmatched)"
+            )
+            return 0
+
+        conn.execute(ADD_COLUMN_SQL)
+        conn.execute(CREATE_INDEX_SQL)
+        result = conn.execute(BACKFILL_SQL)
+        updated = result.rowcount
+
+        after_null = _scalar(
+            conn,
+            "SELECT COUNT(*) FROM persistent_boilerplate_patterns "
+            "WHERE source_id IS NULL",
+        )
+        print(
+            f"backfilled source_id on {updated} rows; "
+            f"source_id NULL (after)={after_null}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/content_cleaner_balanced.py
+++ b/src/utils/content_cleaner_balanced.py
@@ -1047,13 +1047,21 @@ class BalancedBoundaryContentCleaner:
         }
 
     def _remove_persistent_patterns(
-        self, text: str, domain: str, article_id: str | None = None
+        self,
+        text: str,
+        domain: str,
+        article_id: str | None = None,
+        source_id: str | None = None,
     ) -> dict:
-        """Check text against persistent patterns for quick removal."""
+        """Check text against persistent patterns for quick removal.
+
+        Patterns are keyed by the stable source UUID; ``domain`` is passed only
+        as a fallback for legacy rows not yet stamped with a source_id.
+        """
         if not self.enable_telemetry:
             return {"cleaned_text": text, "removals": [], "wire_detected": None}
 
-        patterns = self.telemetry.get_persistent_patterns(domain)
+        patterns = self.telemetry.get_persistent_patterns(domain, source_id=source_id)
         if not patterns:
             return {"cleaned_text": text, "removals": [], "wire_detected": None}
 
@@ -1311,9 +1319,16 @@ class BalancedBoundaryContentCleaner:
         dry_run: bool = False,
     ) -> tuple[str, dict]:
         """Process a single article to remove boilerplate."""
+        # Resolve the stable source UUID so patterns are keyed by source, not
+        # by the drifting domain string (www/protocol/subdomain vary; a domain
+        # is not 1:1 with a source).
+        source_id = self._get_source_id_for_article(article_id) if article_id else None
+
         # Start telemetry session
         if self.enable_telemetry:
-            self.telemetry.start_cleaning_session(domain, article_count=1)
+            self.telemetry.start_cleaning_session(
+                domain, article_count=1, source_id=source_id
+            )
 
         original_text = text
 
@@ -1329,7 +1344,7 @@ class BalancedBoundaryContentCleaner:
 
         # Check persistent patterns for quick matching
         removed_by_persistent = self._remove_persistent_patterns(
-            text, domain, article_id
+            text, domain, article_id, source_id=source_id
         )
 
         removal_details: list[dict[str, Any]] = []
@@ -1946,6 +1961,34 @@ class BalancedBoundaryContentCleaner:
                     "detection_method": "regex_pattern",
                 }
 
+        return None
+
+    def _get_source_id_for_article(self, article_id: str) -> str | None:
+        """Resolve the stable source UUID an article belongs to.
+
+        Patterns are keyed by this UUID rather than the URL/domain string.
+        Returns None if the article isn't linked to a source (so the reader
+        falls back to legacy domain-keyed patterns).
+        """
+        try:
+            with self._session_scope() as (session, _should_commit):
+                result = safe_session_execute(
+                    session,
+                    sql_text("""
+                    SELECT cl.source_id
+                    FROM articles a
+                    JOIN candidate_links cl ON a.candidate_link_id = cl.id
+                    WHERE a.id = :article_id
+                    """),
+                    {"article_id": article_id},
+                )
+                row = result.fetchone()
+                if row and row[0]:
+                    return str(row[0])
+        except Exception as exc:  # noqa: BLE001 - resolver must never break cleaning
+            self.logger.debug(
+                "Could not resolve source_id for article %s: %s", article_id, exc
+            )
         return None
 
     def _get_article_source_context(

--- a/src/utils/content_cleaning_telemetry.py
+++ b/src/utils/content_cleaning_telemetry.py
@@ -68,9 +68,15 @@ class ContentCleaningTelemetry:
         article_count: int,
         min_occurrences: int = 3,
         min_boundary_score: float = 0.3,
+        source_id: str | None = None,
     ) -> str:
         """
         Start a new content cleaning session.
+
+        Args:
+            source_id: Stable source UUID this cleaning run belongs to. Patterns
+                are keyed by it (not the drifting domain string) so learning and
+                lookup align across www/protocol/subdomain variants.
 
         Returns:
             telemetry_id: Unique identifier for this cleaning session
@@ -84,6 +90,7 @@ class ContentCleaningTelemetry:
             "telemetry_id": telemetry_id,
             "session_id": self.session_id,
             "domain": domain,
+            "source_id": source_id,
             "article_count": article_count,
             "min_occurrences": min_occurrences,
             "min_boundary_score": min_boundary_score,
@@ -337,6 +344,7 @@ class ContentCleaningTelemetry:
         domain = session.get("domain")
         if not domain:
             return
+        source_id = session.get("source_id")
 
         self._ensure_persistent_patterns_table(conn)
 
@@ -355,18 +363,23 @@ class ContentCleaningTelemetry:
                 is_ml_eligible = segment.get("pattern_type") in persistent_pattern_types
                 text_hash = segment.get("segment_text_hash")
 
+                # Match a source-keyed row when we know the source, else the
+                # legacy domain-keyed row (transition: rows predate source_id).
                 cursor.execute(
                     """
                     SELECT id, occurrences_total, last_seen
                     FROM persistent_boilerplate_patterns
-                    WHERE domain = ? AND text_hash = ?
+                    WHERE text_hash = ?
+                      AND (source_id = ? OR (source_id IS NULL AND domain = ?))
                     """,
-                    (domain, text_hash),
+                    (text_hash, source_id, domain),
                 )
 
                 existing = cursor.fetchone()
 
                 if existing:
+                    # Stamp source_id onto a legacy (domain-only) row as it is
+                    # re-seen, so it becomes source-keyed without a backfill.
                     cursor.execute(
                         """
                         UPDATE persistent_boilerplate_patterns
@@ -374,6 +387,7 @@ class ContentCleaningTelemetry:
                             last_seen = ?,
                             confidence_score = MAX(confidence_score, ?),
                             is_ml_training_eligible = ?,
+                            source_id = COALESCE(source_id, ?),
                             updated_at = CURRENT_TIMESTAMP
                         WHERE id = ?
                         """,
@@ -382,6 +396,7 @@ class ContentCleaningTelemetry:
                             datetime.now(),
                             segment.get("boundary_score"),
                             is_ml_eligible,
+                            source_id,
                             existing[0],
                         ),
                     )
@@ -389,16 +404,17 @@ class ContentCleaningTelemetry:
                     cursor.execute(
                         """
                         INSERT INTO persistent_boilerplate_patterns (
-                            id, domain, pattern_type, text_content,
+                            id, domain, source_id, pattern_type, text_content,
                             text_hash, confidence_score,
                             occurrences_total, first_seen,
                             last_seen, removal_reason, is_active,
                             is_ml_training_eligible
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             str(uuid.uuid4()),
                             domain,
+                            source_id,
                             segment.get("pattern_type"),
                             segment.get("segment_text"),
                             text_hash,
@@ -425,6 +441,7 @@ class ContentCleaningTelemetry:
             CREATE TABLE IF NOT EXISTS persistent_boilerplate_patterns (
                 id TEXT PRIMARY KEY,
                 domain TEXT NOT NULL,
+                source_id TEXT,
                 pattern_type TEXT NOT NULL,
                 text_content TEXT NOT NULL,
                 text_hash TEXT NOT NULL,
@@ -447,6 +464,11 @@ class ContentCleaningTelemetry:
         """)
 
             cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_persistent_patterns_source
+            ON persistent_boilerplate_patterns(source_id, is_active)
+        """)
+
+            cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_persistent_patterns_hash
             ON persistent_boilerplate_patterns(domain, text_hash)
         """)
@@ -463,8 +485,16 @@ class ContentCleaningTelemetry:
         finally:
             cursor.close()
 
-    def get_persistent_patterns(self, domain: str) -> list[dict]:
-        """Get persistent boilerplate patterns for a domain."""
+    def get_persistent_patterns(
+        self, domain: str, source_id: str | None = None
+    ) -> list[dict]:
+        """Get persistent boilerplate patterns for a source (preferred) or domain.
+
+        Keys on the stable source UUID when provided; also returns legacy
+        domain-keyed rows not yet stamped with a source_id, so lookups keep
+        working during the transition. Passing only a domain preserves the old
+        behavior.
+        """
         try:
             store = self.store
         except RuntimeError:
@@ -482,10 +512,12 @@ class ContentCleaningTelemetry:
                                occurrences_total, removal_reason,
                                is_ml_training_eligible
                         FROM persistent_boilerplate_patterns
-                        WHERE domain = ? AND is_active IS TRUE
+                        WHERE is_active IS TRUE
+                          AND (source_id = ?
+                               OR (source_id IS NULL AND domain = ?))
                         ORDER BY confidence_score DESC, occurrences_total DESC
                         """,
-                        (domain,),
+                        (source_id, domain),
                     )
 
                     patterns = []

--- a/tests/cli/commands/test_extraction_content_validation.py
+++ b/tests/cli/commands/test_extraction_content_validation.py
@@ -1009,8 +1009,11 @@ class TestContentValidationWithPersistentPatterns:
         # Verify remaining content is less than MIN_CONTENT_LENGTH (150)
         assert len(stripped_content.strip()) < 150
 
-        # Verify pattern lookup was called
-        mock_telemetry.get_persistent_patterns.assert_called_with("testboilerplate.com")
+        # Verify pattern lookup was called (no article_id -> source_id is None,
+        # so the reader falls back to domain-keyed patterns)
+        mock_telemetry.get_persistent_patterns.assert_called_with(
+            "testboilerplate.com", source_id=None
+        )
 
 
 @pytest.mark.postgres

--- a/tests/test_subscription_module_cleaning.py
+++ b/tests/test_subscription_module_cleaning.py
@@ -44,7 +44,7 @@ def test_subscription_snippet_marked_high_confidence():
 def test_subscription_persistent_pattern_is_removed():
     cleaner = _build_cleaner_with_stubbed_telemetry()
 
-    cleaner.telemetry.get_persistent_patterns = lambda domain: [
+    cleaner.telemetry.get_persistent_patterns = lambda domain, source_id=None: [
         {
             "pattern_type": "subscription",
             "text_content": SUBSCRIPTION_SNIPPET,

--- a/tests/utils/test_content_cleaner_balanced.py
+++ b/tests/utils/test_content_cleaner_balanced.py
@@ -46,7 +46,10 @@ class _StubTelemetry:
         self.log_summary["sessions"].append((domain, kwargs))
         return "session"
 
-    def get_persistent_patterns(self, domain):
+    def get_persistent_patterns(self, domain, source_id=None):
+        self.log_summary.setdefault("pattern_lookups", []).append(
+            {"domain": domain, "source_id": source_id}
+        )
         return self._patterns
 
     def log_wire_detection(self, **kwargs):
@@ -96,6 +99,32 @@ def test_process_single_article_removes_persistent_patterns():
     logged_segment = telemetry_stub.log_summary["segments"][0]
     assert logged_segment["segment_text"] == pattern_text
     assert logged_segment["was_removed"] is True
+
+
+def test_process_single_article_keys_patterns_by_source_uuid():
+    """The resolved source UUID (not the domain) is what's passed to the
+    pattern reader, so lookups align across www/protocol/subdomain drift."""
+    cleaner = BalancedBoundaryContentCleaner(db_path=":memory:")
+    telemetry_stub = _StubTelemetry(patterns=[])
+    cleaner.telemetry = telemetry_stub  # type: ignore[assignment]
+    # Article is linked to a stable source UUID; the URL host happens to be the
+    # bare form while patterns may have been learned under the www form.
+    cleaner._get_source_id_for_article = (  # type: ignore[assignment]
+        lambda article_id: "SRC-ABC"
+    )
+
+    cleaner.process_single_article(
+        "Some article body text.",
+        domain="example.com",
+        article_id="article-1",
+    )
+
+    lookups = telemetry_stub.log_summary.get("pattern_lookups", [])
+    assert lookups, "reader was never queried"
+    assert lookups[0]["source_id"] == "SRC-ABC"
+    # The session should also carry the source_id for the writer path.
+    session_domain, session_kwargs = telemetry_stub.log_summary["sessions"][0]
+    assert session_kwargs.get("source_id") == "SRC-ABC"
 
 
 def test_assess_locality_detects_city_and_county_signals():

--- a/tests/utils/test_content_cleaner_balanced_comprehensive.py
+++ b/tests/utils/test_content_cleaner_balanced_comprehensive.py
@@ -29,7 +29,7 @@ class _StubTelemetry:
         self.log_summary["sessions"].append((domain, kwargs))
         return "session"
 
-    def get_persistent_patterns(self, domain):
+    def get_persistent_patterns(self, domain, source_id=None):
         return self._patterns
 
     def log_wire_detection(self, **kwargs):

--- a/tests/utils/test_content_cleaning_telemetry.py
+++ b/tests/utils/test_content_cleaning_telemetry.py
@@ -788,3 +788,126 @@ class TestTelemetryPersistence:
 
         telemetry.flush()
         telemetry.shutdown(wait=True)
+
+
+class TestPersistentPatternsSourceIdKeying:
+    """Patterns are keyed by the stable source UUID, not the URL/domain string.
+
+    Regression coverage for the bug where patterns learned under one domain
+    form (e.g. ``www.example.com``) were never found at clean time because the
+    lookup used a different form (``example.com``), and where two sources
+    sharing a domain collided into one bucket.
+    """
+
+    def _log_removed_nav(self, telemetry, text="Navigation footer boilerplate"):
+        telemetry.log_segment_detection(
+            segment_text=text,
+            boundary_score=0.8,
+            occurrences=3,
+            pattern_type="navigation",
+            position_consistency=0.9,
+            segment_length=len(text),
+            article_ids=["1", "2", "3"],
+            was_removed=True,
+            removal_reason="nav_footer",
+        )
+
+    def test_pattern_persisted_with_source_id(self, telemetry_store):
+        store, conn = telemetry_store
+        telemetry = ContentCleaningTelemetry(enable_telemetry=True, store=store)
+
+        telemetry.start_cleaning_session(
+            domain="www.example.com", article_count=3, source_id="SRC-1"
+        )
+        self._log_removed_nav(telemetry)
+        telemetry.finalize_cleaning_session(
+            rough_candidates_found=1,
+            segments_detected=1,
+            total_removable_chars=30,
+            removal_percentage=0.1,
+        )
+        store.flush()
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT source_id, domain FROM persistent_boilerplate_patterns")
+        source_id, domain = cursor.fetchone()
+        assert source_id == "SRC-1"
+        assert domain == "www.example.com"
+
+    def test_lookup_by_source_id_survives_domain_drift(self, telemetry_store):
+        """The core fix: a pattern learned under www.example.com is found when
+        the article's URL host is the bare example.com, because both resolve to
+        the same source UUID."""
+        store, conn = telemetry_store
+        telemetry = ContentCleaningTelemetry(enable_telemetry=True, store=store)
+
+        telemetry.start_cleaning_session(
+            domain="www.example.com", article_count=3, source_id="SRC-1"
+        )
+        self._log_removed_nav(telemetry)
+        telemetry.finalize_cleaning_session(
+            rough_candidates_found=1,
+            segments_detected=1,
+            total_removable_chars=30,
+            removal_percentage=0.1,
+        )
+        store.flush()
+
+        # Look up with a DIFFERENT domain string but the same source UUID.
+        patterns = telemetry.get_persistent_patterns(
+            domain="example.com", source_id="SRC-1"
+        )
+        assert len(patterns) == 1
+        assert patterns[0]["pattern_type"] == "navigation"
+
+        # Domain-only lookup under the bare form finds nothing (proves the old
+        # domain-string keying was the failure mode).
+        assert telemetry.get_persistent_patterns(domain="example.com") == []
+
+    def test_legacy_null_source_rows_found_via_domain_fallback(self, telemetry_store):
+        store, conn = telemetry_store
+        telemetry = ContentCleaningTelemetry(enable_telemetry=True, store=store)
+        telemetry._ensure_persistent_patterns_table(conn)
+        # A legacy row predating source_id (source_id NULL), keyed by domain.
+        conn.execute("""
+            INSERT INTO persistent_boilerplate_patterns (
+                id, domain, source_id, pattern_type, text_content,
+                text_hash, confidence_score, occurrences_total,
+                is_active, is_ml_training_eligible
+            ) VALUES ('leg-1', 'legacy.com', NULL, 'footer',
+                      'Legacy footer boilerplate text here', 'h1', 0.9, 5,
+                      1, 1)
+            """)
+        conn.commit()
+
+        # Found via the domain fallback even though a source_id is supplied.
+        patterns = telemetry.get_persistent_patterns(
+            domain="legacy.com", source_id="SRC-UNRELATED"
+        )
+        assert len(patterns) == 1
+        assert patterns[0]["pattern_type"] == "footer"
+
+    def test_source_keyed_row_not_returned_for_other_source_and_domain(
+        self, telemetry_store
+    ):
+        store, conn = telemetry_store
+        telemetry = ContentCleaningTelemetry(enable_telemetry=True, store=store)
+
+        telemetry.start_cleaning_session(
+            domain="www.example.com", article_count=3, source_id="SRC-1"
+        )
+        self._log_removed_nav(telemetry)
+        telemetry.finalize_cleaning_session(
+            rough_candidates_found=1,
+            segments_detected=1,
+            total_removable_chars=30,
+            removal_percentage=0.1,
+        )
+        store.flush()
+
+        # A different source on a different domain must not pick up SRC-1's
+        # pattern (no cross-source collision).
+        assert (
+            telemetry.get_persistent_patterns(domain="other.com", source_id="SRC-2")
+            == []
+        )


### PR DESCRIPTION
## Problem

`persistent_boilerplate_patterns` is keyed by the URL-derived `domain` string, which is:

- **Inconsistent** — stored `www.`-prefixed for most rows, bare for others. At clean time the lookup uses `urlparse(url).netloc`, so patterns stored under a different form never match. Verified in prod: **ccheadliner.com has 292 learned patterns that never apply** (stored bare, looked up as `www.ccheadliner.com`).
- **Not 1:1 with a source** — e.g. `columbiamissourian.com` maps to 2 sources; they collide into one boilerplate bucket.

Net effect: sources with thousands of collected samples (stlpr.org: 1,934 articles) show zero usable patterns, and `process_single_article` removes 0 chars of known boilerplate.

## Fix — key patterns by the stable source UUID (`candidate_links.source_id`)

- **Schema:** `source_id` column added to the `CREATE TABLE` (fresh/test DBs) + `(source_id, is_active)` index. Prod gets the column via the backfill's idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS` — matching how this table is actually managed in prod (raw runtime DDL; the alembic def has drifted and prod is unstamped).
- **Writer:** cleaning session carries `source_id`; `_update_persistent_patterns_in_db` stamps it on insert, matches source-keyed OR legacy rows, and `COALESCE`s `source_id` onto legacy rows as they're re-seen (self-healing without a mass rewrite).
- **Reader:** `get_persistent_patterns(domain, source_id=…)` matches on `source_id`, with a domain fallback for not-yet-stamped legacy rows.
- **Cleaner:** `process_single_article` resolves `article_id → source_id` (`_get_source_id_for_article`) and threads it through the reader and the session.
- **Backfill:** `scripts/backfill_boilerplate_source_id.py` (`--dry-run` supported) maps existing rows to their source where the domain↔source mapping is unambiguous (www/bare tolerant); ambiguous domains stay NULL and keep domain-fallback behavior.

Wire/source/byline detection is unchanged and still runs **before** body trimming, so source attribution and byline extraction keep their input.

## Tests

New `TestPersistentPatternsSourceIdKeying` (real in-memory store, write→read round-trips):
- pattern persisted with `source_id`
- **lookup survives www/bare domain drift** (the prod failure mode, reproduced then fixed)
- legacy NULL-source rows still found via domain fallback
- no cross-source collision

Plus `test_process_single_article_keys_patterns_by_source_uuid` (cleaner threads resolved UUID to reader + session), and updates to the four existing stubs/assertions that used the old `(domain)`-only signature.

## Deploy notes

After merge: run `python scripts/backfill_boilerplate_source_id.py --dry-run` then live against prod to add the column and stamp existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)