### PR TITLE
fix(extraction): reuse the page capture instead of re-fetching per parser

### DIFF
--- a/docs/capture-reuse.md
+++ b/docs/capture-reuse.md
@@ -1,0 +1,68 @@
+# Capture once, parse many
+
+Extraction falls back through several methods until an article's fields are
+satisfied. Those fallbacks are **parsing** attempts — they are not a reason to
+fetch the page again. One capture, many parsers.
+
+## What it looked like before
+
+Every parser in the chain already accepted HTML and skipped its own fetch when
+given it (`_extract_with_mcmetadata`, `_extract_with_newspaper`,
+`_extract_with_beautifulsoup`), but nothing handed a capture forward:
+
+- The BeautifulSoup fallback was guarded on `html_for_methods` and then passed
+  `html` — the untouched `extract_content` parameter, `None` for every
+  production call — so it re-fetched even when the guard had just confirmed a
+  capture existed.
+- No method wrote its fetched HTML back, so nothing downstream could reuse it.
+
+A single article commonly cost three HTTP fetches of the same URL, and on
+Selenium-first (bot-protected) domains the HTTP parsers would re-fetch over the
+network *after* the browser had already rendered the page — extra exposure on
+exactly the hosts where that is most dangerous.
+
+Measured against the real `extract_content` with the network stubbed:
+
+| scenario | before | after |
+| --- | --- | --- |
+| HTTP chain, parsers falling back | 3 fetches | 1 fetch |
+| chain ending in a Selenium fallback | 4 fetches | 2 fetches |
+
+Selenium still fetches when it runs: rendering the page is the reason to call
+it. The redundant HTTP re-fetches are what disappear.
+
+## The rule
+
+`ContentExtractor._capture_for_parsing()` decides what the next parser works
+from:
+
+1. **A Selenium capture wins.** It is the same page after JavaScript, which is
+   strictly more of the article than an HTTP response.
+2. **Otherwise reuse what's in hand** — a caller-supplied capture (e.g. a
+   preemptive AMP fetch), else the most recent one fetched.
+3. **Never reuse while bot protection is flagged.** The capture may be a
+   challenge page rather than the article, and letting the next method fetch
+   for itself is exactly the escape hatch that recovers from it.
+
+## Why parsers may disagree without this
+
+Beyond the request cost, separate fetches mean parsers can be reading different
+bytes for the same article — a page that changed between requests, or one
+served differently to a different client. Comparing extractor output under
+those conditions measures the fetches as much as the parsers, which is the same
+trap `scripts/extraction_quality_report.py` warns about for re-fetch
+comparisons.
+
+## Turning it off
+
+`EXTRACTION_REUSE_CAPTURE=false` restores per-method fetching without a
+rebuild. It exists because this changes behavior on the core extraction path;
+if a publisher turns out to need a fresh fetch per parser, the switch buys time
+to investigate.
+
+## Verifying it holds
+
+With the raw HTML archive (`docs/raw-html-archive.md`), capture-once is
+observable rather than assumed: an extraction that fetched once produces one
+capture, so the archived object is the article's input by construction rather
+than by selection.

--- a/docs/raw-html-archive.md
+++ b/docs/raw-html-archive.md
@@ -78,25 +78,11 @@ parse HTML someone else fetched contribute no response of their own; when the
 winner is one of those, the last response fetched is stored, since that is the
 page it worked from.
 
-The intended pipeline shape is **capture once, parse many**: fetch the page a
-single time, then run parsers against that capture. Today the fallback chain
-does not fully honor that — `beautifulsoup`, `selenium` and `unblock_proxy`
-each fetch their own copy, so one extraction can produce several captures of
-the same URL. See "Known gap" below.
-
-## Known gap: the chain re-fetches
-
-`src/crawler/__init__.py` guards the BeautifulSoup fallback on
-`html_for_methods` but then passes `html` — the untouched `extract_content`
-parameter, which is `None` for every production call — so BeautifulSoup
-re-fetches even when a capture (e.g. AMP) is already in hand. No method feeds
-its fetched HTML back into `html_for_methods` either, so nothing downstream can
-reuse an earlier capture.
-
-The cost is extra requests per article, more bot-protection exposure, and
-parsers that may not even be looking at the same bytes. Fixing it would make
-"capture once, parse many" true, and would make this archive exactly one object
-per article by construction rather than by selection.
+The pipeline shape is **capture once, parse many** — see
+`docs/capture-reuse.md`. Selenium and the unblock proxy still fetch when they
+run, because rendering and proxy bypass are the reason to call them at all, so
+an extraction can still hold more than one capture and the selection rule above
+decides between them.
 
 ## Reading it back
 

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -2622,6 +2622,7 @@ class ContentExtractor:
                 if metrics:
                     metrics.start_method("mcmetadata")
 
