### PR TITLE
feat(auth): eType login mechanism for the Newport Miner paywall

### DIFF
--- a/scripts/configure_publisher_auth.py
+++ b/scripts/configure_publisher_auth.py
@@ -57,6 +57,20 @@ Configure the Port Townsend Leader (SimpleCirc)::
 Note that SimpleCirc publishers have no password: the secret payload is
 ``{"username": "<subscriber email>", "zip": "<billing ZIP on the account>"}``.
 
+Configure the Newport Miner (eType metered paywall)::
+
+    python scripts/configure_publisher_auth.py \
+        --host www.pendoreillerivervalley.com \
+        --dataset WSU Washington State \
+        --auth-type etype \
+        --secret-name publisher-auth-pendoreillerivervalley-com \
+        --config '{"login_url":
+                     "https://www.pendoreillerivervalley.com/account/etype-login"}'
+
+eType publishers have a *second*, unrelated site login at ``/account/login``;
+subscriber credentials belong to ``/account/etype-login`` and are rejected by
+the other one.
+
 Disable authenticated extraction for a publisher::
 
     python scripts/configure_publisher_auth.py --host www.spokesman.com --disable
@@ -103,7 +117,7 @@ def _parse_args(argv=None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--auth-type",
-        choices=["auth0", "form", "newzware", "simplecirc"],
+        choices=["auth0", "form", "newzware", "simplecirc", "etype"],
         help="Login mechanism (required unless --disable)",
     )
     parser.add_argument(

--- a/src/crawler/authenticated_login.py
+++ b/src/crawler/authenticated_login.py
@@ -5,7 +5,7 @@ session cookies carry through to subsequent (paywalled) article fetches. Whether
 any individual story is paywalled is decided dynamically by the publisher; this
 module simply establishes an authenticated session for the domain.
 
-Four login mechanisms are supported:
+Five login mechanisms are supported:
 
 * ``auth0`` – Auth0 Universal Login (OAuth2 / OIDC with PKCE). The form only
   renders when reached via ``/authorize`` with a fresh, valid
@@ -19,6 +19,9 @@ Four login mechanisms are supported:
 * ``simplecirc`` – the SimpleCirc subscriber form, which has no password: the
   subscriber authenticates with their email (or account number) plus the
   billing ZIP code on the account.
+* ``etype`` – the eType Services metered paywall, whose login form is guarded
+  by an invisible reCAPTCHA v3 that locks the submit button until Google's
+  script resolves. The form is submitted directly to sidestep that lock.
 
 The password-based mechanisms handle "identifier-first" flows where the password
 field only appears after the email is submitted.
@@ -589,6 +592,114 @@ def _login_simplecirc(driver, cfg: dict, creds: dict) -> bool:
     return True
 
 
+# The eType login form. Selectors are keyed off the Symfony form name rather
+# than the generic candidate lists, because the login field is a bare
+# ``type="text"`` input named ``etype_login[login]`` — it carries neither
+# "email" nor "user" in its name or id, so EMAIL_CANDIDATES cannot find it.
+ETYPE_FORM_NAME = "etype_login"
+ETYPE_LOGIN_SELECTOR = 'form[name="etype_login"] input[name="etype_login[login]"]'
+ETYPE_PASSWORD_SELECTOR = 'form[name="etype_login"] input[name="etype_login[password]"]'
+# eType returns one generic message for a bad password, an unknown account and
+# a lapsed subscription alike.
+ETYPE_FAILURE_TEXT = "Incorrect login details or subscription has expired"
+
+
+def _login_etype(driver, cfg: dict, username: str, password: str) -> bool:
+    """Log in through an eType Services paywall (e.g. the Newport Miner).
+
+    eType meters access with an ``_etype_fv`` cookie carrying ``{count, total}``
+    — a small daily allowance of full articles, after which the publisher serves
+    a truncated stub. An authenticated session is not metered at all, so the
+    cookie is never set once this succeeds.
+
+    The form cannot be driven by clicking its submit button. The page loads
+    reCAPTCHA v3 (``<body data-rc="...">``) and holds a ``buttonLock`` on the
+    submit handler until Google's script resolves a token into the hidden
+    ``etype_login[recaptcha_response]`` field. In a headless pod that script is
+    slow, proxied, or scored as automation, so the click can hang indefinitely.
+    The server does not actually verify the token, so we fill the fields and
+    call ``HTMLFormElement.submit()``, which bypasses the onsubmit handler (and
+    therefore the lock) entirely.
+    """
+    login_url = cfg.get("login_url")
+    if not login_url:
+        logger.warning("etype login requires login_url in auth_config")
+        return False
+
+    login_sel = cfg.get("email_selector") or ETYPE_LOGIN_SELECTOR
+    pass_sel = cfg.get("password_selector") or ETYPE_PASSWORD_SELECTOR
+    form_timeout = float(cfg.get("form_timeout", 20))
+    failure_text = cfg.get("failure_text", ETYPE_FAILURE_TEXT)
+
+    try:
+        driver.set_page_load_timeout(45)
+    except Exception:
+        pass
+    try:
+        driver.get(login_url)
+    except Exception as exc:
+        logger.warning("etype login: navigation to login URL failed: %s", exc)
+
+    login_el = None
+
+    def _form_present(d):
+        nonlocal login_el
+        login_el, _ = _find_first(d, [login_sel])
+        return login_el is not None
+
+    if not _wait_for(driver, _form_present, form_timeout):
+        logger.warning("etype login: login field not found")
+        return False
+
+    pass_el, _ = _find_first(driver, [pass_sel])
+    if not pass_el:
+        logger.warning("etype login: password field not found")
+        return False
+
+    login_el.clear()
+    login_el.send_keys(username)
+    pass_el.clear()
+    pass_el.send_keys(password)
+
+    # Submit the form element itself, not the button — see the docstring.
+    form_name = cfg.get("form_name") or ETYPE_FORM_NAME
+    try:
+        submitted = driver.execute_script(
+            "var f = document.forms[arguments[0]];"
+            "if (!f) { return false; } f.submit(); return true;",
+            form_name,
+        )
+    except Exception as exc:
+        logger.warning("etype login: direct form submit failed: %s", exc)
+        return False
+    if submitted is False:
+        logger.warning("etype login: form '%s' not present on the page", form_name)
+        return False
+
+    time.sleep(3)
+
+    if failure_text and failure_text.lower() in _page_source(driver).lower():
+        logger.warning("etype login: credentials were rejected")
+        return False
+
+    # A rejected login re-renders the login form at the same path; a successful
+    # one redirects to the site root (or to ``app_redirect`` when the login URL
+    # carries one).
+    login_path = urllib.parse.urlparse(login_url).path.rstrip("/")
+    current_path = urllib.parse.urlparse(driver.current_url).path.rstrip("/")
+    if current_path == login_path:
+        logger.warning("etype login: still on the login page after submit")
+        return False
+
+    success_text = (cfg.get("success_text") or "").strip()
+    if success_text and success_text.lower() not in _page_source(driver).lower():
+        logger.warning(
+            "etype login: success marker '%s' not found after submit", success_text
+        )
+        return False
+    return True
+
+
 def perform_login(
     driver,
     *,
@@ -600,11 +711,12 @@ def perform_login(
 ) -> bool:
     """Log into a publisher on ``driver``. Returns True on success.
 
-    ``auth_type`` selects the mechanism ('auth0', 'form', 'newzware' or
-    'simplecirc'). ``auth_config`` carries the non-secret parameters
+    ``auth_type`` selects the mechanism ('auth0', 'form', 'newzware',
+    'simplecirc' or 'etype'). ``auth_config`` carries the non-secret parameters
     (domain/client_id/redirect_uri/scope for auth0; login_url/selectors/
     success_text for form; login_url/return_host/success_text for newzware;
-    login_url/selectors for simplecirc).
+    login_url/selectors for simplecirc; login_url/selectors/failure_text for
+    etype).
 
     Credentials may be passed either as ``username``/``password`` or as a
     ``credentials`` dict (see :func:`resolve_auth_credentials`). The dict form is
@@ -633,6 +745,8 @@ def perform_login(
             return _login_auth0(driver, cfg, user, pw)
         if mechanism == "newzware":
             return _login_newzware(driver, cfg, user, pw)
+        if mechanism == "etype":
+            return _login_etype(driver, cfg, user, pw)
         return _login_form(driver, cfg, user, pw)
     except Exception as exc:
         logger.error("Authenticated login raised: %s", exc, exc_info=True)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -683,8 +683,9 @@ class Source(Base):
         Boolean, default=False, nullable=False, server_default=text("FALSE")
     )
     # Login mechanism: 'auth0' (OAuth2/OIDC universal login), 'form' (plain
-    # username/password form POST), 'newzware' (Newzware SSO handoff) or
-    # 'simplecirc' (SimpleCirc subscriber form: email + billing ZIP, no password).
+    # username/password form POST), 'newzware' (Newzware SSO handoff),
+    # 'simplecirc' (SimpleCirc subscriber form: email + billing ZIP, no password)
+    # or 'etype' (eType Services metered paywall, reCAPTCHA-locked submit).
     auth_type = Column(String(32), nullable=True)
     # Name of the secret (GCP Secret Manager id, or env-override key) holding
     # the subscriber credentials for this publisher. Convention:

--- a/tests/crawler/test_authenticated_login.py
+++ b/tests/crawler/test_authenticated_login.py
@@ -838,3 +838,222 @@ def test_newzware_login_success_without_success_marker():
         password="pw",
     )
     assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# _login_etype: eType Services metered paywall
+# ---------------------------------------------------------------------------
+ETYPE_LOGIN_URL = "https://www.pendoreillerivervalley.com/account/etype-login"
+
+
+def _etype_driver(*, on_submit, page_source=""):
+    """Fake eType login page.
+
+    The real page's login field is a bare ``type="text"`` input named
+    ``etype_login[login]``, so the generic EMAIL_CANDIDATES cannot match it —
+    the fake deliberately exposes nothing under those selectors.
+    """
+    login_field = FakeElement(attrs={"type": "text"})
+    password = FakeElement(attrs={"type": "password"})
+    # The reCAPTCHA-locked submit button. Clicking it in a headless pod can hang
+    # forever, so the mechanism must never touch it.
+    submit = FakeElement(tag="button")
+
+    def _locked_click():
+        raise AssertionError("etype login must not click the reCAPTCHA-locked button")
+
+    submit.click = _locked_click  # type: ignore[method-assign]
+
+    driver = FakeDriver(
+        {
+            al.ETYPE_LOGIN_SELECTOR: [login_field],
+            al.ETYPE_PASSWORD_SELECTOR: [password],
+            'button[type="submit"]': [submit],
+        },
+        login_url=ETYPE_LOGIN_URL,
+        success_url=None,
+    )
+    driver.current_url = ETYPE_LOGIN_URL
+    driver.page_source = page_source
+
+    def _execute_script(_script, *args):
+        on_submit(driver)
+        return True
+
+    driver.execute_script = _execute_script  # type: ignore[attr-defined]
+    return driver, login_field, password
+
+
+def test_etype_login_success_submits_form_directly():
+    def _logged_in(driver):
+        # A successful login redirects off the login page to the site root.
+        driver.current_url = "https://www.pendoreillerivervalley.com/"
+        driver.page_source = "<html>Log out</html>"
+
+    driver, login_field, password = _etype_driver(on_submit=_logged_in)
+
+    ok = al.perform_login(
+        driver,
+        auth_type="etype",
+        auth_config={"login_url": ETYPE_LOGIN_URL},
+        username="subscriber@example.edu",
+        password="pw",
+    )
+    assert ok is True
+    assert login_field.value == "subscriber@example.edu"
+    assert password.value == "pw"
+
+
+def test_etype_login_submits_the_form_element_not_the_button():
+    # Regression guard: the submit button is held by a reCAPTCHA v3 buttonLock,
+    # so the mechanism must submit the form element by name instead.
+    calls = []
+
+    def _logged_in(driver):
+        driver.current_url = "https://www.pendoreillerivervalley.com/"
+
+    driver, _login, _password = _etype_driver(on_submit=_logged_in)
+    inner = driver.execute_script
+
+    def _record(script, *args):
+        calls.append((script, args))
+        return inner(script, *args)
+
+    driver.execute_script = _record  # type: ignore[attr-defined]
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": ETYPE_LOGIN_URL},
+            username="u",
+            password="pw",
+        )
+        is True
+    )
+    assert len(calls) == 1
+    script, args = calls[0]
+    assert "document.forms" in script and ".submit()" in script
+    assert args == (al.ETYPE_FORM_NAME,)
+
+
+def test_etype_login_rejected_credentials_returns_false():
+    def _rejected(driver):
+        # eType re-renders the login page with one generic message.
+        driver.page_source = (
+            "<html>Incorrect login details or subscription has expired.</html>"
+        )
+
+    driver, _login, _password = _etype_driver(on_submit=_rejected)
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": ETYPE_LOGIN_URL},
+            username="theminer",
+            password="pw",
+        )
+        is False
+    )
+
+
+def test_etype_login_still_on_login_page_is_failure():
+    # No failure text, but the URL never left the login path.
+    driver, _login, _password = _etype_driver(on_submit=lambda d: None)
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": ETYPE_LOGIN_URL},
+            username="u",
+            password="pw",
+        )
+        is False
+    )
+
+
+def test_etype_login_ignores_query_string_when_comparing_paths():
+    # The publisher links to the login page with ?app_redirect=<article>; the
+    # success test must compare paths, not whole URLs.
+    def _logged_in(driver):
+        driver.current_url = (
+            "https://www.pendoreillerivervalley.com/article/5813,ballot-fight"
+        )
+
+    driver, _login, _password = _etype_driver(on_submit=_logged_in)
+    url = ETYPE_LOGIN_URL + "?app_redirect=https%3A%2F%2Fexample.com%2Farticle%2F1"
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": url},
+            username="u",
+            password="pw",
+        )
+        is True
+    )
+
+
+def test_etype_login_missing_form_returns_false():
+    driver, _login, _password = _etype_driver(on_submit=lambda d: None)
+    driver.execute_script = lambda *_a, **_k: False  # type: ignore[attr-defined]
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": ETYPE_LOGIN_URL},
+            username="u",
+            password="pw",
+        )
+        is False
+    )
+
+
+def test_etype_login_honors_success_text():
+    def _logged_in(driver):
+        driver.current_url = "https://www.pendoreillerivervalley.com/"
+        driver.page_source = "<html>nothing useful here</html>"
+
+    driver, _login, _password = _etype_driver(on_submit=_logged_in)
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": ETYPE_LOGIN_URL, "success_text": "Log out"},
+            username="u",
+            password="pw",
+        )
+        is False
+    )
+
+
+def test_etype_login_login_field_not_found_returns_false():
+    driver = FakeDriver({}, login_url=ETYPE_LOGIN_URL, success_url=None)
+    driver.current_url = ETYPE_LOGIN_URL
+
+    assert (
+        al.perform_login(
+            driver,
+            auth_type="etype",
+            auth_config={"login_url": ETYPE_LOGIN_URL, "form_timeout": 0.01},
+            username="u",
+            password="pw",
+        )
+        is False
+    )
+
+
+def test_etype_login_requires_login_url():
+    driver = FakeDriver({}, login_url=ETYPE_LOGIN_URL, success_url=None)
+
+    assert (
+        al.perform_login(
+            driver, auth_type="etype", auth_config={}, username="u", password="pw"
+        )
+        is False
+    )


### PR DESCRIPTION
The Newport Miner (www.pendoreillerivervalley.com) meters access with an eType Services paywall: an `_etype_fv` cookie carrying {count, total} grants 3 full articles, after which the publisher serves a ~200-char stub. Measured against the live site — article 5488 returns 209 chars anonymously once the meter is spent, and 7842 chars with a session.

Two details make this its own mechanism rather than `form` config:

* The login field is a bare `type="text"` input named `etype_login[login]`. It carries neither "email" nor "user" in its name or id, so not one of the EMAIL_CANDIDATES matches it — verified against the live page markup.
* The page loads reCAPTCHA v3 (`<body data-rc=...>`) and holds a buttonLock on the submit handler until Google's script resolves a token. In a headless pod that click can hang. The server does not verify the token, so we fill the fields and call HTMLFormElement.submit(), which bypasses the onsubmit handler and its lock.

Success is judged by leaving the login path plus the absence of eType's one generic rejection message ("Incorrect login details or subscription has expired"), which it returns for a bad password, an unknown account and a lapsed subscription alike.

Note these publishers also run a second, unrelated site login at /account/login; subscriber credentials belong to /account/etype-login and are rejected by the other one.