### PR TITLE
chore(deps): stop the processor shipping an extraction stack it never runs

### DIFF
--- a/Dockerfile.ci-base
+++ b/Dockerfile.ci-base
@@ -14,8 +14,15 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy test-only requirements
-COPY requirements-dev.txt ./
+# Copy test-only requirements plus every service's, so tests exercise the real
+# dependency set rather than a subset. Previously this image installed only
+# requirements-dev.txt, which omits trafilatura — so the vendored src/mcmetadata
+# could not import, MCMETADATA_AVAILABLE was False, and CI silently ran every
+# extraction test through the newspaper4k/BeautifulSoup fallbacks instead of the
+# primary extractor. Tests passed locally (dev venv has everything) and behaved
+# differently in CI.
+COPY requirements-dev.txt requirements-crawler.txt requirements-processor.txt \
+     requirements-api.txt ./
 
 # Install test-only dependencies on top of production base
 # These are heavy packages only needed for tests (PyTorch, transformers, etc)
@@ -27,7 +34,10 @@ COPY requirements-dev.txt ./
 # so CI type-checks/tests against the same torch build production uses.
 RUN pip install --no-cache-dir "torch>=2.1.0" --index-url https://download.pytorch.org/whl/cpu && \
     pip install --no-cache-dir "transformers>=5.5.0" && \
-    pip install --no-cache-dir -r requirements-dev.txt
+    pip install --no-cache-dir -r requirements-dev.txt && \
+    pip install --no-cache-dir -r requirements-crawler.txt \
+                                -r requirements-processor.txt \
+                                -r requirements-api.txt
 
 # Metadata
 LABEL maintainer="MizzouNewsCrawler"

--- a/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
+++ b/gcp/cloudbuild/cloudbuild-pr-image-check.yaml
@@ -126,18 +126,24 @@ steps:
 
         if want processor; then
           build processor --build-arg "ML_BASE_IMAGE=$$MLBASE_IMG"
-          # Assert the mcmetadata dependency stack is present — a missing dep
-          # here is what silently set MCMETADATA_AVAILABLE=False and disabled
-          # the trafilatura extractor. Test the DEPS directly rather than the
-          # full src.crawler bootstrap (which has runtime-env assumptions like
-          # the origin-shim PYTHONPATH that a bare `docker run` can't replicate).
-          smoke processor python -c "import trafilatura, readability, goose3, boilerpy3, htmldate, py3langid, furl, url_normalize, dateparser; print('processor OK — mcmetadata stack present, trafilatura', trafilatura.__version__)"
+          # Assert what this image actually runs: entity extraction, wire
+          # detection and WARC import. The mcmetadata stack assertion moved to
+          # the crawler smoke below — extraction runs there, not here, and
+          # asserting it on the processor kept a browser/extraction stack alive
+          # in an image that never invokes it.
+          smoke processor python -c "import rapidfuzz, mediacloud, warcio; print('processor OK — entity/wire/WARC deps present')"
           contracts processor
         fi
 
         if want crawler; then
           build crawler --build-arg "BASE_IMAGE=$$BASE_IMG"
-          smoke crawler bash -c "python -c 'import selenium, undetected_chromedriver' && (chromium --version || google-chrome --version) && echo 'crawler OK'"
+          # The mcmetadata dependency stack is asserted HERE because extraction
+          # runs on this image. A missing dep is what silently set
+          # MCMETADATA_AVAILABLE=False and disabled the trafilatura extractor.
+          # Test the DEPS directly rather than the full src.crawler bootstrap
+          # (which has runtime-env assumptions like the origin-shim PYTHONPATH
+          # that a bare `docker run` can't replicate).
+          smoke crawler bash -c "python -c 'import selenium, undetected_chromedriver' && python -c 'import trafilatura, readability, goose3, boilerpy3, htmldate, py3langid, furl, url_normalize, dateparser; print(\"mcmetadata stack present, trafilatura\", trafilatura.__version__)' && (chromium --version || google-chrome --version) && echo 'crawler OK'"
           contracts crawler
         fi
 

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -58,3 +58,6 @@ structlog>=26.1.0  # Structured logging
 google-cloud-logging>=3.16.1  # Cloud Logging integration
 google-cloud-monitoring>=2.31.0  # Cloud Monitoring metrics
 google-cloud-storage>=3.13.0  # Raw HTML archive (extractor A/B replay)
