### PR TITLE
fix(contracts): mirror src's uc.Chrome invocation + local venue simulator

### DIFF
--- a/docs/dependency-contract-testing.md
+++ b/docs/dependency-contract-testing.md
@@ -55,6 +55,20 @@ the same suite runs everywhere.
 Not duplicated here: sqlalchemy/psycopg2/alembic (covered by the PostgreSQL
 integration suite), requests/proxy stack (covered by the proxy smoke suite).
 
+## Testing the tests (mandatory before pushing contract changes)
+
+The binding venue for contracts is *inside the built images* — repo-layout
+local runs do not prove venue correctness (mount depth, upload manifest,
+baked env vars all differ). Five CI cascades were burned learning this.
+
+**Run `scripts/test_contracts_local.sh` before pushing any change to
+`tests/dependency_contracts/` or the contracts() wiring.** It reproduces the
+Cloud Build execution exactly: stages the suite from the real
+`gcloud meta list-files-for-upload` manifest (catches .gcloudignore holes),
+mounts it at `/contracts` read-only (catches path assumptions), and runs the
+identical pytest invocation inside real images (catches baked-env
+mismatches). ~1 minute after the one-time image pull; $0.
+
 ## Handling a red contract
 
 1. Read the failure — it names the call site and the changed behavior.

--- a/scripts/test_contracts_local.sh
+++ b/scripts/test_contracts_local.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Local venue simulator for the dependency contracts.
+#
+# Reproduces EXACTLY how cloudbuild-pr-image-check.yaml runs the contracts —
+# so venue bugs (mount-depth paths, files missing from the upload set, baked
+# env-var invocations) surface here in ~1 minute instead of in a ~20-minute
+# Cloud Build cascade.
+#
+# Fidelity guarantees:
+#   1. The suite is staged from the ACTUAL gcloud upload manifest
+#      (`gcloud meta list-files-for-upload`), so anything .gcloudignore
+#      strips is missing here too — the tests/-exclusion bug would have
+#      failed this script, not round 2 of CI.
+#   2. Mounted at /contracts, read-only, same pytest flags — the parents[2]
+#      crash would have failed this script, not round 4.
+#   3. Runs inside the real images (default: current prod tags), so baked
+#      env contracts (CHROMEDRIVER_PATH, CHROME_BIN, /app/models) hold —
+#      the uc.Chrome driver-mismatch would have failed this script, not
+#      round 5.
+#
+# Usage:
+#   scripts/test_contracts_local.sh                    # processor + crawler
+#   scripts/test_contracts_local.sh processor          # one image
+#   IMAGES="api migrator" scripts/test_contracts_local.sh
+#   TAG=pr-check scripts/test_contracts_local.sh       # locally built tags
+set -euo pipefail
+
+REGISTRY="${REGISTRY:-us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler}"
+TAG="${TAG:-latest}"
+IMAGES="${IMAGES:-${*:-processor crawler}}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "── staging contracts from the real gcloud upload manifest ──"
+manifest=$(gcloud meta list-files-for-upload . | grep '^tests/dependency_contracts/' || true)
+if [ -z "$manifest" ]; then
+  echo "❌ tests/dependency_contracts is NOT in the gcloud upload set —"
+  echo "   .gcloudignore is stripping it; Cloud Build would see an empty mount."
+  exit 1
+fi
+mkdir -p "$STAGE/contracts"
+while IFS= read -r f; do
+  cp "$f" "$STAGE/contracts/"
+done <<< "$manifest"
+echo "staged $(ls "$STAGE/contracts" | wc -l | tr -d ' ') files"
+
+fail=0
+for img in $IMAGES; do
+  ref="$REGISTRY/$img:$TAG"
+  # Prefer a local image (e.g. TAG=pr-check builds); else pull.
+  if ! docker image inspect "$ref" >/dev/null 2>&1; then
+    echo "── pulling $ref ──"
+    docker pull -q "$ref" || { echo "❌ cannot pull $ref"; fail=1; continue; }
+  fi
+  echo ""
+  echo "════ contracts in $img ($ref) ════"
+  # Identical invocation to cloudbuild-pr-image-check.yaml contracts()
+  if ! docker run --rm \
+      -v "$STAGE/contracts":/contracts:ro \
+      --entrypoint bash "$ref" -c '
+        echo "── contract evidence: $(python -V 2>&1) ──"
+        pip install --no-cache-dir -q pytest || pip install --no-cache-dir -q --user pytest
+        python -m pytest /contracts -q -rs -o addopts="" -p no:cacheprovider
+      '; then
+    fail=1
+  fi
+done
+exit $fail

