### PR TITLE
perf(extraction): cut Selenium cost and fix entity extraction's corpus-wide scan

### DIFF
--- a/alembic/versions/d5f1a2b3c4e6_add_entities_extracted_at.py
+++ b/alembic/versions/d5f1a2b3c4e6_add_entities_extracted_at.py
@@ -1,0 +1,74 @@
+"""Record entity-extraction state on articles instead of deriving it.
+
+Finding pending work used to be an anti-join against article_entities, which
+cost O(corpus) to locate a handful of rows and grew more expensive as the
+pipeline got further ahead — eventually exceeding the 120s statement_timeout on
+the mizzou_user role and failing every cycle.
+
+``entities_extracted_at`` plus a partial index over exactly the pending
+predicate makes that lookup proportional to work outstanding instead, and the
+index shrinks as the queue drains.
+
+Revision ID: d5f1a2b3c4e6
+Revises: c4e8a1f52b7d
+Create Date: 2026-07-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5f1a2b3c4e6"
+down_revision: str | Sequence[str] | None = "c4e8a1f52b7d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INDEX_NAME = "idx_articles_pending_entities"
+
+
+def upgrade() -> None:
+    # The mizzou_user role carries statement_timeout=120s — the ceiling that
+    # turned this query's slowness into an outage. The backfill below touches
+    # ~122k rows, so lift it for this migration or the fix trips over the same
+    # limit it exists to escape.
+    op.execute("SET statement_timeout='900s'")
+
+    op.add_column(
+        "articles",
+        sa.Column("entities_extracted_at", sa.DateTime(), nullable=True),
+    )
+
+    # Stamp everything already processed BEFORE the new query goes live, or it
+    # would treat 122k finished articles as pending and reprocess the corpus.
+    op.execute("""
+        UPDATE articles a
+        SET entities_extracted_at = COALESCE(src.first_seen, NOW())
+        FROM (
+            SELECT article_id, MIN(created_at) AS first_seen
+            FROM article_entities
+            GROUP BY article_id
+        ) src
+        WHERE a.id = src.article_id
+          AND a.entities_extracted_at IS NULL
+    """)
+
+    # Mirrors the candidate query's WHERE clause so the planner can use it.
+    op.create_index(
+        INDEX_NAME,
+        "articles",
+        ["candidate_link_id"],
+        unique=False,
+        postgresql_where=sa.text(
+            "entities_extracted_at IS NULL "
+            "AND content IS NOT NULL "
+            "AND text IS NOT NULL "
+            "AND status NOT IN ('error', 'paywall', 'wire')"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(INDEX_NAME, table_name="articles")
+    op.drop_column("articles", "entities_extracted_at")

--- a/scripts/backfill_entities_extracted_at.py
+++ b/scripts/backfill_entities_extracted_at.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Record entity-extraction state on articles instead of deriving it.
+
+Finding pending work used to be an anti-join:
+
+    NOT EXISTS (SELECT 1 FROM article_entities ae WHERE ae.article_id = a.id)
+
+which had to consider the whole corpus to locate the handful of articles still
+pending — 150k articles against 2.7M entity rows to find ~80. Cost grew as more
+work completed, so the query got slower the further ahead the pipeline got, and
+once it crossed the 120s statement_timeout on the mizzou_user role it failed
+every cycle. The timeout revealed the problem rather than causing it.
+
+This makes the pending set directly indexable:
+
+  1. ``articles.entities_extracted_at`` (idempotent ADD COLUMN IF NOT EXISTS).
+  2. Backfill it for every article that already has entity rows, so switching
+     the query does not reprocess 122k articles.
+  3. A partial index over exactly the pending predicate. It holds only the rows
+     still outstanding and SHRINKS as the queue drains — the opposite of the
+     anti-join, which grew.
+
+Order matters: column, then backfill, then index, then deploy the query change.
+A half-applied migration must never leave the new query seeing everything as
+pending.
+
+Usage:
+  python scripts/backfill_entities_extracted_at.py --dry-run
+  python scripts/backfill_entities_extracted_at.py
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from sqlalchemy import text
+
+from src.models.database import DatabaseManager
+
+ADD_COLUMN_SQL = text(
+    "ALTER TABLE articles ADD COLUMN IF NOT EXISTS entities_extracted_at TIMESTAMP"
+)
+
+# Stamp articles that already have entities. Uses the entity row's own
+# created_at where available so the record reflects when work actually
+# happened rather than when this script ran.
+BACKFILL_SQL = text("""
+UPDATE articles a
+SET entities_extracted_at = COALESCE(src.first_seen, NOW())
+FROM (
+    SELECT article_id, MIN(created_at) AS first_seen
+    FROM article_entities
+    GROUP BY article_id
+) src
+WHERE a.id = src.article_id
+  AND a.entities_extracted_at IS NULL
+""")
+
+# Mirrors the candidate query's WHERE clause exactly, so the planner can use it
+# for that lookup. CONCURRENTLY keeps writes flowing while it builds.
+CREATE_INDEX_SQL = text("""
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_pending_entities
+ON articles (candidate_link_id)
+WHERE entities_extracted_at IS NULL
+  AND content IS NOT NULL
+  AND text IS NOT NULL
+  AND status NOT IN ('error', 'paywall', 'wire')
+""")
+
+PENDING_SQL = """
+SELECT COUNT(*) FROM articles a
+WHERE a.content IS NOT NULL AND a.text IS NOT NULL
+  AND a.status NOT IN ('error', 'paywall', 'wire')
+  AND NOT EXISTS (SELECT 1 FROM article_entities ae WHERE ae.article_id = a.id)
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing.",
+    )
+    args = parser.parse_args()
+
+    engine = DatabaseManager().engine
+
+    with engine.begin() as conn:
+        # The anti-join this replaces is the slow one, so give it room to run
+        # for reporting purposes even though the role caps statements at 120s.
+        conn.execute(text("SET statement_timeout='600s'"))
+
+        total = conn.execute(text("SELECT COUNT(*) FROM articles")).scalar() or 0
+        with_entities = (
+            conn.execute(
+                text("SELECT COUNT(DISTINCT article_id) FROM article_entities")
+            ).scalar()
+            or 0
+        )
+        pending = conn.execute(text(PENDING_SQL)).scalar() or 0
+        print(
+            f"articles={total:,}  with_entities={with_entities:,}  pending={pending:,}"
+        )
+
+        if args.dry_run:
+            print(
+                f"DRY RUN: would add entities_extracted_at, stamp {with_entities:,} "
+                f"already-processed articles, and index the {pending:,} pending"
+            )
+            return 0
+
+        conn.execute(ADD_COLUMN_SQL)
+        print("column ensured")
+
+        stamped = conn.execute(BACKFILL_SQL).rowcount
+        print(f"backfilled entities_extracted_at on {stamped:,} articles")
+
+    # CONCURRENTLY cannot run inside a transaction block.
+    with engine.connect() as conn:
+        conn.execute(text("COMMIT"))
+        conn.execute(text("SET statement_timeout='600s'"))
+        conn.execute(CREATE_INDEX_SQL)
+        print("partial index ensured (idx_articles_pending_entities)")
+
+    with engine.connect() as conn:
+        remaining = (
+            conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM articles WHERE entities_extracted_at IS NULL"
+                )
+            ).scalar()
+            or 0
+        )
+        print(f"articles still unstamped (genuine pending + skipped): {remaining:,}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrations/reconcile_alembic_state.sh
+++ b/scripts/migrations/reconcile_alembic_state.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Bring production's alembic_version in line with the schema that is actually
+# there, then apply pending migrations.
+#
+# Production sits at cea12b602254 while the repo head is further ahead, and two
+# of the intervening migrations were applied to the database but never recorded.
+# `alembic upgrade head` therefore fails immediately, trying to re-add columns
+# that already exist. Verified against production on 2026-07-20:
+#
+#   cea12b602254 -> f7a2b9c1d3e4  auth columns on sources   ALREADY APPLIED
+#   f7a2b9c1d3e4 -> b2d9f4c7e1a3  datasets.created_at       GENUINELY MISSING
+#   b2d9f4c7e1a3 -> c4e8a1f52b7d  uq_articles_url           ALREADY APPLIED
+#   c4e8a1f52b7d -> d5f1a2b3c4e6  entities_extracted_at     NOT APPLIED
+#
+# So: stamp what is already true, run what is genuinely missing.
+#
+# datasets.created_at is worth understanding before running: the table was
+# created without the column while the Dataset model has always declared it, so
+# ORM inserts fail with `column "created_at" of relation "datasets" does not
+# exist` and poison the surrounding transaction. That migration repairs the
+# breakage — it does not introduce it.
+#
+# MUST run from the migrator image (the processor image ships no alembic/), and
+# that image must be built from a commit containing d5f1a2b3c4e6.
+#
+# Re-verify before trusting the plan — drift can change:
+#   SELECT version_num FROM alembic_version;
+#   SELECT 1 FROM information_schema.columns
+#    WHERE table_name='datasets' AND column_name='created_at';
+
+set -euo pipefail
+
+echo "== current alembic state =="
+python -m alembic current
+
+echo
+echo "== 1/4 stamp f7a2b9c1d3e4 (sources auth columns already present) =="
+python -m alembic stamp f7a2b9c1d3e4
+
+echo
+echo "== 2/4 upgrade b2d9f4c7e1a3 (adds the missing datasets.created_at) =="
+python -m alembic upgrade b2d9f4c7e1a3
+
+echo
+echo "== 3/4 stamp c4e8a1f52b7d (uq_articles_url already present) =="
+python -m alembic stamp c4e8a1f52b7d
+
+echo
+echo "== 4/4 upgrade head (entities_extracted_at + partial index) =="
+# That migration lifts statement_timeout itself: the role caps statements at
+# 120s and the backfill touches ~122k rows.
+python -m alembic upgrade head
+
+echo
+echo "== final state =="
+python -m alembic current

--- a/scripts/monitor_extraction_change_points.py
+++ b/scripts/monitor_extraction_change_points.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Report the observable change points for the Selenium / entity-extraction work.
+
+Run it BEFORE deploying and again after, over comparable windows, so the next
+round of fixes is aimed by measurement rather than inference. Every number here
+corresponds to something a change in this branch should move — or must NOT move.
+
+    python scripts/monitor_extraction_change_points.py --since '2026-07-20 12:00'
+    python scripts/monitor_extraction_change_points.py --since '2026-07-21 09:00' --hosts
+
+What each section is watching:
+
+  selenium duration   Should fall sharply. page_source used to block until the
+                      page load settled (~208s measured); the stop now runs
+                      first. This is the headline claim and the one that was
+                      never proven inside the pipeline.
+
+  methods attempted   Should NOT change much. The fixes make Selenium cheaper,
+                      not rarer. A big shift means something unintended.
+
+  field completeness  MUST NOT regress. The safety metric — cheaper extraction
+                      that loses fields is not a win. Compare per field.
+
+  challenge leakage   THE RISK. Treating a reCAPTCHA as non-blocking when the
+                      page still carries prose could, if the content probe is
+                      wrong, let a real challenge page through as an article.
+                      Watch for short articles carrying challenge language.
+
+  entity backlog      Should drain to ~0 and stay there. If it climbs, the
+                      partial index is not being used or the stamp is not being
+                      written.
+
+  archive coverage    Share of new articles with raw_gcs_path. Feeds the
+                      same-input extractor A/B; a drop means archiving broke.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections import Counter, defaultdict
+
+from sqlalchemy import text
+
+from src.models.database import DatabaseManager
+
+CHALLENGE_MARKERS = (
+    "enable javascript",
+    "checking your browser",
+    "verify you are human",
+    "just a moment",
+    "attention required",
+    "access denied",
+)
+
+
+def _pct(n: int, d: int) -> str:
+    return f"{n}/{d} ({n / d:.1%})" if d else f"{n}/0"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--since", required=True, help="window start, e.g. '2026-07-21 09:00'"
+    )
+    ap.add_argument("--until", default=None, help="window end (default: now)")
+    ap.add_argument(
+        "--hosts", action="store_true", help="break Selenium timing out by host"
+    )
+    args = ap.parse_args()
+
+    params = {"since": args.since, "until": args.until or "2999-01-01"}
+    eng = DatabaseManager().engine
+
+    with eng.connect() as conn:
+        conn.execute(text("SET statement_timeout='300s'"))
+
+        rows = conn.execute(
+            text("""
+                SELECT host, method_timings, methods_attempted, extracted_fields
+                FROM extraction_telemetry_v2
+                WHERE created_at >= :since AND created_at < :until
+                  AND method_timings IS NOT NULL
+            """),
+            params,
+        ).all()
+
+        per_method: dict[str, list[float]] = defaultdict(list)
+        per_host: dict[str, list[float]] = defaultdict(list)
+        n_methods: Counter = Counter()
+        have: Counter = Counter()
+        total = 0
+
+        for host, mt, ma, ef in rows:
+            t = json.loads(mt) if isinstance(mt, str) else (mt or {})
+            m = json.loads(ma) if isinstance(ma, str) else (ma or [])
+            d = json.loads(ef) if isinstance(ef, str) else (ef or {})
+            total += 1
+            n_methods[len(m)] += 1
+            for k, v in t.items():
+                if isinstance(v, (int, float)):
+                    per_method[k].append(v)
+                    if k == "selenium" and host:
+                        per_host[host].append(v)
+            if isinstance(d, dict):
+                for f in ("title", "author", "content", "publish_date"):
+                    v = d.get(f)
+                    if v not in (None, "", [], {}) and v is not False:
+                        have[f] += 1
+
+        print(f"window: {args.since} .. {args.until or 'now'}   extractions: {total}")
+
+        print("\n-- per-method duration (median / p90) --")
+        for k in sorted(per_method):
+            v = sorted(per_method[k])
+            p90 = v[max(int(len(v) * 0.9) - 1, 0)]
+            print(
+                f"  {k:16s} n={len(v):5d}  median={statistics.median(v) / 1000:8.1f}s"
+                f"  p90={p90 / 1000:8.1f}s"
+            )
+
+        print("\n-- methods attempted per extraction (should stay stable) --")
+        print("  ", dict(sorted(n_methods.items())))
+
+        print("\n-- field completeness (MUST NOT regress) --")
+        for f in ("title", "author", "content", "publish_date"):
+            print(f"  {f:14s} {_pct(have[f], total)}")
+
+        if args.hosts and per_host:
+            print("\n-- selenium median by host --")
+            for h in sorted(per_host, key=lambda x: -statistics.median(per_host[x]))[
+                :12
+            ]:
+                v = per_host[h]
+                print(
+                    f"  {str(h)[:34]:34s} n={len(v):3d}  {statistics.median(v) / 1000:7.1f}s"
+                )
+
+        print("\n-- challenge leakage (THE RISK: real walls read as widgets) --")
+        marker_sql = " OR ".join(
+            f"lower(a.text) LIKE '%%{m}%%'" for m in CHALLENGE_MARKERS
+        )
+        leaked = conn.execute(
+            text(f"""
+                SELECT COUNT(*) FROM articles a
+                WHERE a.created_at >= :since AND a.created_at < :until
+                  AND length(a.text) < 1200 AND ({marker_sql})
+            """),
+            params,
+        ).scalar()
+        new_articles = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM articles WHERE created_at >= :since "
+                "AND created_at < :until"
+            ),
+            params,
+        ).scalar()
+        print(
+            f"  short articles carrying challenge language: {_pct(leaked or 0, new_articles or 0)}"
+        )
+        print(
+            "  (baseline should be ~0; any rise means the content probe is too permissive)"
+        )
+
+        print("\n-- entity backlog (should drain and stay near zero) --")
+        pending = conn.execute(text("""
+                SELECT COUNT(*) FROM articles a
+                WHERE a.content IS NOT NULL AND a.text IS NOT NULL
+                  AND a.status NOT IN ('error','paywall','wire')
+                  AND NOT EXISTS (
+                      SELECT 1 FROM article_entities ae WHERE ae.article_id = a.id
+                  )
+            """)).scalar()
+        print(f"  pending entity extraction: {pending:,}")
+
+        print("\n-- archive coverage (feeds same-input extractor A/B) --")
+        archived = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM articles WHERE created_at >= :since "
+                "AND created_at < :until AND raw_gcs_path IS NOT NULL"
+            ),
+            params,
+        ).scalar()
+        print(
+            f"  new articles with raw_gcs_path: {_pct(archived or 0, new_articles or 0)}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/commands/entity_extraction.py
+++ b/src/cli/commands/entity_extraction.py
@@ -93,7 +93,19 @@ def handle_entity_extraction_command(args, extractor=None) -> int:
             # - save_article_entities(autocommit=False) used per article
             # - Batch commit after each source releases locks together
             # - Other workers skip locked articles, grab different ones
-            # - EXISTS check prevents re-processing on subsequent runs
+            # - entities_extracted_at prevents re-processing on subsequent runs
+            #
+            # That column replaced `NOT EXISTS (SELECT 1 FROM article_entities
+            # ...)`. The anti-join had to consider the whole corpus to find the
+            # few articles still pending — 150k articles against 2.7M entity
+            # rows to locate ~80 — so it grew more expensive the more work was
+            # already done, and eventually exceeded the 120s statement_timeout
+            # set on the role, failing every cycle. Matching on recorded state
+            # makes the lookup proportional to work outstanding instead, via a
+            # partial index that shrinks as the queue drains.
+            #
+            # ORDER BY is unchanged on purpose: articles are processed
+            # source-by-source so each publisher's gazetteer is loaded once.
             query = sql_text(
                 """
                 SELECT a.id, a.text, a.text_hash, cl.source_id, cl.dataset_id, cl.source
@@ -101,9 +113,7 @@ def handle_entity_extraction_command(args, extractor=None) -> int:
                 JOIN candidate_links cl ON a.candidate_link_id = cl.id
                 WHERE a.content IS NOT NULL
                 AND a.text IS NOT NULL
-                AND NOT EXISTS (
-                    SELECT 1 FROM article_entities ae WHERE ae.article_id = a.id
-                )
+                AND a.entities_extracted_at IS NULL
                 AND a.status NOT IN ('error', 'paywall', 'wire')
                 """
                 + ("AND cl.source = :source" if source else "")

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -4258,17 +4258,23 @@ class ContentExtractor:
                 return {}
 
             # Extract content after ensuring page is loaded
-            html = driver.page_source
-
-            self._update_wire_hints_from_html(html, url)
-            self._record_raw_html(html, "selenium")
-
-            # Stop page load immediately after getting HTML to prevent
-            # waiting for slow ads/trackers (fixes 147s timeout issue)
+            # Stop the page load BEFORE reading page_source. Reading it while
+            # the document is still fetching ads and trackers blocks until the
+            # load settles — measured at ~208s on newstribune, versus 0.1s when
+            # the stop runs first (nav itself is ~2s).
+            #
+            # The stop used to run immediately after this read, with a comment
+            # noting it "fixes 147s timeout issue" — the right instinct applied
+            # one line too late, since page_source is what blocks.
             try:
                 driver.execute_script("window.stop();")
             except Exception:
                 pass  # Ignore if page already finished loading
+
+            html = driver.page_source
+
+            self._update_wire_hints_from_html(html, url)
+            self._record_raw_html(html, "selenium")
 
             soup = BeautifulSoup(html, "html.parser")
 
@@ -5790,6 +5796,31 @@ class ContentExtractor:
             logger.error(f"Error in challenge bypass attempt: {e}")
             return False
 
+    # A page carrying this much prose is showing an article, not a challenge.
+    # Interstitials ("Just a moment...", "Attention Required") are near-empty by
+    # design, so the threshold separates them without naming any of them.
+    ARTICLE_CONTENT_MIN_CHARS = 1200
+    ARTICLE_CONTENT_MIN_PARAGRAPHS = 5
+
+    def _page_has_article_content(self, driver) -> bool:
+        """Whether the rendered page still carries a story.
+
+        Used to tell a blocking wall from a widget that merely sits on the page:
+        a wall replaces the article, a sign-in or subscription prompt does not.
+        Deliberately structural — no vendor or publisher names — so it keeps
+        working as publishers change providers.
+        """
+        try:
+            paragraphs = driver.find_elements(By.CSS_SELECTOR, "article p, main p, p")
+            if len(paragraphs) < self.ARTICLE_CONTENT_MIN_PARAGRAPHS:
+                return False
+            chars = sum(len((p.text or "").strip()) for p in paragraphs[:40])
+            return chars >= self.ARTICLE_CONTENT_MIN_CHARS
+        except Exception:
+            # Never let this probe decide by accident — if we cannot tell, fall
+            # through to the existing detection rather than assuming safety.
+            return False
+
     def _detect_captcha_or_challenge(self, driver) -> bool:
         """Detect if page contains CAPTCHA or other bot challenges.
 
@@ -5837,9 +5868,40 @@ class ContentExtractor:
                 "iframe[src*='captcha']",  # Generic captcha iframe
             ]
 
+            # A bot wall REPLACES the article; a sign-in or subscription widget
+            # sits beside it. So the question isn't which vendor drew the
+            # widget, it's whether the page still carries the story — which is
+            # site-agnostic and doesn't rot as publishers change vendors.
+            #
+            # newstribune is the case that exposed the gap: it embeds reCAPTCHA
+            # in a subscriber sign-in widget and carries only one subscription
+            # keyword, so the >=2 keyword rule above missed it. Every article
+            # then paid ~86s failing to "bypass" a login form before extracting
+            # the article anyway — telemetry showed 11/11 selenium "success"
+            # alongside "Could not bypass".
+            has_article_content = self._page_has_article_content(driver)
+
+            # Only the soft, embeddable widgets get this exemption. Cloudflare
+            # and PerimeterX challenges below are genuine walls and still block
+            # even when markup happens to linger behind them.
+            soft_captcha_selectors = (
+                "iframe[src*='recaptcha']",
+                "iframe[src*='hcaptcha']",
+                "[class*='g-recaptcha']",
+                "[class*='h-captcha']",
+                "iframe[src*='captcha']",
+            )
+
             for selector in captcha_selectors:
                 try:
                     if driver.find_elements(By.CSS_SELECTOR, selector):
+                        if has_article_content and selector in soft_captcha_selectors:
+                            logger.info(
+                                "Detected %s but the page still carries article "
+                                "content (not blocking) — extracting normally",
+                                selector,
+                            )
+                            return False
                         # If this is a subscription modal with a CAPTCHA, it's NOT blocking
                         if has_subscription_keywords and "recaptcha" in selector:
                             logger.info(

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -167,7 +167,13 @@ class Article(Base):
     )
 
     # Storage references
-    raw_gcs_path = Column(String)  # Future: GCS path for raw HTML
+    raw_gcs_path = Column(String)  # GCS path for raw HTML (see raw_html_archive)
+
+    # Set when entity extraction completes for this article. Recorded state
+    # rather than derived: finding pending work used to be an anti-join against
+    # every row of article_entities (2.7M+), which cost O(corpus) to locate a
+    # handful of rows and eventually exceeded the role's statement_timeout.
+    entities_extracted_at = Column(DateTime, index=True)
 
     # Processing metadata
     extracted_at: Mapped[datetime] = mapped_column(

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     insert,
     select,
     text,
+    update,
 )
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
@@ -1163,6 +1164,16 @@ def save_article_entities(
         )
         session.add(sentinel)
         records.append(sentinel)
+
+    # Stamp the article as processed so finding work is an index lookup on the
+    # pending set rather than an anti-join against every row of
+    # article_entities. Written in the same transaction as the entities, so the
+    # two cannot disagree.
+    session.execute(
+        update(Article)
+        .where(Article.id == article_id)
+        .values(entities_extracted_at=datetime.utcnow())
+    )
 
     if autocommit:
         _commit_with_retry(session)

--- a/tests/crawler/test_captcha_vs_widget.py
+++ b/tests/crawler/test_captcha_vs_widget.py
@@ -1,0 +1,96 @@
+"""Tell a blocking wall from a widget that merely sits on the page.
+
+A bot wall replaces the article; a sign-in or subscription prompt does not. The
+detector used to treat any reCAPTCHA iframe as a wall, so pages that embed one
+in a subscriber sign-in widget paid ~86s per article failing to "bypass" a login
+form — then extracted the article anyway (telemetry showed selenium 11/11
+"success" alongside "Could not bypass").
+
+The rule is structural, not a vendor list: does the rendered page still carry
+prose? Hard challenges (Cloudflare, PerimeterX) must still block regardless.
+"""
+
+import pytest
+
+from src.crawler import ContentExtractor
+
+
+class FakeElement:
+    def __init__(self, text=""):
+        self.text = text
+
+
+class FakeDriver:
+    """Answers CSS queries from a {selector_substring: [elements]} map."""
+
+    def __init__(self, matches, page_source="<html><body>page</body></html>"):
+        self._matches = matches
+        self.page_source = page_source
+        self.title = "A story headline"
+        self.current_url = "https://example.com/news/story"
+
+    def find_elements(self, by, selector):
+        # Exact match only. Substring matching bites here: the paragraph key
+        # "p" is a substring of "iframe[src*='recaptcha']", which would make
+        # every selector return prose.
+        if "p" in self._matches and selector == "article p, main p, p":
+            return self._matches["p"]
+        return self._matches.get(selector, [])
+
+
+PROSE = [FakeElement("A paragraph of real article text that runs on. " * 4)] * 8
+THIN = [FakeElement("Enable JavaScript and cookies to continue")]
+
+
+@pytest.fixture
+def extractor():
+    return ContentExtractor.__new__(ContentExtractor)
+
+
+def test_article_prose_is_recognised(extractor):
+    assert extractor._page_has_article_content(FakeDriver({"p": PROSE})) is True
+
+
+def test_interstitial_is_not_mistaken_for_an_article(extractor):
+    assert extractor._page_has_article_content(FakeDriver({"p": THIN})) is False
+
+
+def test_no_paragraphs_at_all(extractor):
+    assert extractor._page_has_article_content(FakeDriver({})) is False
+
+
+def test_probe_failure_does_not_assert_content(extractor):
+    """If the probe cannot tell, it must not claim the page is fine."""
+
+    class Broken:
+        def find_elements(self, *_a):
+            raise RuntimeError("driver gone")
+
+    assert extractor._page_has_article_content(Broken()) is False
+
+
+def test_signin_widget_on_a_real_article_does_not_block(extractor):
+    """The case that cost ~86s per article."""
+    driver = FakeDriver({"p": PROSE, "iframe[src*='recaptcha']": [FakeElement()]})
+
+    assert extractor._detect_captcha_or_challenge(driver) is False
+
+
+def test_recaptcha_on_a_contentless_page_still_blocks(extractor):
+    """Same widget, no article — that is a wall and must be treated as one."""
+    driver = FakeDriver({"p": THIN, "iframe[src*='recaptcha']": [FakeElement()]})
+
+    assert extractor._detect_captcha_or_challenge(driver) is True
+
+
+def test_cloudflare_challenge_blocks_even_with_prose(extractor):
+    """Hard challenges are not exempted by lingering markup."""
+    driver = FakeDriver({"p": PROSE, ".cf-challenge-form": [FakeElement()]})
+
+    assert extractor._detect_captcha_or_challenge(driver) is True
+
+
+def test_perimeterx_blocks_even_with_prose(extractor):
+    driver = FakeDriver({"p": PROSE, "#px-captcha": [FakeElement()]})
+
+    assert extractor._detect_captcha_or_challenge(driver) is True

--- a/tests/test_entity_extraction_command.py
+++ b/tests/test_entity_extraction_command.py
@@ -381,12 +381,24 @@ class TestEntityExtractionCommand:
         # source_id comes from candidate_links join
         assert "cl.source_id" in query_str or "source_id" in query_str
 
-        # Should filter for articles with content but no entities
+        # Should filter for articles with content but no entities yet.
+        # Pending work is matched on recorded state rather than an anti-join
+        # against article_entities: that anti-join cost O(corpus) to find a
+        # handful of rows and grew as the pipeline got further ahead, until it
+        # exceeded the role's statement_timeout and failed every cycle.
         assert "content is not null" in query_str
         assert "text is not null" in query_str
-        assert "not exists" in query_str
-        assert "article_entities" in query_str
+        assert "entities_extracted_at is null" in query_str
+        assert "not exists" not in query_str, (
+            "the anti-join against article_entities must not come back — it is "
+            "what made this query scale with the corpus instead of the backlog"
+        )
 
         # Should exclude error articles
         assert "status" in query_str
         assert "error" in query_str
+
+        # Ordering is load-bearing, not cosmetic: articles are processed
+        # source-by-source so each publisher's own gazetteer is loaded once
+        # rather than swapped per article.
+        assert "order by cl.source_id" in query_str


### PR DESCRIPTION
Selenium is **800 minutes across 194 runs** since 2026-07-19 — median ~320s against **under 1.6s for every HTTP parser combined**. Plus entity extraction has been failing every cycle in production. All measured, all fixed here.

## 1. `window.stop()` ran *after* `page_source`

Reading `page_source` while the document is still fetching ads and trackers blocks until the load settles.

| order | `page_source` |
| --- | --- |
| production (`page_source` → `window.stop()`) | **~208s** |
| fixed (`window.stop()` → `page_source`) | **0.1s** |

Navigation itself is ~2s. The gap was reproduced three times in real pipeline runs, appearing as complete log silence between "Could not bypass challenge" and "Selenium extraction succeeded". The stop already carried a comment about fixing a "147s timeout issue" — right instinct, applied one line too late.

## 2. Any reCAPTCHA iframe was treated as a bot wall

Publishers embed reCAPTCHA in subscriber **sign-in widgets**, so pages serving the article perfectly well spent **~86s per article** failing to "bypass" a login form — then extracted the article anyway. That's why telemetry showed selenium 11/11 "success" alongside "Could not bypass" in the logs.

**Structural rule, not a vendor list:** a wall *replaces* the article, a widget *sits beside* it. `_page_has_article_content()` asks whether the rendered page still carries prose, so it keeps working as publishers change providers. **Hard challenges still block** — Cloudflare and PerimeterX are excluded from the exemption.

Evidence: archived HTML from a real Argo run — two newstribune articles, both extracted fine (4,258 and 1,506 chars), each with one reCAPTCHA belonging to a subscriber-auth iframe, zero paywall markers.

## 3. Entity extraction: finding work cost O(corpus)

Failing every cycle at exactly 120.1s. The candidate query used:

```sql
NOT EXISTS (SELECT 1 FROM article_entities ae WHERE ae.article_id = a.id)
```

With 81% of articles already processed it discarded ~1,700 finished articles for every one it wanted — 150k articles against 2.7M entity rows to locate ~110.

**Why it worked for months, then didn't:** the query got slower as the pipeline got *further ahead* (every processed article lengthens the useless prefix), and `ALTER ROLE mizzou_user SET statement_timeout='120s'` — a per-role setting, not application code — converted latent slowness into hard failure. The timeout revealed the problem; raising it would only hide this until the next query crosses the same line.

Fixed with `articles.entities_extracted_at`, stamped in the same transaction as the entities, plus a partial index over exactly the pending predicate. It holds the outstanding rows only (110, not 150,635) and **shrinks as the queue drains**.

`ORDER BY cl.source_id, cl.dataset_id` is deliberately **unchanged** — articles are processed source-by-source so each publisher's own gazetteer loads once. That ruled out simply dropping the sort, and the test now guards it.

## Migration

Not a plain `alembic upgrade head`. Prod is at `cea12b602254`, four revisions back, with two intervening migrations applied to the database but unrecorded:

| migration | reality |
| --- | --- |
| auth columns on sources | already applied |
| `datasets.created_at` | **genuinely missing** |
| `uq_articles_url` | already applied |

`scripts/migrations/reconcile_alembic_state.sh` scripts the stamp/upgrade sequence with its verification queries. Requires a migrator image built from this branch — the published one is from 2025-12-31.

`scripts/backfill_entities_extracted_at.py` applies the same DDL without touching `alembic_version`, and uses `CREATE INDEX CONCURRENTLY` which alembic cannot do inside its transaction.

## Verification

2,677 tests passing, `mypy src/` clean across 110 files, ruff clean. Dry run against production: 150,635 articles, 122,291 to stamp, 110 pending.

## Still unproven

**The latency claim needs an Argo run on the built branch.** `page_source` was measured outside the pipeline; the pipeline-level ~300s → seconds is inference until a newstribune-scoped run confirms it. Unit tests cannot establish this.

## Deliberately not included

- **Parsers follow the capture** — trafilatura never re-parses Selenium's rendered HTML, so after paying for a browser we take the soup extraction. Architectural; needs its own tests.
- **Decoupling identity rotation from driver teardown** — `SELENIUM_DRIVER_REUSE_LIMIT=3` destroys authenticated sessions every 3 articles. Justified only by a config comment citing PerimeterX; needs a measured trial, not a config edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)