+# Needed by api, crawler and processor, so it belongs here rather than being
+# repeated in each service's requirements.
+google-cloud-secret-manager>=2.30.0  # Secret retrieval

--- a/requirements-processor.txt
+++ b/requirements-processor.txt
@@ -2,10 +2,9 @@
 # These packages are only needed for the background processor service
 # Note: Heavy ML dependencies (torch, transformers, etc.) are in requirements-ml.txt
 # and installed in the ml-base image to speed up processor builds
-
-# Processor-specific utilities only
-# (Currently all heavy dependencies are in ml-base, so this file is minimal)
-# Add lightweight processor-specific packages here as needed
+#
+# Scope rule: anything more than one image needs belongs in requirements-base.txt;
+# anything only this image needs belongs here.
 
 # Fast fuzzy string matching for entity extraction
 rapidfuzz>=3.14.5  # 50-100x faster than difflib for gazetteer matching
@@ -13,32 +12,32 @@ rapidfuzz>=3.14.5  # 50-100x faster than difflib for gazetteer matching
 # WARC file parsing for Minnesota dataset import
 warcio>=1.8.1  # Parse WARC archives for historical data ingestion
 
-# Browser automation used for last-resort extraction in processor
-selenium>=4.46.0
-undetected-chromedriver>=3.5.5
-selenium-stealth>=1.0.6
-
-# MediaCloud headline detection stack
+# MediaCloud headline detection — used by src/services/wire_detection/, which
+# this image does run. Not part of the extraction stack removed below.
 mediacloud>=5.1.0
-# mcmetadata (vendored in src/mcmetadata) runtime deps — the processor image
-# runs extraction, so it needs the full stack or MCMETADATA_AVAILABLE=False and
-# the trafilatura-based extractor (cascade step 1, on by default) silently
-# disables. Floors mirror requirements-crawler.txt. (newspaper4k/tldextract/
-# lxml/bs4/regex already present in this image.)
-dateparser>=1.4.1
-htmldate>=1.10.0
-trafilatura>=2.1.0
-boilerpy3>=1.0.7
-goose3>=3.1.21
-readability-lxml>=0.8.4.1
-py3langid>=0.3.0
-url-normalize>=3.0.0
-furl>=2.1.4
-newspaper4k>=0.9.6
 
 # Data export and analytics
 google-cloud-bigquery[pandas]>=3.42.2  # BigQuery export for analytics pipeline
-cloud-sql-python-connector[pg8000]>=1.20.4  # Cloud SQL connector for database access
 
-# Secret management for secure credential retrieval
-google-cloud-secret-manager>=2.30.0
+# Removed 2026-07-20 — the browser automation and mcmetadata extraction stacks:
+#   selenium, undetected-chromedriver, selenium-stealth, trafilatura, goose3,
+#   readability-lxml, boilerpy3, htmldate, py3langid, url-normalize, furl,
+#   dateparser, newspaper4k
+#
+# They supported a "last-resort extraction in processor" path gated behind
+# ENABLE_EXTRACTION, which is false in production. Confirmed against the running
+# system: discovery/verification/extraction steps in the Argo pipeline all use
+# the crawler image, while this image runs continuous_processor, clean,
+# entity-extraction and ML analysis. Nothing outside src/crawler/ and
+# src/mcmetadata/ imports any of them.
+#
+# The previous comment here warned that dropping them makes MCMETADATA_AVAILABLE
+# False and silently disables the trafilatura extractor. That is true and is why
+# this needed checking rather than assuming — but it only matters where
+# extraction actually runs, which is the crawler image, whose requirements are
+# untouched. If extraction is ever re-enabled on the processor, this stack has
+# to come back, and the failure would be silent.
+#
+# cloud-sql-python-connector dropped as a duplicate of requirements-base.txt;
+# google-cloud-secret-manager moved to base, since api, crawler and processor
+# all need it.

