### PR TITLE
perf(selenium): stop the load before any reader + instrument the driver timing

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 from html import unescape
@@ -4271,7 +4272,8 @@ class ContentExtractor:
             except Exception:
                 pass  # Ignore if page already finished loading
 
-            html = driver.page_source
+            with self._phase("extract_page_source"):
+                html = driver.page_source
 
             self._update_wire_hints_from_html(html, url)
             self._record_raw_html(html, "selenium")
@@ -5227,6 +5229,19 @@ class ContentExtractor:
         # command executor timeout set above depending on headless/headful mode
         return driver
 
+    @contextmanager
+    def _phase(self, label: str):
+        """Log how long a Selenium phase took, so a real pipeline run tells us
+        where the per-article seconds actually go (page_source vs find_elements
+        vs scroll vs the load itself). Greppable as 'SELENIUM_PHASE'. Cheap
+        enough to leave on; remove once the driver timing is understood.
+        """
+        started = time.time()
+        try:
+            yield
+        finally:
+            logger.info("SELENIUM_PHASE %s %.2fs", label, time.time() - started)
+
     def _navigate_with_human_behavior(self, driver, url: str) -> bool:
         """Navigate to URL with minimal delays for faster content extraction."""
         try:
@@ -5269,13 +5284,35 @@ class ContentExtractor:
                         logger.debug("Cookie import step failed: %s", e_c)
 
                     with lock:
-                        driver.get(url)
+                        with self._phase("driver_get"):
+                            driver.get(url)
 
                     # Wait for basic page load; allow more time on later attempts
                     wait_time = 5 if attempt == 1 else (10 if attempt == 2 else 15)
-                    WebDriverWait(driver, wait_time).until(
-                        EC.presence_of_element_located((By.TAG_NAME, "body"))
-                    )
+                    with self._phase("wait_for_body"):
+                        WebDriverWait(driver, wait_time).until(
+                            EC.presence_of_element_located((By.TAG_NAME, "body"))
+                        )
+
+                    # Stop the load the instant <body> exists — page_load_strategy
+                    # is 'eager' so the DOM is ready here while ads, trackers and
+                    # auth/captcha iframes keep fetching through the proxy. Every
+                    # DOM read after this (the captcha/subscription detectors, the
+                    # human-scroll, then extraction) blocks until the load quiets
+                    # down otherwise. This restores 47b5ad61's intent ("147s ->
+                    # ~5-15s"): stop BEFORE anything reads the page. #388 stopped
+                    # too late — the detectors run first and had already blocked.
+                    #
+                    # With the load halted here, every driver.page_source read
+                    # downstream returns instantly AND reflects the live DOM, so
+                    # a mutation (closing a modal, passing a challenge, scrolling
+                    # in lazy content) is picked up by the next read with no stale
+                    # cache to invalidate.
+                    try:
+                        with self._phase("window_stop"):
+                            driver.execute_script("window.stop();")
+                    except Exception:
+                        pass
 
                     success = True
                     logger.info("Selenium navigation succeeded on attempt %d", attempt)
@@ -5524,14 +5561,15 @@ class ContentExtractor:
                     scroll_positions.append(current_pos)
 
                 # Limit scrolling to avoid timeout - faster scrolling
-                for pos in scroll_positions[:3]:  # Reduced from 5 positions
-                    driver.execute_script(f"window.scrollTo(0, {pos});")
-                    # Quick pause between scrolls
-                    time.sleep(0.2)  # Reduced from 0.8-2.0 seconds
+                with self._phase("human_scroll"):
+                    for pos in scroll_positions[:3]:  # Reduced from 5 positions
+                        driver.execute_script(f"window.scrollTo(0, {pos});")
+                        # Quick pause between scrolls
+                        time.sleep(0.2)  # Reduced from 0.8-2.0 seconds
 
