### PR TITLE
fix(contracts): conftest crashed under the in-image /contracts mount

### DIFF
--- a/tests/dependency_contracts/conftest.py
+++ b/tests/dependency_contracts/conftest.py
@@ -102,10 +102,13 @@ def rss_xml() -> str:
 
 def find_production_checkpoint() -> Path | None:
     """Locate the production classifier checkpoint if this venue has it."""
-    candidates = [
-        Path("/app/models/productionmodel.pt"),  # inside built images
-        Path(__file__).resolve().parents[2] / "models" / "productionmodel.pt",
-    ]
+    candidates = [Path("/app/models/productionmodel.pt")]  # inside built images
+    here = Path(__file__).resolve()
+    # Repo layout: tests/dependency_contracts/conftest.py -> parents[2] is the
+    # repo root. In-image the suite is mounted at /contracts, which has fewer
+    # parents — guard so the helper can't crash in that venue.
+    if len(here.parents) > 2:
+        candidates.append(here.parents[2] / "models" / "productionmodel.pt")
     env = os.environ.get("PRODUCTION_MODEL_PATH")
     if env:
         candidates.insert(0, Path(env))
@@ -113,6 +116,13 @@ def find_production_checkpoint() -> Path | None:
         if path.is_file():
             return path
     return None
+
+
+def pytest_configure(config):
+    """Register repo markers for standalone (in-image) runs of this dir."""
+    config.addinivalue_line(
+        "markers", "allow_network: test may make real network connections"
+    )
 
 
 def chrome_binary_present() -> bool:


### PR DESCRIPTION
`find_production_checkpoint()` built its candidate list with `Path(__file__).parents[2]`, which doesn't exist when the suite is mounted at `/contracts` (two parents only) — `IndexError` killed both transformers contracts in every image venue. Seen on #365's api run: `2 failed, 16 passed, 14 skipped` (the 16 passes prove the in-image gate now executes; the 2 failures were this helper bug, not dependencies).

- Guard the repo-relative checkpoint candidate behind a parents-depth check.
- Register the `allow_network` marker for standalone runs (silences unknown-mark warnings in-image).

Verified both venues: shallow-mount copy (27 passed, 5 skipped) and repo layout (30 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)