--- a/tests/test_deployment_requirements.py
+++ b/tests/test_deployment_requirements.py
@@ -308,13 +308,13 @@ class TestRequirementsConsistency:
             services_with_secret_manager = set(
                 google_cloud_packages["google-cloud-secret-manager"].keys()
             )
-            # At minimum, crawler, processor, and api should have it
-            assert (
-                "crawler" in services_with_secret_manager
-            ), "Crawler must have google-cloud-secret-manager for proxy"
-            assert (
-                "processor" in services_with_secret_manager
-            ), "Processor must have google-cloud-secret-manager for proxy"
-            assert (
-                "api" in services_with_secret_manager
-            ), "API must have google-cloud-secret-manager for proxy"
+            # crawler, processor and api all need it — but every image builds
+            # FROM base, so listing it once in requirements-base.txt satisfies
+            # all three and is where a dependency shared by more than one image
+            # belongs. Only demand a per-service entry when base lacks it.
+            if "base" not in services_with_secret_manager:
+                for service_name in ("crawler", "processor", "api"):
+                    assert service_name in services_with_secret_manager, (
+                        f"{service_name} must have google-cloud-secret-manager "
+                        "for proxy (not inherited from base)"
+                    )


### PR DESCRIPTION
Scope rule: anything more than one image needs belongs in `requirements-base.txt`; anything one image needs belongs in that image's file. The graph had drifted from that in both directions.

## Confirmed against the running system, not the config

| image | what actually runs on it |
| --- | --- |
| **crawler** | `discovery-step`, `verification-step`, `extraction-step` (Argo `news-pipeline-template`); `work-queue` deployment |
| **processor** | `continuous_processor`; `clean-step`, `entity-extraction-step`, `ml-analysis-step`; pipeline counting/coordination; `mizzou-cli` (`tail -f /dev/null`) |

`ENABLE_EXTRACTION` and `ENABLE_VERIFICATION` are both `false` on `mizzou-processor`. Crawl and extract happen on the crawler image only.

## Changes

**`requirements-processor.txt`: ~20 dependency lines → 4.** Removed the browser automation and mcmetadata extraction stacks — selenium, undetected-chromedriver, selenium-stealth, trafilatura, goose3, readability-lxml, boilerpy3, htmldate, py3langid, url-normalize, furl, dateparser, newspaper4k. Nothing outside `src/crawler/` and `src/mcmetadata/` imports any of them. The image was shipping a browser stack it cannot invoke — build time, image size and CVE surface for nothing.

**Kept after checking, not assumed:** `mediacloud`. `src/services/wire_detection/` imports it and the processor does run that. An earlier scan missed it because I grepped for `mcmetadata`, not `mediacloud` — removing it would have broken wire detection silently.

**`google-cloud-secret-manager` → base** (api + crawler + processor all need it). **`cloud-sql-python-connector`** dropped from processor as a base duplicate.

**`Dockerfile.ci-base` now installs base + crawler + processor + api requirements.** It previously installed only `requirements-dev.txt`, which omits trafilatura — so the vendored `src/mcmetadata` could not import, `MCMETADATA_AVAILABLE` was False, and **CI silently ran every extraction test through the newspaper4k/BeautifulSoup fallbacks. Our primary extractor was never exercised in CI.** That divergence is what made a test pass locally and fail in CI earlier today.

**Test:** the consistency check required each service file to literally list `google-cloud-secret-manager`. Every image builds `FROM base`, so listing it once there satisfies all three; the per-service requirement now applies only when base lacks it.

## Expect CI failures here, and treat them as information

Local is green (2,669 tests, ruff clean) but that says little: my venv has always had trafilatura. The point of the `ci-base` change is that CI will now exercise the real extractor for the first time, so tests quietly passing against fallbacks may start failing.

## Risk

The removed comment warned that dropping this stack makes `MCMETADATA_AVAILABLE` False and silently disables the trafilatura extractor. True — and why this needed verifying rather than assuming. It only bites where extraction runs, which is the crawler image, whose requirements are untouched. **If extraction is ever re-enabled on the processor, this stack must come back, and the failure would be silent.**

## Not included

Removing the dead `ENABLE_EXTRACTION`/`ENABLE_VERIFICATION` flags and their branches in `orchestration/continuous_processor.py` — code surgery, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)