-                # Scroll back to top (common human behavior)
-                driver.execute_script("window.scrollTo(0, 0);")
-                time.sleep(0.2)  # Reduced from 0.5-1.0 seconds
+                    # Scroll back to top (common human behavior)
+                    driver.execute_script("window.scrollTo(0, 0);")
+                    time.sleep(0.2)  # Reduced from 0.5-1.0 seconds
 
             # Simulate mouse movement (if ActionChains available)
             if hasattr(driver, "execute_script"):
@@ -5612,7 +5650,8 @@ class ContentExtractor:
         These should be tracked separately as they may block for days/months.
         """
         try:
-            page_source = driver.page_source.lower()
+            with self._phase("subwall_page_source"):
+                page_source = driver.page_source.lower()
 
             # Common subscription wall indicators
             subscription_keywords = [
@@ -5871,7 +5910,8 @@ class ContentExtractor:
         NOT subscription modals or promotional CAPTCHAs.
         """
         try:
-            page_source = driver.page_source.lower()
+            with self._phase("captcha_page_source"):
+                page_source = driver.page_source.lower()
 
             # 1. Check for subscription/paywall modals (these are NOT blockers)
             # If reCAPTCHA is inside a subscription modal, content is still accessible
@@ -5922,7 +5962,8 @@ class ContentExtractor:
             # then paid ~86s failing to "bypass" a login form before extracting
             # the article anyway — telemetry showed 11/11 selenium "success"
             # alongside "Could not bypass".
-            has_article_content = self._page_has_article_content(driver)
+            with self._phase("page_has_article_content"):
+                has_article_content = self._page_has_article_content(driver)
 
             # Only the soft, embeddable widgets get this exemption. Cloudflare
             # and PerimeterX challenges below are genuine walls and still block


### PR DESCRIPTION
## Why

Selenium is ~200-230s median per article; #388 confirmed both its fixes fire on newstribune (captcha ruled non-blocking, no bypass) yet the article still took ~184s. Tracing it showed **two silent gaps — 49s then 121s — after** the two costs #388 removed.

## Root cause

The feature is `47b5ad61` (Nov 2025): `page_load_strategy='eager'` + `window.stop()`, explicitly to cut Selenium "from 147s to ~5-15s" by not waiting for slow ads/trackers through the proxy. It worked when **one** call read the page. Detection functions were added since — `_detect_subscription_wall` and `_detect_captcha_or_challenge` each call `driver.page_source`, and `_page_has_article_content` reads element text — and #388 placed the stop **after** them. On a page still fetching, every one of those reads re-blocks. #388's stop guarded only the last read, so the block moved earlier rather than disappearing.

## Change

Move `window.stop()` to fire the instant `<body>` exists in `_navigate_with_human_behavior` — before the detectors, the human-scroll, and extraction. With the load halted there, every downstream `driver.page_source` returns instantly **and** reflects the live DOM, so a mutation (closing a modal, passing a challenge, lazy-load on scroll) is seen by the next read with no stale cache to keep in sync.

An earlier draft cached one snapshot for all readers; that reintroduced exactly that staleness (a modal close would leave readers parsing the pre-close DOM), so it was dropped. Live reads made cheap by the early stop are simpler and satisfy "recapture after every mutation" by construction.

## Instrumented, because the mechanism isn't proven

I could not prove *which* call eats the seconds — I'd been citing a bench measurement, not pipeline evidence. So this ships with timing: a `_phase()` context manager logs `SELENIUM_PHASE <label> <s>` around `driver_get`, `wait_for_body`, `window_stop`, both detector `page_source` reads, `page_has_article_content`, `extract_page_source`, and `human_scroll`.

**A real Argo newstribune run will show the breakdown and confirm or correct the mechanism.** If the `page_source` phases are now ~0.1s, the fix works and the cause is confirmed. If some phase is still seconds long, that's the real culprit, named in the logs. Cheap enough to leave on; remove once understood.

## Validation

Pre-push suite green (2,683). **Timing win is NOT claimed here** — it must be read from the `SELENIUM_PHASE` logs on a newstribune Argo run after deploy, not from unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)