--- a/tests/dependency_contracts/test_browser_stack.py
+++ b/tests/dependency_contracts/test_browser_stack.py
@@ -32,8 +32,13 @@ class TestSeleniumSurface:
         assert "--no-sandbox" in opts.arguments
 
     def test_undetected_chromedriver_real_boot(self):
-        """Boot real Chrome via undetected_chromedriver as extraction does,
-        load a data: URL, read page_source. Crawler-image venue only."""
+        """Boot real Chrome via undetected_chromedriver EXACTLY as extraction
+        does (src/crawler/__init__.py:4778-4799): the baked, version-matched
+        driver from CHROMEDRIVER_PATH and browser from CHROME_BIN. A bare
+        uc.Chrome() would download the latest chromedriver and fail on any
+        Chrome-version mismatch prod never sees. Crawler-image venue only."""
+        import os
+
         if not chrome_binary_present():
             pytest.skip("no Chrome binary in this venue")
         uc = pytest.importorskip("undetected_chromedriver")
@@ -42,7 +47,16 @@ class TestSeleniumSurface:
         opts.add_argument("--headless=new")
         opts.add_argument("--no-sandbox")
         opts.add_argument("--disable-dev-shm-usage")
-        driver = uc.Chrome(options=opts)
+
+        uc_kwargs = {}
+        driver_path = os.getenv("CHROMEDRIVER_PATH")
+        chrome_bin = os.getenv("CHROME_BIN") or os.getenv("GOOGLE_CHROME_BIN")
+        if driver_path:
+            uc_kwargs["driver_executable_path"] = str(driver_path)
+        if chrome_bin:
+            uc_kwargs["browser_executable_path"] = str(chrome_bin)
+
+        driver = uc.Chrome(options=opts, **uc_kwargs)
         try:
             driver.get("data:text/html,<html><body><h1>contract</h1></body></html>")
             assert "contract" in driver.page_source


### PR DESCRIPTION
## The last contract fix

The real-Chrome boot contract called `uc.Chrome(options)` bare, so undetected_chromedriver downloaded the **latest** chromedriver (151) and failed against the image's Chrome 150 — a mismatch production never sees because src passes `driver_executable_path=CHROMEDRIVER_PATH` / `browser_executable_path=CHROME_BIN` ([src/crawler/__init__.py:4778-4799](../blob/main/src/crawler/__init__.py#L4778-L4799)). The contract now mirrors the exact production invocation — which is the doctrine: test *our* call, not a generic one.

## Test the tests: `scripts/test_contracts_local.sh`

Five CI cascades were burned on venue bugs in the contract suite itself (mount depth, upload manifest, baked env). The simulator reproduces the Cloud Build contracts run exactly — stages from the real `gcloud meta list-files-for-upload` manifest, mounts at `/contracts` read-only, identical pytest invocation, inside real images. Mandatory before pushing contract changes (documented in docs/dependency-contract-testing.md).

**Validation of this PR, by the simulator, inside the real prod crawler image:**
- `uc.Chrome` real-boot contract: **passes** with the baked driver/browser pair
- 27 passed, 4 venue-skips (named), and **1 failure that is the live production trafilatura 2.x bug** (`content.py:202: 'Document' object is not subscriptable`) — the prod image predates the #378 shim. The suite pointed at prod correctly convicts the prod bug; that failure flips green when the cascade deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)