### PR TITLE
perf(selenium): escalate on a missing body, not on missing metadata

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -2925,16 +2925,25 @@ class ContentExtractor:
 
         # Try Selenium final fallback for remaining missing fields when not already attempted
         if missing_fields and SELENIUM_AVAILABLE and not selenium_attempted_primary:
-            fallback_reason = (
-                "selenium_secondary" if skip_http_methods else "http_fallback"
-            )
-            self._run_selenium_extraction(
-                url,
-                result,
-                metrics,
-                fallback_reason,
-                missing_fields=missing_fields,
-            )
+            if self._selenium_would_add_value(result, missing_fields):
+                fallback_reason = (
+                    "selenium_secondary" if skip_http_methods else "http_fallback"
+                )
+                self._run_selenium_extraction(
+                    url,
+                    result,
+                    metrics,
+                    fallback_reason,
+                    missing_fields=missing_fields,
+                )
+            else:
+                logger.info(
+                    "Skipping Selenium for %s: body already captured (%d chars); "
+                    "missing %s is not recoverable by a second capture",
+                    url,
+                    len((result.get("content") or result.get("text") or "").strip()),
+                    missing_fields,
+                )
 
         detection_info = self._last_bot_protection_detection
         # If bot protection was detected in newspaper4k and Selenium also failed, raise RateLimitError
@@ -5911,6 +5920,43 @@ class ContentExtractor:
     # design, so the threshold separates them without naming any of them.
     ARTICLE_CONTENT_MIN_CHARS = 1200
     ARTICLE_CONTENT_MIN_PARAGRAPHS = 5
