### PR TITLE
perf(selenium): parse the HTML snapshot, not 40 live .text round-trips

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -5885,41 +5885,92 @@ class ContentExtractor:
     ARTICLE_CONTENT_MIN_PARAGRAPHS = 5
 
     def _page_has_article_content(self, driver) -> bool:
-        """Whether the rendered page still carries a story.
+        """Whether the captured page still carries a story.
 
         Used to tell a blocking wall from a widget that merely sits on the page:
         a wall replaces the article, a sign-in or subscription prompt does not.
         Deliberately structural — no vendor or publisher names — so it keeps
         working as publishers change providers.
+
+        Parses the page's HTML *snapshot* — one ``page_source`` round-trip, then
+        BeautifulSoup in-process — instead of reading each ``<p>.text`` live. The
+        live read issued one WebDriver round-trip per element and each forced a
+        layout reflow; instrumentation measured it at up to 124s on heavy pages
+        versus ~0.2s for a snapshot parse, with ``driver_ping`` (a no-DOM
+        round-trip) staying sub-2s the whole time — i.e. the cost was the
+        per-element ``.text`` round-trips, not an unresponsive browser.
+
+        Note the semantic shift: ``get_text()`` on the snapshot is ``textContent``
+        (raw DOM text), not the rendered/visible text ``.text`` returned. For
+        "is there article-length text here" that is fine, but be aware a paywall
+        that CSS-hides an article still present in the DOM would now read as
+        content-bearing; server-truncated paywalls (body absent from the DOM)
+        still read as empty. Set ``SELENIUM_TEXT_DECOMPOSE=1`` to emit the extra
+        probes that decompose round-trip chattiness from forced reflow.
         """
         try:
-            # DIAGNOSTIC (instrument/selenium-driver-responsiveness): decide the
-            # architecture question — is the cost the .text/find_elements
-            # round-trips (which we remove by parsing captured HTML instead), or
-            # is the browser globally unresponsive (a trivial execute_script also
-            # blocks)? driver_ping is a no-DOM round-trip; compare it to
-            # pha_find_elements and pha_text_loop. Remove once answered.
-            try:
-                with self._phase("driver_ping"):
-                    driver.execute_script("return 1")
-            except Exception:
-                pass
-
-            with self._phase("pha_find_elements"):
-                paragraphs = driver.find_elements(
-                    By.CSS_SELECTOR, "article p, main p, p"
-                )
-            if len(paragraphs) < self.ARTICLE_CONTENT_MIN_PARAGRAPHS:
-                return False
-            n = min(len(paragraphs), 40)
-            with self._phase("pha_text_loop"):
-                chars = sum(len((p.text or "").strip()) for p in paragraphs[:40])
+            with self._phase("pha_page_source"):
+                html = driver.page_source or ""
+            with self._phase("pha_bs_parse"):
+                soup = BeautifulSoup(html, "html.parser")
+                # script/style/noscript never carry article prose and would
+                # inflate the textContent char count.
+                for junk in soup(["script", "style", "noscript"]):
+                    junk.decompose()
+                paragraphs = soup.select("article p, main p, p")
+                if len(paragraphs) < self.ARTICLE_CONTENT_MIN_PARAGRAPHS:
+                    return False
+                n = min(len(paragraphs), 40)
+                chars = sum(len(p.get_text(strip=True)) for p in paragraphs[:n])
             logger.info("SELENIUM_PHASE pha_text_elements %d", n)
+
+            if os.getenv("SELENIUM_TEXT_DECOMPOSE") == "1":
+                self._decompose_text_cost(driver)
+
             return chars >= self.ARTICLE_CONTENT_MIN_CHARS
         except Exception:
             # Never let this probe decide by accident — if we cannot tell, fall
             # through to the existing detection rather than assuming safety.
             return False
+
+    def _decompose_text_cost(self, driver) -> None:
+        """Diagnostic (gated by SELENIUM_TEXT_DECOMPOSE=1): isolate *why* the old
+        live ``.text`` loop was slow — round-trip chattiness vs forced reflow.
+
+        Times, on the SAME page: a no-DOM round-trip (``driver_ping``), a single
+        in-page ``textContent`` read (one round-trip, no reflow), and a single
+        in-page ``innerText`` read (one round-trip, forces reflow). Read against
+        the old per-element ``.text`` loop (~124s = 40 round-trips of rendered
+        text):
+
+        - textContent fast AND innerText fast → cost was the 40 round-trips.
+        - textContent fast BUT innerText slow → forced reflow per rendered read
+          dominates; a static snapshot (textContent) is what avoids it.
+        - both slow → main-thread/layout contention even for a single in-page
+          read — a deeper problem than the round-trip count.
+
+        Never runs in production; best-effort, failures swallowed.
+        """
+        sel = "article p, main p, p"
+        js = (
+            "return Array.from(document.querySelectorAll(arguments[0]))"
+            ".slice(0,40).map(e=>e[arguments[1]]||'').join('')"
+        )
+        try:
+            with self._phase("driver_ping"):
+                driver.execute_script("return 1")
+        except Exception:
+            pass
+        try:
+            with self._phase("pha_execjs_textcontent"):
+                driver.execute_script(js, sel, "textContent")
+        except Exception:
+            pass
+        try:
+            with self._phase("pha_execjs_innertext"):
+                driver.execute_script(js, sel, "innerText")
+        except Exception:
+            pass
 
     def _detect_captcha_or_challenge(self, driver) -> bool:
         """Detect if page contains CAPTCHA or other bot challenges.

