### PR TITLE
fix(scripts): let CREATE INDEX CONCURRENTLY actually run outside a transaction

### DIFF
--- a/scripts/backfill_entities_extracted_at.py
+++ b/scripts/backfill_entities_extracted_at.py
@@ -118,9 +118,18 @@ def main() -> int:
         stamped = conn.execute(BACKFILL_SQL).rowcount
         print(f"backfilled entities_extracted_at on {stamped:,} articles")
 
-    # CONCURRENTLY cannot run inside a transaction block.
+    # CONCURRENTLY cannot run inside a transaction block, and getting there
+    # takes both of the steps below. A bare COMMIT does not do it: the
+    # connection begins a transaction implicitly, so the COMMIT only ends the
+    # block that the next statement reopens. AUTOCOMMIT alone does not do it
+    # either, because DatabaseManager hands out a process-wide singleton engine
+    # whose pool has just served the backfill above — a connection checked back
+    # out of that pool still arrives inside a transaction, and the statement
+    # fails with 25001 exactly as before. Disposing the pool first forces a new
+    # connection, which is the only state AUTOCOMMIT reliably applies to.
+    engine.dispose()
     with engine.connect() as conn:
-        conn.execute(text("COMMIT"))
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
         conn.execute(text("SET statement_timeout='600s'"))
         conn.execute(CREATE_INDEX_SQL)
         print("partial index ensured (idx_articles_pending_entities)")


### PR DESCRIPTION
## What

`scripts/backfill_entities_extracted_at.py` failed at its last step every time it ran:

```
25001 CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

leaving the column added and ~122k rows backfilled but **no partial index** — the half-applied state the script's own docstring warns against. Hit for real applying this to production; the index had to be created by hand.

## Why the obvious fix isn't enough

> Note: an earlier revision of this branch (and this PR's original description) claimed `AUTOCOMMIT` alone was the fix. Testing against production showed that is **not** true. Corrected below.

The intent was already in the code as a bare `COMMIT` before the statement, but that doesn't opt a connection out of transactions: one begins implicitly, so the `COMMIT` closed a block the next statement reopened.

Switching to the `AUTOCOMMIT` isolation level is **necessary and still not sufficient**. `DatabaseManager` caches a process-wide engine in `_SHARED_ENGINES`, so by this point the pool has already served the backfill transaction above, and a connection checked back out of that pool arrives inside a transaction regardless of the isolation level requested.

Each of these reproduced `25001` against production on the shared engine:

| approach | result |
| --- | --- |
| bare `COMMIT` (original) | ❌ 25001 |
| connection-level `AUTOCOMMIT` | ❌ 25001 |
| engine-level `AUTOCOMMIT` | ❌ 25001 |
| raw DBAPI conn, `autocommit=True` | ❌ 25001 |
| **`engine.dispose()` then `AUTOCOMMIT`** | ✅ |

The same code against a freshly built engine succeeds, which is what pointed at the pool. Disposing it forces a genuinely new connection, and that is the state `AUTOCOMMIT` applies to.

## Verification

Ran the corrected script end to end against production (exit 0):

```
articles=151,987  with_entities=122,714  pending=788
column ensured
backfilled entities_extracted_at on 0 articles
partial index ensured (idx_articles_pending_entities)   <- used to raise here
```

The script is idempotent, so this is the difference between one clean run and a half-applied schema someone finishes by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)