### PR TITLE
fix(ci): make the in-image contract gate actually fire

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -25,8 +25,13 @@ logs/
 !lookups/
 !lookups/**
 
-# Exclude test and development files
-tests/
+# Exclude test and development files — but the dependency contracts MUST
+# upload: cloudbuild-pr-image-check.yaml mounts tests/dependency_contracts
+# into each freshly built image and runs it there (the whole point of the
+# in-image gate). gitignore semantics: a fully excluded parent dir can't be
+# re-included, so exclude tests/* and negate the contracts subdir.
+tests/*
+!tests/dependency_contracts/
 artifacts/
 reports/
 docs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
               Dockerfile.ci-base|requirements-dev.txt) add ci-base ;;
               Dockerfile.processor|requirements-processor.txt) add processor ;;
               Dockerfile.crawler|requirements-crawler.txt) add crawler ;;
-              Dockerfile.api|requirements-api.txt) add api ;;
+              Dockerfile.api|requirements-api.txt|backend/*) add api ;;
               Dockerfile.migrator|requirements-migrator.txt) add migrator ;;
             esac
           done <<< "$changed"


### PR DESCRIPTION
Two gaps found while validating the new dependency-contract gate on the live Dependabot batch:

1. **`.gcloudignore` excluded `tests/`** from the Cloud Build source upload, so the `contracts()` mount in `cloudbuild-pr-image-check.yaml` pointed at nothing — pytest exited 5 (`no tests ran in 0.00s`), failing #372's otherwise-successful cascade run. Fix: `tests/*` + `!tests/dependency_contracts/` (gitignore semantics can't re-include a child of a fully excluded dir). Verified with `gcloud meta list-files-for-upload`: exactly the 7 contract files upload, nothing else from tests/ leaks.
2. **`backend/` had no change-detection mapping.** `Dockerfile.api` COPYs `backend/` into the image, but only `Dockerfile.api|requirements-api.txt` mapped to `api` — so backend changes skipped Image Build Check entirely (observed on #365: "Image Build Check: Skipped"). Map `backend/*` → api.

Also surfaced (no change here, flagging for review): **`backend/requirements.txt` is installed by nothing** — no Dockerfile, workflow, or compose file references it. Dependabot is dutifully bumping a file with no consumer; either some external deploy uses it or it's dead and should be removed from the dependabot config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)