+                html_for_methods = self._capture_for_parsing(html_for_methods)
                 mcmetadata_result = self._extract_with_mcmetadata(
                     url,
                     html_for_methods,
@@ -2662,6 +2663,7 @@ class ContentExtractor:
                 if metrics:
                     metrics.start_method("newspaper4k")
 
+                html_for_methods = self._capture_for_parsing(html_for_methods)
                 newspaper_result = self._extract_with_newspaper(url, html_for_methods)
 
                 if newspaper_result:
@@ -2757,7 +2759,11 @@ class ContentExtractor:
                 if metrics:
                     metrics.start_method("beautifulsoup")
 
-                bs_result = self._extract_with_beautifulsoup(url, html)
+                # Was passing `html` — the untouched extract_content parameter,
+                # None for every production call — so this re-fetched even
+                # though the guard above had just confirmed a capture exists.
+                html_for_methods = self._capture_for_parsing(html_for_methods)
+                bs_result = self._extract_with_beautifulsoup(url, html_for_methods)
 
                 if bs_result:
                     # Only copy missing fields
@@ -6059,6 +6065,49 @@ class ContentExtractor:
             html_str = html_text
 
         self._raw_html_by_method[method] = html_str
+
+    def _capture_reuse_enabled(self) -> bool:
+        """Whether parsers may reuse a capture instead of fetching their own."""
+        return os.getenv("EXTRACTION_REUSE_CAPTURE", "true").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+
+    def _capture_for_parsing(self, current: str | None) -> str | None:
+        """Return the page capture the next parser should work from.
+
+        The chain is meant to fetch once and parse many times — every parser
+        here accepts HTML and skips its own fetch when given it — but nothing
+        used to hand a capture forward, so each fallback re-fetched the same
+        URL. That costs requests, exposes us to bot protection repeatedly, and
+        lets parsers disagree because they read different bytes.
+
+        A Selenium capture wins over an HTTP one: it is the same page after
+        JavaScript, which is strictly more of the article.
+
+        Reuse is skipped while bot protection is flagged. The capture in hand
+        may be a challenge page rather than the article, and letting the next
+        method fetch for itself is exactly the escape hatch that recovers from
+        that.
+        """
+        if not self._capture_reuse_enabled():
+            return current
+
+        if self._last_bot_protection_detection:
+            return current
+
+        selenium_capture = self._raw_html_by_method.get("selenium")
+        if selenium_capture:
+            return selenium_capture
+
+        if current:
+            return current
+
+        if not self._raw_html_by_method:
+            return None
+        return self._raw_html_by_method[next(reversed(self._raw_html_by_method))]
 
     def _select_raw_html_for_archive(self, primary_method: str | None) -> None:
         """Pick which fetched response to archive for this extraction.

--- a/tests/crawler/test_capture_reuse.py
+++ b/tests/crawler/test_capture_reuse.py
@@ -1,0 +1,72 @@
+"""Tests for capture-once/parse-many reuse in the extraction fallback chain."""
+
+import pytest
+
+from src.crawler import ContentExtractor
+
+
+@pytest.fixture
+def extractor():
+    """A bare extractor with just the capture-tracking state initialized."""
+    ex = ContentExtractor.__new__(ContentExtractor)
+    ex._raw_html_by_method = {}
+    ex._latest_raw_html = None
+    ex._latest_raw_html_method = None
+    ex._last_bot_protection_detection = None
+    return ex
+
+
+def test_a_later_parser_reuses_an_earlier_fetch(extractor):
+    """The whole point: don't fetch the same URL again to parse it again."""
+    extractor._record_raw_html("<html>fetched once</html>", "mcmetadata")
+
+    assert extractor._capture_for_parsing(None) == "<html>fetched once</html>"
+
+
+def test_rendered_capture_beats_an_http_one(extractor):
+    """Selenium's capture is the same page after JS — strictly more article."""
+    extractor._record_raw_html("<html>http copy</html>", "mcmetadata")
+    extractor._record_raw_html("<html>rendered copy</html>", "selenium")
+
+    assert extractor._capture_for_parsing(None) == "<html>rendered copy</html>"
+    # ...even when an earlier capture was already threaded through.
+    assert extractor._capture_for_parsing("<html>http copy</html>") == (
+        "<html>rendered copy</html>"
+    )
+
+
+def test_no_reuse_while_bot_protection_is_flagged(extractor):
+    """The capture may be a challenge page; a fresh fetch is the escape hatch."""
+    extractor._record_raw_html("<html>Just a moment...</html>", "mcmetadata")
+    extractor._last_bot_protection_detection = {
+        "type": "cloudflare",
+        "status_code": 403,
+        "source": "newspaper4k",
+    }
+
+    assert extractor._capture_for_parsing(None) is None
+
+
+def test_prefetched_amp_capture_is_preserved(extractor):
+    """A caller-supplied capture stands when nothing better was fetched."""
+    assert extractor._capture_for_parsing("<html>amp</html>") == "<html>amp</html>"
+
+
+def test_no_captures_yet_leaves_the_caller_unchanged(extractor):
+    assert extractor._capture_for_parsing(None) is None
+
+
+def test_kill_switch_restores_per_method_fetching(extractor, monkeypatch):
+    """Reuse can be turned off in production without a rebuild."""
+    monkeypatch.setenv("EXTRACTION_REUSE_CAPTURE", "false")
+    extractor._record_raw_html("<html>fetched once</html>", "mcmetadata")
+
+    assert extractor._capture_for_parsing(None) is None
+    assert extractor._capture_for_parsing("<html>amp</html>") == "<html>amp</html>"
+
+
+def test_most_recent_http_capture_wins_without_selenium(extractor):
+    extractor._record_raw_html("<html>first</html>", "mcmetadata")
+    extractor._record_raw_html("<html>second</html>", "newspaper4k")
+
+    assert extractor._capture_for_parsing(None) == "<html>second</html>"


### PR DESCRIPTION
> Stacked on #384 — merge that first. The diff here is only the reuse change.

## The problem

The fallback chain's methods are *parsing* attempts, not a reason to fetch the page again. Every parser already accepted HTML and skipped its own fetch when given it (`_extract_with_mcmetadata`, `_extract_with_newspaper`, `_extract_with_beautifulsoup`) — but nothing handed a capture forward, so each fallback went back to the network for the same URL.

The BeautifulSoup fallback was the clearest case: guarded on `html_for_methods`, then passed `html` — the untouched `extract_content` parameter, `None` for every production call. It re-fetched even though the guard had just confirmed a capture existed.

Worse on Selenium-first (bot-protected) domains: the browser rendered the page, then the HTTP parsers went back to the network anyway — extra exposure on exactly the hosts already fighting us. This is visible in production logs, e.g. mystandardnews taking a newspaper4k fetch, then a BeautifulSoup fetch, then a full Selenium navigation, the last two only chasing a missing author.

## Measured

Against the real `extract_content` with the network stubbed:

| scenario | before | after |
| --- | --- | --- |
| HTTP chain falling through its parsers | 3 fetches | 1 fetch |
| chain ending in a Selenium fallback | 4 fetches | 2 fetches |

Selenium still fetches when it runs — rendering is why it's called. What disappears is the redundant HTTP re-fetching.

## The rule

`_capture_for_parsing()` supplies each parser:

1. **A Selenium capture wins** — same page after JavaScript, strictly more of the article.
2. **Otherwise reuse what's in hand** — a caller-supplied capture (e.g. preemptive AMP), else the most recent fetched.
3. **Never reuse while bot protection is flagged** — the capture may be a challenge page, and letting the next method fetch for itself is exactly the escape hatch that recovers from it.

## Beyond request count

Separate fetches let parsers read *different bytes* for the same article — a page that changed between requests, or one served differently to a different client. Comparing extractor output under those conditions measures the fetches as much as the parsers, the same trap `scripts/extraction_quality_report.py` warns about for re-fetch comparisons.

## Kill switch

`EXTRACTION_REUSE_CAPTURE=false` restores per-method fetching without a rebuild. This changes behavior on the core extraction path, and after the silent trafilatura breakage I'd rather be able to flip it off in prod than discover a publisher that needs per-parser fetches the hard way.

## Verification

- 7 new tests for the reuse policy; full suite 2,654 passing, `mypy src/` clean, ruff clean.
- **Verified against the actual bumped dependency set**: local venv is stale on 30 of the floors from #372 (incl. beautifulsoup4, lxml, newspaper4k, selenium — all in this code path), so the changed sources and tests were run inside a throwaway pod on `crawler:3b60ab1`, which carries bs4 4.15.0 / lxml 6.1.1 / newspaper4k 0.9.6 / selenium 4.46.0. 40 tests pass there.

## Recommended follow-up before wide rollout

A controlled Argo run on the same 10 sources, comparing per-article request counts and extraction outcomes. With #384's archive in place, capture-once becomes observable: an extraction that fetched once produces one capture.

Docs: `docs/capture-reuse.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)