### PR TITLE
instrument(selenium): split the DOM-read cost to settle the architecture question

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -5893,10 +5893,28 @@ class ContentExtractor:
         working as publishers change providers.
         """
         try:
-            paragraphs = driver.find_elements(By.CSS_SELECTOR, "article p, main p, p")
+            # DIAGNOSTIC (instrument/selenium-driver-responsiveness): decide the
+            # architecture question — is the cost the .text/find_elements
+            # round-trips (which we remove by parsing captured HTML instead), or
+            # is the browser globally unresponsive (a trivial execute_script also
+            # blocks)? driver_ping is a no-DOM round-trip; compare it to
+            # pha_find_elements and pha_text_loop. Remove once answered.
+            try:
+                with self._phase("driver_ping"):
+                    driver.execute_script("return 1")
+            except Exception:
+                pass
+
+            with self._phase("pha_find_elements"):
+                paragraphs = driver.find_elements(
+                    By.CSS_SELECTOR, "article p, main p, p"
+                )
             if len(paragraphs) < self.ARTICLE_CONTENT_MIN_PARAGRAPHS:
                 return False
-            chars = sum(len((p.text or "").strip()) for p in paragraphs[:40])
+            n = min(len(paragraphs), 40)
+            with self._phase("pha_text_loop"):
+                chars = sum(len((p.text or "").strip()) for p in paragraphs[:40])
+            logger.info("SELENIUM_PHASE pha_text_elements %d", n)
             return chars >= self.ARTICLE_CONTENT_MIN_CHARS
         except Exception:
             # Never let this probe decide by accident — if we cannot tell, fall


### PR DESCRIPTION
Diagnostic-only. Follows the verified result that #390's `window.stop()` fix does **nothing** (selenium median 224.8s / n=55 vs 224.3s baseline, 100% field completeness) and that every WebDriver command carries a 30–138s fat tail clustering at the driver's 30s `command_executor` timeout.

## The open question

Is the per-article cost the live-DOM `.text`/`find_elements` round-trips specifically — which the "Selenium captures HTML, the real parsers parse it" direction removes — or is the browser globally unresponsive, in which case no API change helps?

## What this adds

`_page_has_article_content` is split, all logged as `SELENIUM_PHASE`:

- **`driver_ping`** — `execute_script("return 1")`, a no-DOM round-trip = baseline driver responsiveness at that moment.
- **`pha_find_elements`** — the `find_elements` DOM query alone.
- **`pha_text_loop`** — the `.text` sum over up to 40 elements alone.
- **`pha_text_elements`** — element count `.text` ran on.

## The decisive read (after deploy + a verify Argo run)

- `driver_ping` ≈ ms but `pha_text_loop` = seconds → the cost is live-DOM text extraction; parsing the captured `page_source` string instead removes it.
- `driver_ping` also seconds → the browser is globally unresponsive; the fix is below the API.

Diagnostic only (adds logging, no behavior change). Remove once answered. The timing conclusion must be read from a real Argo run, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)