--- a/tests/crawler/test_captcha_vs_widget.py
+++ b/tests/crawler/test_captcha_vs_widget.py
@@ -6,8 +6,12 @@ in a subscriber sign-in widget paid ~86s per article failing to "bypass" a login
 form — then extracted the article anyway (telemetry showed selenium 11/11
 "success" alongside "Could not bypass").
 
-The rule is structural, not a vendor list: does the rendered page still carry
-prose? Hard challenges (Cloudflare, PerimeterX) must still block regardless.
+The rule is structural, not a vendor list: does the page still carry prose?
+Content is now judged from the HTML *snapshot* (``page_source`` parsed in-process)
+rather than reading each ``<p>.text`` live — the live read cost up to 124s on
+heavy pages (one WebDriver round-trip per element, each forcing a layout reflow)
+while the browser itself stayed responsive. Hard challenges (Cloudflare,
+PerimeterX) must still block regardless of lingering prose.
 """
 
 import pytest
@@ -15,31 +19,41 @@ import pytest
 from src.crawler import ContentExtractor
 
 
+def _page(paragraphs):
+    """Wrap paragraph strings in a minimal article document."""
+    body = "".join(f"<p>{p}</p>" for p in paragraphs)
+    return f"<html><body><article>{body}</article></body></html>"
+
+
+# 8 substantial paragraphs — clears both the >=5 paragraph and >=1200 char bars.
+_SENTENCE = (
+    "A paragraph of real article text that runs on for a while and keeps going. "
+)
+PROSE_HTML = _page([_SENTENCE * 4 for _ in range(8)])
+# 6 paragraphs (clears the count bar) but far under the char bar — an
+# interstitial, not a story; exercises the char threshold specifically.
+THIN_HTML = _page(["Enable JavaScript and cookies to continue."] * 6)
+# No paragraphs at all.
+EMPTY_HTML = "<html><body><div>Loading…</div></body></html>"
+
+
 class FakeElement:
-    def __init__(self, text=""):
-        self.text = text
+    pass
 
 
 class FakeDriver:
-    """Answers CSS queries from a {selector_substring: [elements]} map."""
+    """Serves the content snapshot via ``page_source`` and answers challenge
+    selectors via ``find_elements`` (which is all ``_detect_captcha_or_challenge``
+    still uses live)."""
 
-    def __init__(self, matches, page_source="<html><body>page</body></html>"):
-        self._matches = matches
+    def __init__(self, page_source, challenge_selectors=()):
         self.page_source = page_source
+        self._challenge = set(challenge_selectors)
         self.title = "A story headline"
         self.current_url = "https://example.com/news/story"
 
     def find_elements(self, by, selector):
-        # Exact match only. Substring matching bites here: the paragraph key
-        # "p" is a substring of "iframe[src*='recaptcha']", which would make
-        # every selector return prose.
-        if "p" in self._matches and selector == "article p, main p, p":
-            return self._matches["p"]
-        return self._matches.get(selector, [])
-
-
-PROSE = [FakeElement("A paragraph of real article text that runs on. " * 4)] * 8
-THIN = [FakeElement("Enable JavaScript and cookies to continue")]
+        return [FakeElement()] if selector in self._challenge else []
 
 
 @pytest.fixture
@@ -48,22 +62,23 @@ def extractor():
 
 
 def test_article_prose_is_recognised(extractor):
-    assert extractor._page_has_article_content(FakeDriver({"p": PROSE})) is True
+    assert extractor._page_has_article_content(FakeDriver(PROSE_HTML)) is True
 
 
 def test_interstitial_is_not_mistaken_for_an_article(extractor):
-    assert extractor._page_has_article_content(FakeDriver({"p": THIN})) is False
+    assert extractor._page_has_article_content(FakeDriver(THIN_HTML)) is False
 
 
 def test_no_paragraphs_at_all(extractor):
-    assert extractor._page_has_article_content(FakeDriver({})) is False
+    assert extractor._page_has_article_content(FakeDriver(EMPTY_HTML)) is False
 
 
 def test_probe_failure_does_not_assert_content(extractor):
-    """If the probe cannot tell, it must not claim the page is fine."""
+    """If the probe cannot read the page, it must not claim the page is fine."""
 
     class Broken:
-        def find_elements(self, *_a):
+        @property
+        def page_source(self):
             raise RuntimeError("driver gone")
 
     assert extractor._page_has_article_content(Broken()) is False
@@ -71,26 +86,26 @@ def test_probe_failure_does_not_assert_content(extractor):
 
 def test_signin_widget_on_a_real_article_does_not_block(extractor):
     """The case that cost ~86s per article."""
-    driver = FakeDriver({"p": PROSE, "iframe[src*='recaptcha']": [FakeElement()]})
+    driver = FakeDriver(PROSE_HTML, {"iframe[src*='recaptcha']"})
 
     assert extractor._detect_captcha_or_challenge(driver) is False
 
 
 def test_recaptcha_on_a_contentless_page_still_blocks(extractor):
     """Same widget, no article — that is a wall and must be treated as one."""
-    driver = FakeDriver({"p": THIN, "iframe[src*='recaptcha']": [FakeElement()]})
+    driver = FakeDriver(THIN_HTML, {"iframe[src*='recaptcha']"})
 
     assert extractor._detect_captcha_or_challenge(driver) is True
 
 
 def test_cloudflare_challenge_blocks_even_with_prose(extractor):
     """Hard challenges are not exempted by lingering markup."""
-    driver = FakeDriver({"p": PROSE, ".cf-challenge-form": [FakeElement()]})
+    driver = FakeDriver(PROSE_HTML, {".cf-challenge-form"})
 
     assert extractor._detect_captcha_or_challenge(driver) is True
 
 
 def test_perimeterx_blocks_even_with_prose(extractor):
-    driver = FakeDriver({"p": PROSE, "#px-captcha": [FakeElement()]})
+    driver = FakeDriver(PROSE_HTML, {"#px-captcha"})
 
     assert extractor._detect_captcha_or_challenge(driver) is True


### PR DESCRIPTION
## What

`_page_has_article_content` read each `<p>.text` **live** — one WebDriver round-trip per element, each forcing a rendered-text layout reflow. This replaces that with a single `page_source` snapshot parsed by BeautifulSoup in-process.

## Why (measured, not asserted)

Instrumented on the #391 validation run (image `4a58b27`, in-image code verified before trusting logs). Paired per-call split from the extract-step `main` container:

| phase | median | max |
| --- | --- | --- |
| `driver_ping` (no-DOM round-trip) | 0.13s | **1.73s** |
| `pha_find_elements` (1 round-trip) | 0.03s | **0.41s** |
| `pha_text_loop` (40× `.text`) | 0.97s | **124.50s** |

On the pathological article the browser answered `driver_ping` in 1.73s and `find_elements` in 0.41s while the `.text` loop alone took **124.5s**. So the cost is the per-element `.text` round-trips (each forcing a rendered-text reflow), **not** an unresponsive browser. Post-stop `page_source` reads are ~0.1–0.2s; the char count then runs in-process with zero further round-trips.

## Architecture

Article **body text comes from the captured HTML**, not from live visible-element reads. Live visible-element identification is reserved for the two cases that actually need visibility — closing a modal, and classifying an overlay as paywall-vs-ad — which stay out of this snapshot body-text check.

## Semantic note

`get_text()` is `textContent`, not rendered/visible text. For "is there article-length body text here" that is correct. A paywall that **CSS-hides** an article still present in the DOM would read as content-bearing — but that's the paywall-vs-ad *visibility* decision, which belongs to the separate visible-element path, not here. Server-truncated paywalls (body absent from the DOM) still read empty.

## Instrumentation (gated)

Adds `_decompose_text_cost`, gated by `SELENIUM_TEXT_DECOMPOSE=1` (off in prod), timing a single in-page `textContent` vs `innerText` read to settle round-trip-chattiness vs forced-reflow on the next validation run.

## Tests

`tests/crawler/test_captcha_vs_widget.py` rewritten to drive the snapshot path (fake serves `page_source`; `find_elements` kept for challenge selectors `_detect_captcha_or_challenge` still uses). 8/8 pass. Local pre-push mirror green incl. the docker Postgres suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)