+
+    # A body this short is a teaser, not the story — a browser may still reveal the
+    # real one, so Selenium stays on the table below this.
+    #
+    # 400 chars is ~66 words: shorter than a typical 1-3 paragraph paywall teaser,
+    # and short enough that only 14.8% of genuinely complete articles fall under it.
+    # Local news runs short — over 30 days the median `labeled` article was 2,190
+    # chars (~365 words) and the 10th percentile 279 — so a higher cut wastes the
+    # saving: 1200 chars would still escalate on 31% of complete stories.
+    PAYWALL_STUB_MAX_CHARS = 400
+
+    def _selenium_would_add_value(self, result: dict, missing_fields: list) -> bool:
+        """Whether launching a browser can plausibly recover the missing fields.
+
+        Selenium earns its cost when it is the ONLY way to get the page: the site
+        blocks bots, or the body needs interaction (closing a modal) or JS to
+        render. It earns nothing as a metadata backfill — a second capture of the
+        same HTML cannot beat the parsers that already ran on it.
+
+        Measured over 30 days of production telemetry: of **6,366** extractions
+        where a non-Selenium method already supplied the content, Selenium went on
+        to supply the author exactly **once** and the publish_date **zero** times.
+        Yet that path was ~92% of all Selenium invocations and consumed ~67% of
+        worker capacity. Many of those articles simply have no byline to find.
+
+        So gate on the BODY, not on metadata: escalate when the content is absent
+        or short enough to be a teaser, and skip when we already hold a full story
+        and are only missing author/date.
+        """
+        content = (result.get("content") or result.get("text") or "").strip()
+        if not content:
+            return True  # nothing captured at all — Selenium is the last resort
+        if len(content) <= self.PAYWALL_STUB_MAX_CHARS:
+            return True  # teaser above a paywall; a real browser may reveal the body
+        # Full body in hand. Whatever metadata is still missing is missing from the
+        # page itself, and re-fetching it will not conjure it.
+        return False
 
     def _page_has_article_content(self, driver) -> bool:
         """Whether the captured page still carries a story.

--- a/tests/crawler/test_selenium_escalation_guard.py
+++ b/tests/crawler/test_selenium_escalation_guard.py
@@ -1,0 +1,87 @@
+"""Selenium escalates on a missing BODY, not on missing metadata.
+
+Selenium is the expensive last resort: it exists for pages a plain fetch cannot
+get — bot walls, modals, JS-rendered bodies. It was also being launched whenever
+*any* field was missing, which in practice meant chasing bylines over stories we
+had already captured in full.
+
+Production telemetry over 30 days: of 6,366 extractions where a non-Selenium
+method supplied the content, Selenium then supplied the author exactly ONCE and
+the publish_date ZERO times — while that path made up ~92% of all Selenium
+invocations and ~67% of worker capacity. Most of those articles simply have no
+byline to find.
+"""
+
+import pytest
+
+from src.crawler import ContentExtractor
+
+
+@pytest.fixture
+def extractor():
+    return ContentExtractor.__new__(ContentExtractor)
+
+
+FULL_BODY = "A paragraph of real article text that runs on. " * 60  # ~2800 chars
+TEASER = "Subscribers only. Sign in to continue reading."
+
+
+def test_full_body_missing_author_does_not_escalate(extractor):
+    """The case that burned ~67% of capacity for one success in 6,366."""
+    result = {"content": FULL_BODY, "title": "A story"}
+
+    assert extractor._selenium_would_add_value(result, ["author"]) is False
+
+
+def test_full_body_missing_author_and_date_does_not_escalate(extractor):
+    result = {"content": FULL_BODY}
+
+    assert (
+        extractor._selenium_would_add_value(result, ["author", "publish_date"]) is False
+    )
+
+
+def test_no_content_escalates(extractor):
+    """Nothing captured — a browser is the last resort and worth the cost."""
+    result = {"content": "", "title": "A story"}
+
+    assert extractor._selenium_would_add_value(result, ["content", "author"]) is True
+
+
+def test_missing_content_key_escalates(extractor):
+    assert extractor._selenium_would_add_value({}, ["content"]) is True
+
+
+def test_paywall_teaser_escalates(extractor):
+    """A stub above a paywall is not the story; a real browser may reveal it."""
+    result = {"content": TEASER, "title": "A story"}
+
+    assert extractor._selenium_would_add_value(result, ["content"]) is True
+
+
+def test_whitespace_only_body_escalates(extractor):
+    assert (
+        extractor._selenium_would_add_value({"content": "   \n\t "}, ["content"])
+        is True
+    )
+
+
+def test_text_field_counts_as_body(extractor):
+    """Some paths populate `text` rather than `content`."""
+    result = {"text": FULL_BODY}
+
+    assert extractor._selenium_would_add_value(result, ["author"]) is False
+
+
+def test_boundary_is_inclusive_of_stub_threshold(extractor):
+    """At exactly the threshold we still treat it as a teaser and escalate."""
+    at_limit = "x" * ContentExtractor.PAYWALL_STUB_MAX_CHARS
+    over_limit = "x" * (ContentExtractor.PAYWALL_STUB_MAX_CHARS + 1)
+
+    assert (
+        extractor._selenium_would_add_value({"content": at_limit}, ["author"]) is True
+    )
+    assert (
+        extractor._selenium_would_add_value({"content": over_limit}, ["author"])
+        is False
+    )


### PR DESCRIPTION
> **Stacked on #397** — base is `fix/mask-proxy-credentials`. Merge #397 first, then this retargets to `main` cleanly.

## The finding

Selenium ran whenever **any** field was missing. In practice that meant launching a browser to hunt a byline on stories already captured in full.

30 days of production telemetry (`final_field_attribution`):

| case | count |
|---|---|
| content won by a **non-Selenium** method | **6,366** |
| …Selenium then supplied the **author** | **1** |
| …Selenium then supplied the **publish_date** | **0** |
| content won by Selenium (primary extractor) | 1,188 |
| …and it also won the author | 117 |

Every useful Selenium author-win comes from a **full Selenium extraction on a bot-blocked site**. The metadata-backfill path succeeded **once in 6,366 tries** — while accounting for **~92% of Selenium invocations** (33 of 36 sampled were chasing `['author']`) and **~67% of worker capacity**. Many of those articles simply have no byline to find.

## The change

Gate escalation on the **body**, not on metadata:

- content **absent** → escalate (Selenium is the last resort)
- content **≤ 400 chars** → escalate (teaser over a paywall a real browser may unlock)
- **full body**, only author/date missing → **skip**

Sites that block bots or need interaction are unaffected — they escalate via `domain_required`/bot-protection, not this path.

## Why 400 chars

Chosen from the corpus, not taste. Share of genuinely complete (`labeled`) articles that fall below each cut:

| threshold | ~words | still escalates |
|---|---|---|
| ≤400 | 66w | **14.8%** |
| ≤900 | 150w | 25.4% |
| ≤1200 | 200w | 31.3% |

Local news runs short: median `labeled` article is 2,190 chars (~365 words), 10th percentile 279. A higher cut throws away most of the saving.

## Validation

- 8 new tests (`test_selenium_escalation_guard.py`), full pre-push suite green incl. docker Postgres
- **Pre-change baseline captured for comparison:** 417 articles in 141 min on 4 workers (**177/hr**), ~48 Selenium invocations/hr, all 223 sources

Re-running that same config after deploy gives a direct before/after, and settles the worker-count question (current sizing suggests ~1 worker for 1,004/day sustained, ~3 for the 2,900/day peak).

## Risk

This changes core extraction behaviour. The trade is explicit: we give up ~1 author per 6,366 articles to reclaim ~67% of capacity. Worth a validation run before trusting broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)