### PR TITLE
fix(ci): image-check visibility, evidence manifests, and data/ upload fix

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -16,7 +16,6 @@ env/
 ENV/
 
 # Exclude data and logs
-data/
 logs/
 *.log
 *.db
@@ -36,6 +35,13 @@ artifacts/
 reports/
 docs/
 telemetry_demo/
+
+# Root-only data dir. An unanchored "data/" also stripped src/mcmetadata/data/
+# from the PR image-check upload, so pr-check images failed at mcmetadata
+# import (FileNotFoundError: domain-skip-list.txt) while prod trigger builds
+# (which don't use .gcloudignore) worked — a PR-check-only false negative.
+/data/
+!src/mcmetadata/data/
 
 # Exclude node modules and frontend
 node_modules/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,57 @@ jobs:
       - name: Build + smoke affected images from PR source
         run: |
           echo "Images affected by this PR: ${{ needs.changes.outputs.images }}"
+          set +e
           gcloud builds submit \
             --config gcp/cloudbuild/cloudbuild-pr-image-check.yaml \
             --substitutions "^~^_IMAGES=${{ needs.changes.outputs.images }}" \
             --project mizzou-news-crawler \
             --gcs-source-staging-dir gs://mizzou-news-crawler-pr-staging/source \
-            .
+            . 2>&1 | tee submit.log
+          status=${PIPESTATUS[0]}
+          set -e
+          # The build logs to Cloud Logging only, so gcloud can't stream them
+          # here — without this fetch a failure shows nothing but "status 1".
+          build_id=$(grep -oE 'builds/[a-f0-9-]{36}' submit.log | head -1 | cut -d/ -f2)
+          if [ -n "$build_id" ]; then
+            gcloud builds log "$build_id" --project mizzou-news-crawler 2>/dev/null \
+              | sed 's/^Step #[0-9]* - "build-and-smoke": //' > build.log
+            echo ""
+            echo "════════ Cloud Build log (build $build_id) ════════"
+            cat build.log
+
+            # Per-PR visibility: markdown summary on the job page with each
+            # image's build/smoke/contract outcome, plus ::error:: annotations
+            # so contract failures surface directly on the PR.
+            {
+              echo "## Image Build Check — build \`$build_id\`"
+              echo ""
+              if [ "$status" -eq 0 ]; then
+                echo "**✅ SUCCESS** — all affected images built, smoked, and passed dependency contracts."
+              else
+                echo "**❌ FAILURE** — see annotations and log below."
+              fi
+              echo ""
+              echo "| Image | Stage reached | Contracts verdict |"
+              echo "|---|---|---|"
+              awk '
+                /^🔨 Building /       {img=$3; built[img]="built"; stage[img]="build"}
+                /^🧪 Smoke: /         {stage[$3]="smoke"}
+                /^📜 Dependency contracts: / {cur=$4; stage[cur]="contracts"}
+                /(passed|failed|no tests ran)/ && cur {verdict[cur]=$0; cur=""}
+                END {
+                  for (i in built)
+                    printf("| %s | %s | %s |\n", i, stage[i], (i in verdict ? verdict[i] : "—"))
+                }' build.log
+              echo ""
+              echo "Full log: [Cloud Build console](https://console.cloud.google.com/cloud-build/builds/$build_id?project=mizzou-news-crawler)"
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            grep -E "^FAILED |ERROR:" build.log | head -10 | while IFS= read -r line; do
+              echo "::error title=Image Build Check::$line"
+            done
+          fi
+          exit "$status"
 
   lint:
     name: Lint & Format Check

--- a/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
+++ b/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
@@ -86,7 +86,10 @@ steps:
               pip freeze 2>/dev/null | grep -iE "^(trafilatura|transformers|torch|scikit-learn|scikit_learn|pandas|numpy|newspaper4k|spacy|nltk|selenium|undetected-chromedriver|fastapi|pydantic|storysniffer|htmldate|dateparser|readability-lxml|goose3|boilerpy3|feedparser|rapidfuzz|warcio|beautifulsoup4|lxml|tldextract)==" || true
               echo "──────────────────────────────────────────────"
               pip install --no-cache-dir -q pytest || pip install --no-cache-dir -q --user pytest
-              python -m pytest /contracts -q -o addopts="" -p no:cacheprovider
+              # -rs: print every skip WITH its reason (venue guards must be
+              # auditable — a skip should say "no Chrome in this image", not
+              # hide in a count)
+              python -m pytest /contracts -q -rs -o addopts="" -p no:cacheprovider
             '
         }
 

--- a/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
+++ b/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
@@ -81,6 +81,10 @@ steps:
           docker run --rm \
             -v /workspace/tests/dependency_contracts:/contracts:ro \
             --entrypoint bash "$$img:pr-check" -c '
+              echo "── contract evidence: image='"$$img"':pr-check ──"
+              python -V
+              pip freeze 2>/dev/null | grep -iE "^(trafilatura|transformers|torch|scikit-learn|scikit_learn|pandas|numpy|newspaper4k|spacy|nltk|selenium|undetected-chromedriver|fastapi|pydantic|storysniffer|htmldate|dateparser|readability-lxml|goose3|boilerpy3|feedparser|rapidfuzz|warcio|beautifulsoup4|lxml|tldextract)==" || true
+              echo "──────────────────────────────────────────────"
               pip install --no-cache-dir -q pytest || pip install --no-cache-dir -q --user pytest
               python -m pytest /contracts -q -o addopts="" -p no:cacheprovider
             '


### PR DESCRIPTION
Closes the remaining gaps found auditing #372's round-4 cascade run:

1. **`.gcloudignore` unanchored `data/`** also stripped `src/mcmetadata/data/` from the PR-check upload — pr-check images failed at mcmetadata import (`FileNotFoundError: domain-skip-list.txt`) while prod trigger builds (no .gcloudignore) worked. Round-4's processor contract "failure" was this, not a dependency. Root-anchored to `/data/` + explicit `!src/mcmetadata/data/`; verified with `gcloud meta list-files-for-upload`.
2. **Contract evidence manifests**: `contracts()` now prints, from inside each container, the image tag + python version + installed versions of every contract-covered package before pytest runs — each verdict is bound to the image and versions it was rendered against.
3. **Skip auditability**: `-rs` prints every venue skip with its reason ("no Chrome binary in this venue", "src/ not shipped in this image") instead of a bare count.
4. **GitHub-side visibility**: the Image Build Check step now fetches the Cloud Build log into the job output (the build logs to Cloud Logging only — failures previously showed nothing but "status 1"), writes a per-image markdown summary table (stage reached + contracts verdict) to the job summary, emits `::error::` annotations for failures, and links the Cloud Build console.

Evidence from round 4 that the gate itself works: ml-base `17 passed, 15 skipped`; processor `29 passed` including **StorySniffer skops under scikit-learn 1.9.0** (passes, with `InconsistentVersionWarning`) and the trafilatura 2.1 shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)