### PR TITLE
fix(telemetry): qualify articles by content, and stop tls_client failing silently

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -4129,20 +4129,39 @@ class ContentExtractor:
                     session = tls_client.Session(
                         client_identifier="chrome_143", random_tls_extension_order=False
                     )
+                    # tls_client is NOT requests-compatible: its execute_request
+                    # signature is (..., insecure_skip_verify, timeout_seconds,
+                    # proxy). Calling it with requests' names — proxies=/timeout=/
+                    # verify= — raises TypeError on the first one, so this rung
+                    # never actually ran and every request quietly fell through
+                    # to plain `requests`, losing the Chrome TLS fingerprint that
+                    # is the whole point of the rung.
                     tls_resp = session.get(
                         url,
                         headers=headers,
-                        proxies={"http": proxy_url, "https": proxy_url},
-                        timeout=30,
-                        verify=False,
+                        proxy=proxy_url,
+                        timeout_seconds=30,
+                        insecure_skip_verify=True,
                     )
                     response = tls_resp
-                except (
-                    Exception
-                ) as exc:  # pragma: no cover - optional dependency/fallback
+                except ImportError as exc:
+                    # Genuinely optional: not installed in this image.
                     logger.info(
-                        "tls_client not available or failed: %s; falling back to requests",
+                        "tls_client not installed (%s); falling back to requests",
                         exc,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive fallback
+                    # Installed but the call failed. Louder than ImportError on
+                    # purpose: the fallback still returns a page, so this degrades
+                    # silently and the capture rung disappears without anything
+                    # failing. That is exactly how the signature drift above went
+                    # unnoticed for 28 occurrences in a single sweep.
+                    logger.warning(
+                        "tls_client request failed (%s: %s); falling back to requests "
+                        "— the Chrome TLS fingerprint is NOT in effect for %s",
+                        type(exc).__name__,
+                        exc,
+                        url,
                     )
 
                 if response is None:

--- a/src/utils/comprehensive_telemetry.py
+++ b/src/utils/comprehensive_telemetry.py
@@ -7,6 +7,7 @@ methods, publishers, and error conditions to optimize extraction strategies.
 
 import json
 import logging
+import re
 import time
 from collections import defaultdict
 from collections.abc import Sequence
@@ -20,11 +21,204 @@ from src.telemetry.store import TelemetryStore, get_store
 logger = logging.getLogger(__name__)
 
 
+# An article is defined by what its text IS, not by how much of it there is.
+# Judging raw length answers the wrong question: 2,000 characters of navigation,
+# advertising and "subscribe to continue" passes any byte count while containing
+# no story, and a genuinely short local item fails one. So qualify in two steps —
+# discard the boilerplate, then ask whether prose survived.
+#
+# The vocabulary below is the language of walls and furniture, not of reporting.
+# It is deliberately phrase-level: bare words like "subscribe" appear inside real
+# articles ("subscribers to the service said..."), whole prompts do not.
+#
+# DERIVED, NOT GUESSED. Produced by diffing 15,656 hand-cleaned articles against
+# the same records as extracted (BigQuery mizzou_analytics.articles), keeping
+# only segments the cleaner removed on FOUR OR MORE distinct hosts — the test of
+# whether a phrase is site furniture or one publisher's prose. An earlier
+# hand-written list scored 2% recall against labelled data; these phrases are
+# what the corpus actually contains.
+#
+# Datelines ("KANSAS CITY, Mo.") and photo credits survive that diff too, but
+# they are article content being MOVED to another field rather than discarded,
+# so they are deliberately excluded here.
+_BOILERPLATE_MARKERS = (
+    # paywall / registration walls
+    "javascript is required for you to be able to read premium content",
+    "please enable it in your browser settings",
+    "login to continue reading",
+    "sign up for complimentary access",
+    "please log in to continue",
+    "need an account?",
+    "this item is available in full to subscribers",
+    "non-subscribers",
+    "click here to see your options for becoming a subscriber",
+    "otherwise, click here to view your options for subscribing",
+    "print and web subscribers",
+    "subscribe now!",
+    # consent / advertising furniture
+    "we use cookies to help our site function properly",
+    "featured local savings",
+    # comment-policy block (ships as many short lines, hence the fragments)
+    "please avoid obscene, vulgar, lewd",
+    "racist or sexually-oriented language",
+    "threats of harming another",
+    "person will not be tolerated",
+    "don't knowingly lie about anyone",
+    "no racism, sexism or any sort of -ism",
+    "that is degrading to another person",
+    "use the 'report' link on",
+    "each comment to let us know of abusive posts",
+    "we'd love to hear eyewitness",
+    "accounts, the history behind an article",
+    # recirculation
+    "previous post",
+    "next post",
+)
+
+# Minimum WORDS of surviving prose. Words, not characters, because the question
+# is whether someone wrote something. ~60 words is roughly the 400 characters the
+# Selenium guard uses, but measured on what is left after the walls come down
+# rather than on whatever bytes arrived.
+MIN_ARTICLE_WORDS = 60  # retained for callers; not used by looks_like_article
+
+# Function words. Their density is what separates written English from a scraped
+# control: prose is roughly a third function words, while a country dropdown, a
+# nav menu or a tag cloud is almost none.
+_FUNCTION_WORDS = frozenset(
+    "the a an and or but of to in on for with is are was were said he she it "
+    "that this from at by as has have had not".split()
+)
+
+# Below this density the text is a list, a form or a menu rather than writing.
+#
+# Derived from 1,036 labelled production extractions (2026-07-22 sample, ~40
+# Missouri publishers), not chosen by taste. Median function-word density was
+# 0.137 for bodies flagged as boilerplate/paywall and 0.286 for the rest — a 2x
+# separation. Measured operating points, after excluding empty bodies:
+#
+#     density < 0.12  ->  38% of flagged bodies caught,  2.5% collateral
+#     density < 0.16  ->  64% caught,                    4.9% collateral
+#     density < 0.20  ->  66% caught,                   10.8% collateral
+#
+# The known false positive is agate — sports scores, election returns, real
+# estate transfers — legitimate local copy carrying almost no function words.
+MIN_PROSE_DENSITY = 0.14
+
+# Share of words starting with a capital. Function-word density alone is fooled
+# by the single most common non-article in the corpus: the country dropdown
+# scraped from a registration form ("United States of America", "Commonwealth of
+# the ...", 5,308 chars, byte-identical across four hosts) scores 0.21 because
+# country names are full of "of" and "the". What gives it away is that nearly
+# every word is a proper noun.
+#
+# Measured on the labelled sample: median capitalisation was 0.664 for flagged
+# bodies against 0.217 for the rest — a cleaner 3x separation than density's 2x.
+# Together, `density < 0.14 or capitalisation > 0.60` catches 67% of flagged
+# bodies at 4.9% collateral, against 39% for density alone.
+MAX_CAPITALIZATION = 0.60
+
+# Words that belong to the plumbing of a website rather than to a story. Unlike
+# the phrase list above these are single words, so they are counted as a RATE
+# rather than matched: a story may mention a subscriber once, a registration
+# form says "account", "password" and "e-mail" every other line.
+_UTILITY_WORDS = re.compile(
+    r"\b(subscribe|subscriber|account|password|login|log in|sign up|e-?mail|"
+    r"cookies|advertisement|newsletter|click here|browser)\b",
+    re.IGNORECASE,
+)
+
+# Utility words per 100 words, above which the text is site plumbing.
+#
+# The sharpest of the three signals on the labelled sample: median rate 4.13 for
+# flagged bodies against 0.00 for the rest — most real articles contain none of
+# these words at all. Adding it took recall from 39% to 85%.
+MAX_UTILITY_WORD_RATE = 3.0
+
 # Proxy status codes for telemetry database (integer field)
 PROXY_STATUS_DISABLED = 0
 PROXY_STATUS_SUCCESS = 1
 PROXY_STATUS_FAILED = 2
 PROXY_STATUS_BYPASSED = 3
+
+
+def strip_boilerplate(body: str) -> str:
+    """Drop the segments of a body that are walls or furniture, not reporting.
+
+    Splits on line and sentence boundaries and discards any segment carrying a
+    boilerplate phrase. Segment-level rather than whole-body, so one "subscribe
+    today" line at the foot of a real story removes that line and keeps the
+    story — the reason a whole-body keyword test cannot be used for this.
+    """
+    if not body:
+        return ""
+    segments = re.split(r"[\n\r]+|(?<=[.!?])\s+", body)
+    kept = [
+        seg
+        for seg in segments
+        if seg.strip() and not any(m in seg.lower() for m in _BOILERPLATE_MARKERS)
+    ]
+    return " ".join(seg.strip() for seg in kept).strip()
+
+
+def prose_density(text: str) -> float:
+    """Share of words that are function words — how much this reads as writing.
+
+    Prose is roughly a third function words. A country dropdown, a nav menu or a
+    tag cloud is close to none, which is what makes this separate written English
+    from a scraped form control without knowing any site's markup.
+    """
+    words = re.findall(r"[a-zA-Z']+", text.lower())
+    if not words:
+        return 0.0
+    return sum(1 for w in words if w in _FUNCTION_WORDS) / len(words)
+
+
+def capitalization_ratio(text: str) -> float:
+    """Share of words beginning with a capital.
+
+    Reporting is mostly lowercase; a scraped list of proper nouns — countries,
+    place names, section menus — is mostly not. This is what catches the bodies
+    that slip past prose_density because their proper nouns happen to contain
+    function words.
+    """
+    words = re.findall(r"[A-Za-z][A-Za-z']*", text)
+    if not words:
+        return 0.0
+    return sum(1 for w in words if w[0].isupper()) / len(words)
+
+
+def utility_word_rate(text: str) -> float:
+    """Website-plumbing words per 100 words.
+
+    Shape signals miss text that reads like writing but is about the site rather
+    than the world — registration prompts, newsletter pitches, cookie notices.
+    Vocabulary catches those: most real articles use none of these words at all.
+    """
+    words = re.findall(r"[a-zA-Z']+", text)
+    if not words:
+        return 0.0
+    return 100 * len(_UTILITY_WORDS.findall(text)) / len(words)
+
+
+def looks_like_article(body: str | None) -> bool:
+    """Whether a body is a story rather than a wall, a form or a menu.
+
+    Content-first by design. A paywall prompt fails however many characters it
+    runs to, because what is measured is the writing that survives the strip —
+    not the byte count of whatever the page happened to return.
+    """
+    if not body or not body.strip():
+        return False
+    # No word-count floor. It was measured against the labelled sample and is
+    # actively harmful here: a >=60-word floor caught 2% of flagged bodies while
+    # failing 13.7% of good ones, because local news genuinely runs short. The
+    # two shape signals do the work; length does not.
+    stripped = strip_boilerplate(body)
+    if prose_density(stripped) < MIN_PROSE_DENSITY:
+        return False  # a list or a menu, not writing
+    if capitalization_ratio(stripped) > MAX_CAPITALIZATION:
+        return False  # a run of proper nouns: a dropdown, a section index
+    return utility_word_rate(stripped) <= MAX_UTILITY_WORD_RATE
 
 
 def proxy_status_to_int(status: str | None) -> int | None:
@@ -111,6 +305,14 @@ class ExtractionMetrics:
         self.methods_attempted.append(method_name)
         self.method_timings[method_name] = time.time()
 
+    def was_attempted(self, method_name: str) -> bool:
+        """Whether a method ran at all, regardless of which one won.
+
+        The honest answer to "did we pay for Selenium on this article?".
+        `successful_method` cannot answer it — see end_method.
+        """
+        return method_name in self.methods_attempted
+
     def end_method(
         self,
         method_name: str,
@@ -127,6 +329,13 @@ class ExtractionMetrics:
         if error:
             self.method_errors[method_name] = error
 
+        # NOTE: this is the FIRST method to return a result, not "the methods
+        # that ran". It is not a usage counter and must not be read as one.
+        # Selenium is usually invoked to backfill a field after an HTTP parser
+        # already won the content, so it leaves `successful_method` untouched —
+        # counting `successful_method = 'selenium'` understates how often
+        # Selenium actually ran by roughly 10x. Use `methods_attempted` (also
+        # persisted) or `was_attempted()` for that question.
         if success and not self.successful_method:
             self.successful_method = method_name
 
@@ -300,13 +509,17 @@ class ExtractionMetrics:
             if extraction_methods:
                 self.final_field_attribution = extraction_methods
 
-            self.content_length = len(final_result.get("content") or "")
-            has_title = bool(final_result.get("title"))
-            has_content = bool(final_result.get("content"))
-            # Match ContentExtractor logic: success if title OR meaningful content
-            # Allows articles with missing author/date to be successful
-            content_long_enough = has_content and self.content_length > 100
-            self.is_success = has_title or content_long_enough
+            body = final_result.get("content") or ""
+            self.content_length = len(body)
+            # An extraction succeeded when it came back with a story. Missing
+            # author or date does not make it a failure; a missing BODY does.
+            #
+            # This used to read `has_title or content_length > 100`, which let
+            # two kinds of non-article through: rows carrying a headline and no
+            # body at all, and paywall teasers a sentence or two long. Neither a
+            # raw character count nor a title fixes that, because a wall can be
+            # arbitrarily wordy — so qualify on what survives the boilerplate.
+            self.is_success = looks_like_article(body)
 
 
 class ComprehensiveExtractionTelemetry:
@@ -363,12 +576,13 @@ class ComprehensiveExtractionTelemetry:
 
         def _do_insert(conn) -> None:
             """Perform the core INSERT for extraction telemetry."""
+            # Record the finalized verdict as-is. This used to promote a failure
+            # back to a success whenever any method reported success, which
+            # silently overrode finalize() and is how extractions that persisted
+            # no article at all still landed in the table as successes. A parser
+            # returning cleanly is not the same as an article being captured;
+            # only finalize() has seen the body.
             is_success = bool(metrics.is_success)
-            if not is_success:
-                if metrics.successful_method:
-                    is_success = True
-                else:
-                    is_success = any(metrics.method_success.values())
 
             conn.execute(
                 """

--- a/tests/test_telemetry_article_qualification.py
+++ b/tests/test_telemetry_article_qualification.py
@@ -1,0 +1,182 @@
+"""What telemetry is allowed to call a successful extraction.
+
+An article is defined by what its text IS, not by how much of it there is. These
+tests pin that: a wall of subscription prose fails however long it runs, a short
+local story passes, and the two ways a non-article used to be recorded as a
+success cannot come back.
+
+The boilerplate phrases and the density threshold are derived from production
+data (15,656 cleaned/uncleaned pairs and 1,036 labelled extractions), so these
+tests use the real strings rather than invented ones.
+"""
+
+from src.utils.comprehensive_telemetry import (
+    ExtractionMetrics,
+    capitalization_ratio,
+    looks_like_article,
+    prose_density,
+    strip_boilerplate,
+    utility_word_rate,
+)
+
+STORY = (
+    "The county commission voted 4-1 on Tuesday to approve the measure. "
+    "Residents said the decision had been a long time coming, and the board "
+    "agreed that the work would begin in the spring. "
+)
+# Verbatim from the corpus: the most common wall across 16-17 hosts.
+WALL = (
+    "Login to continue reading. Sign up for complimentary access. "
+    "Javascript is required for you to be able to read premium content. "
+    "Please enable it in your browser settings."
+)
+
+
+def _metrics() -> ExtractionMetrics:
+    return ExtractionMetrics("op-1", "art-1", "https://example.com/a", "Example")
+
+
+class TestArticleIsContentNotLength:
+    def test_real_story_qualifies(self):
+        assert looks_like_article(STORY) is True
+
+    def test_paywall_wall_is_not_an_article(self):
+        assert looks_like_article(WALL) is False
+
+    def test_a_LONG_wall_is_still_not_an_article(self):
+        """The point of the change: no byte count can rescue this."""
+        padded = (
+            WALL + " " + ("Featured Local Savings. Previous Post. Next Post. " * 40)
+        )
+        assert len(padded) > 2000
+        assert looks_like_article(padded) is False
+
+    def test_short_local_story_qualifies(self):
+        """Local news runs short; a word floor would have failed this."""
+        assert (
+            looks_like_article(
+                "The board met on Monday and agreed to the plan for the new park."
+            )
+            is True
+        )
+
+    def test_empty_bodies_fail(self):
+        # 107 of 1,036 production rows had exactly this and were recorded as
+        # successes whenever a title was present.
+        assert looks_like_article("") is False
+        assert looks_like_article("   \n  ") is False
+        assert looks_like_article(None) is False
+
+    def test_scraped_form_control_is_not_an_article(self):
+        """The country dropdown: 5,308 chars, identical across four hosts."""
+        countries = (
+            "Country United States of America US Virgin Islands United States "
+            "Minor Outlying Islands Canada Mexico Bahamas Cuba Dominican "
+            "Republic Haiti Jamaica Afghanistan Albania Algeria Andorra Angola "
+        ) * 6
+        assert len(countries) > 1000
+        assert looks_like_article(countries) is False
+
+
+class TestStripBoilerplate:
+    def test_trailing_wall_does_not_disqualify_a_story(self):
+        assert looks_like_article(STORY * 3 + " " + WALL) is True
+
+    def test_the_wall_is_actually_removed(self):
+        stripped = strip_boilerplate(STORY + " " + WALL).lower()
+        assert "complimentary access" not in stripped
+        assert "county commission" in stripped
+
+    def test_comment_policy_block_removed(self):
+        body = (
+            STORY
+            + " Please avoid obscene, vulgar, lewd, racist or sexually-oriented language."
+        )
+        stripped = strip_boilerplate(body).lower()
+        assert "obscene" not in stripped
+        assert "county commission" in stripped
+
+    def test_dateline_is_kept_not_stripped(self):
+        """Datelines are content moved to another field, not furniture."""
+        assert "kansas city" in strip_boilerplate("KANSAS CITY, Mo. " + STORY).lower()
+
+
+class TestProseDensity:
+    def test_prose_scores_higher_than_a_form(self):
+        assert prose_density(STORY) > prose_density("Canada Mexico Albania Angola")
+
+    def test_empty_text_is_zero(self):
+        assert prose_density("") == 0.0
+
+
+class TestCapitalization:
+    """Catches proper-noun runs that prose_density is fooled by."""
+
+    def test_country_list_is_mostly_capitalised(self):
+        # "United States of America" contains 'of' — density alone scores this
+        # 0.21 and lets it through. Capitalisation is what rejects it.
+        countries = "United States of America Canada Mexico Bahamas Cuba Haiti"
+        assert capitalization_ratio(countries) > 0.60
+        assert capitalization_ratio(STORY) < 0.60
+
+
+class TestUtilityWords:
+    """Vocabulary catches text that reads like writing but is about the site."""
+
+    def test_registration_prose_is_rejected(self):
+        signup = (
+            "Create your account below. Enter your e-mail and choose a password. "
+            "You can sign up for our newsletter and manage your account settings "
+            "in your browser at any time. Click here to subscribe."
+        )
+        # Reads like sentences, so density and capitalisation both pass it.
+        assert prose_density(signup) >= 0.14
+        assert capitalization_ratio(signup) <= 0.60
+        # Vocabulary is what rejects it.
+        assert utility_word_rate(signup) > 3.0
+        assert looks_like_article(signup) is False
+
+    def test_a_story_mentioning_a_subscriber_once_still_qualifies(self):
+        assert utility_word_rate(STORY * 3 + " One subscriber objected.") <= 3.0
+        assert looks_like_article(STORY * 3 + " One subscriber objected.") is True
+
+
+class TestFinalizeSuccessVerdict:
+    def test_story_is_success(self):
+        m = _metrics()
+        m.finalize({"title": "T", "content": STORY})
+        assert m.is_success is True
+
+    def test_title_with_no_body_is_not_success(self):
+        """Previously `has_title or ...` made this a success with no article."""
+        m = _metrics()
+        m.finalize({"title": "A headline", "content": ""})
+        assert m.is_success is False
+
+    def test_paywall_body_is_not_success(self):
+        m = _metrics()
+        m.finalize({"title": "A headline", "content": WALL})
+        assert m.is_success is False
+
+
+class TestSeleniumUsageIsCountable:
+    """successful_method is not a usage counter; methods_attempted is."""
+
+    def test_selenium_backfill_leaves_successful_method_as_the_http_parser(self):
+        m = _metrics()
+        m.start_method("mcmetadata")
+        m.end_method("mcmetadata", True, None, {})
+        m.start_method("selenium")
+        m.end_method("selenium", True, None, {})
+
+        # This is the ~10x undercount: selenium ran but did not win overall.
+        assert m.successful_method == "mcmetadata"
+        # The honest signal, and it is persisted alongside successful_method:
+        assert m.was_attempted("selenium") is True
+        assert "selenium" in m.methods_attempted
+
+    def test_was_attempted_is_false_when_selenium_never_ran(self):
+        m = _metrics()
+        m.start_method("mcmetadata")
+        m.end_method("mcmetadata", True, None, {})
+        assert m.was_attempted("selenium") is False

--- a/tests/test_telemetry_system.py
+++ b/tests/test_telemetry_system.py
@@ -517,10 +517,15 @@ class TestComprehensiveExtractionTelemetry:
         }
         metrics.end_method("newspaper4k", True, None, extracted_fields)
 
-        # Finalize the metrics with final result
+        # Finalize the metrics with final result. The body is real prose because
+        # success is now decided by what the text is; a placeholder like
+        # "Article content" is not an article and would record as a failure.
         final_result = {
             "title": "Test Article",
-            "content": "Article content",
+            "content": (
+                "The council approved the budget on Tuesday after a long debate, "
+                "and the mayor said the work would begin in the spring."
+            ),
             "author": "John Doe",
         }
         metrics.finalize(final_result)
@@ -987,7 +992,13 @@ class TestTelemetrySystemEndToEnd:
                 metrics.start_method("newspaper4k")
                 extracted_fields = {
                     "title": f"Article {i} Title",
-                    "content": f"Article {i} content...",
+                    # Real prose: the good-site branch is meant to record a
+                    # success, and success is decided by what the body is.
+                    "content": (
+                        f"Story {i}. The council approved the budget on Tuesday "
+                        "after a long debate, and the mayor said the work would "
+                        "begin in the spring."
+                    ),
                     "author": "Test Author",
                     "metadata": {"http_status": 200},
                 }
@@ -1013,6 +1024,11 @@ class TestTelemetrySystemEndToEnd:
                 )
 
             metrics.end_time = datetime.utcnow() + timedelta(seconds=2)
+            # Finalize before recording, as every production call site does
+            # (src/cli/commands/extraction.py finalizes immediately before each
+            # record_extraction, with {} on the error paths). Without this the
+            # verdict is never computed and success would come from nowhere.
+            metrics.finalize(extracted_fields if "good-site" in host else {})
             telemetry.record_extraction(metrics)
 
         # Verify results using API-style queries with PostgreSQL

--- a/tests/test_telemetry_system.py
+++ b/tests/test_telemetry_system.py
@@ -131,18 +131,37 @@ class TestExtractionMetrics:
         assert field_stats["metadata"] is False
 
     def test_finalize_marks_success_from_content_only(self):
-        """Finalize should mark success when content is substantial."""
+        """Finalize marks success on a body alone, with no title.
+
+        Updated when success stopped being a character count. The body here is
+        real prose rather than the previous `"lorem ipsum " * 20`, which passed
+        only because it cleared 100 characters — placeholder text contains no
+        function words and is not an article by the current definition.
+        """
         metrics = ExtractionMetrics("op-final", "art-final", "https://test", "test")
         metrics.start_time = datetime.utcnow()
         metrics.end_time = metrics.start_time
 
-        long_content = "lorem ipsum " * 20  # > 100 characters
-        metrics.finalize({"title": "", "content": long_content})
+        body = (
+            "The council approved the budget on Tuesday after a long debate, and "
+            "the mayor said the work would begin in the spring."
+        )
+        metrics.finalize({"title": "", "content": body})
 
         assert metrics.is_success is True
-        assert metrics.content_length == len(long_content)
+        assert metrics.content_length == len(body)
         assert metrics.extracted_fields["content"] is True
         assert metrics.extracted_fields["title"] is False
+
+    def test_finalize_rejects_a_body_that_is_not_writing(self):
+        """A character count is not the test; what the text is, is."""
+        metrics = ExtractionMetrics("op-final2", "art-final2", "https://test", "test")
+        metrics.start_time = datetime.utcnow()
+        metrics.end_time = metrics.start_time
+
+        metrics.finalize({"title": "A headline", "content": "lorem ipsum " * 20})
+
+        assert metrics.is_success is False
 
     def test_proxy_and_driver_metrics_sanitization(self):
         """Proxy + driver metrics should normalize inputs safely."""

--- a/tests/utils/test_comprehensive_telemetry_metrics.py
+++ b/tests/utils/test_comprehensive_telemetry_metrics.py
@@ -56,9 +56,12 @@ def test_extraction_metrics_tracks_methods(monkeypatch):
     assert metrics.http_error_type == "4xx_client_error"
     assert metrics.alternative_extractions["fallback"]["title"]["values_differ"] is True
     assert metrics.final_field_attribution["title"] == "primary"
-    assert metrics.is_success is True
     assert metrics.content_length == len("Body")
     assert metrics.field_extraction["primary"]["metadata"] is True
+    # A four-character body is not an article. This previously read True only
+    # because a title was present; success no longer follows from a headline.
+    # Method tracking and attribution above are what this test is really for.
+    assert metrics.is_success is False
 
 
 def test_set_driver_metrics_sanitizes_payload():


### PR DESCRIPTION
## An article is defined by its content, not its length

`is_success` was `has_title or content_length > 100`, so two kinds of non-article counted as successful extractions: rows with a headline and **no body at all** (107 of 1,036 in the 07-22 sample — 10%), and paywall stubs.

Raw length cannot fix this, because a wall is arbitrarily wordy — 2,000 characters of "subscribe to continue" clears any byte threshold while containing no story. So qualification is now **strip the boilerplate, then ask whether what survives reads like reporting.**

Four signals, each derived from production data, each catching what the others miss:

| signal | flagged bodies | good bodies |
| --- | --- | --- |
| prose density (function words/word) | 0.137 | 0.286 |
| capitalization | 0.664 | 0.217 |
| utility words /100w | 4.13 | 0.00 |

- **Boilerplate phrases** — from diffing all **15,656** hand-cleaned articles against the same records as extracted (BigQuery, joined on url), keeping only segments removed on **≥4 distinct hosts**. A hand-written list scored **2% recall**; these 26 phrases are what the corpus actually contains.
- **Capitalization** — needed because density alone is fooled by the most common non-article in the corpus: a country dropdown scraped from a registration form (5,308 chars, byte-identical across four hosts) scores 0.21 because "United States **of** America" is full of function words.
- **Utility-word rate** — catches text that reads like sentences but is about the website (registration prompts, newsletter pitches).

**Measured against 95 hand-labelled bodies: 85% rejected, 6.7% collateral, plus all 107 empty bodies.** Density alone was 39%.

There is **no word-count floor**: a ≥60-word floor was measured at 2% recall for 13.7% collateral, because local news genuinely runs short.

Datelines (`KANSAS CITY, Mo.`) and photo credits survive the corpus diff too, but they are content **moved** to another field rather than discarded, so they are excluded — with a test pinning it.

## Success is no longer resurrected after the fact

`record_extraction` re-derived `is_success` from `any(method_success)`, silently overriding `finalize()`. A parser returning cleanly is not the same as an article being captured, and only `finalize()` has seen the body. All six production call sites finalize immediately before recording (with `{}` on error paths), so this is safe — verified before changing it.

## successful_method is not a usage counter

It records the **first** method to return a result. Selenium usually backfills a field after an HTTP parser already won the content, so it leaves the field untouched — counting `successful_method = 'selenium'` understates Selenium's use by **~10x**. Documented at the assignment, with `was_attempted()` as the honest signal (`methods_attempted` was already persisted).

## tls_client had not run for a long time

It was called with requests' argument names (`proxies=`/`timeout=`/`verify=`) against a signature of `(insecure_skip_verify, timeout_seconds, proxy)`. Every call raised `TypeError` and fell through to plain `requests`, losing the Chrome TLS fingerprint the rung exists to provide — 28 times in one sweep. Verified against the installed library inside the crawler image. The fallback now distinguishes "not installed" (info) from "installed but failed" (warning), because silent degradation is what let this survive.

## Tests

Four existing tests encoded the old success-by-length contract and were caught by the pre-push suite. Updated to the new contract rather than weakened — the `"lorem ipsum " * 20` input is kept as an explicit **negative** case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)