### PR TITLE
test(smoke): assert wire bylines aren't corrupted, not that AP wrote them

### DIFF
--- a/tests/e2e/test_production_smoke.py
+++ b/tests/e2e/test_production_smoke.py
@@ -1263,25 +1263,44 @@ class TestContentCleaningPipeline:
                              OR author ILIKE '%reuters%')
                         AND primary_label IN ('wire', 'syndicated')
                         THEN 1
-                    END) as wire_correctly_labeled
+                    END) as wire_correctly_labeled,
+                    COUNT(CASE
+                        WHEN status = 'wire'
+                        AND author IS NOT NULL
+                        AND btrim(author) = ''
+                        THEN 1
+                    END) as wire_blank_author
                 FROM articles
                 WHERE extracted_at >= NOW() - INTERVAL '7 days'
             """)).fetchone()
 
-            wire_count, local_count, wire_with_svc, labeled = result
+            wire_count, local_count, wire_with_svc, labeled, blank_author = result
 
             # Should have some wire articles detected
             assert (
                 wire_count > 0
             ), "No wire articles detected - wire service detection may be failing"
 
-            # Most wire articles should have wire service author text preserved
+            # How much wire copy carries a service byline is a property of the
+            # source mix, not of extraction health. Roughly 80% of wire articles
+            # carry no byline at all, and the syndicated copy that does carry one
+            # is bylined to the reporter rather than the service, so the share
+            # naming AP/Reuters has sat between 2% and 18% of authored wire
+            # articles every month measured. This once asserted a floor of 70%,
+            # which no month has ever met. Track it; do not gate on it.
             if wire_count > 0:
-                preservation_ratio = wire_with_svc / wire_count
-                assert preservation_ratio > 0.7, (
-                    f"Low wire service preservation: {preservation_ratio:.1%} - "
-                    f"bylines may be corrupted"
+                service_share = wire_with_svc / wire_count
+                logger.info(
+                    f"Wire service byline share: {service_share:.1%} "
+                    f"({wire_with_svc}/{wire_count} wire articles)"
                 )
+
+            # Corruption, unlike the share above, is unambiguous: a byline that
+            # survived extraction as whitespace means something wrote over it.
+            assert blank_author == 0, (
+                f"{blank_author} wire articles have blank (whitespace-only) "
+                f"authors - extraction may be corrupting bylines"
+            )
 
             # Wire articles should have consistent labeling
             if wire_with_svc > 0:


### PR DESCRIPTION
## What

`test_wire_service_detection_and_classification` required that **over 70%** of wire articles carry a wire-service name in `author`, reporting any shortfall as *"bylines may be corrupted"*. Production sits at **0.4%**.

The bylines are not corrupted. The assertion mistook corpus composition for extraction health.

## Evidence

Measured against production:

- **~80% of wire articles have no byline at all** (380 of 459 in the last 7 days are `NULL author`; 0 are blank). A wire article cannot "preserve" a service name in a field that was never populated.
- That is **not new** — the NULL-author rate for wire has been stable all year, so no regression and nothing coinciding with the recent Selenium work:

  | month | wire | NULL author |
  | --- | --- | --- |
  | 2026-01 | 1,821 | 75.0% |
  | 2026-02 | 6,230 | 85.7% |
  | 2026-03 | 9,322 | 86.4% |
  | 2026-04 | 2,196 | 81.1% |
  | 2026-05 | 218 | 82.1% |
  | 2026-07 | 887 | 79.9% |

- The wire copy that **does** carry a byline is bylined to the **reporter**, not the service — `Rudi Keller, Missouri Independent`, `Jason Hancock`, `Anna Spoerre | Missouri Independent`. That is correct: wire status comes from mcmetadata `wire_hints` and the content-type detector's url/byline/copyright/content tiers, none of which require `author` to name a service.
- Among *authored* wire articles, the share naming AP/Reuters has been **2–18% every month over seven months** — so the 70% floor could not have held in any of them. It never has: the smoke suite has **no successful run in its last 100**.

Removing a gate that cannot pass costs no coverage.

## What it asserts now

The thing the docstring actually claims to check, and the only unambiguous evidence of corruption available here — **no wire article should carry a whitespace-only author**, because a byline that survived extraction as blank means something wrote over it. Verified against production: currently `0`.

The service share is kept as a **logged metric**, alongside the labeling ratio already logged just below it.

## Scope

This does not clear the suite. 11 other assertions still fail, including at least one worth real attention (`Statement timeout is 0` — the smoke harness's own connection authenticates as a role without the `statement_timeout=120s` that `mizzou_user` actually carries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)