### PR TITLE
fix(cleaning): remove cross-publisher furniture, and keep the raw capture

### DIFF
--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -201,10 +201,18 @@ echo ""
 # Step 5: PostgreSQL suite, run in succession against a docker PostgreSQL.
 # Mirrors CI's dedicated PostgreSQL job. Uses the docker-compose 'postgres'
 # service and a throwaway database, so it never touches a real dev database and
-# never runs at the same time as the main suite. If Docker is unavailable the
-# suite is skipped locally (CI still runs it).
+# never runs at the same time as the main suite. The local gate is meant to
+# MIRROR remote CI, so Docker being unavailable is a HARD FAILURE (the push is
+# blocked), not a silent skip — otherwise a Postgres-only regression sails past
+# the local gate and only surfaces in remote CI. Set SKIP_PG=1 to deliberately
+# opt out for the rare case where you knowingly want to defer to CI.
 echo "🐘 Step 5/6: Running PostgreSQL suite (docker)..."
 
+if [ "${SKIP_PG:-}" = "1" ]; then
+    echo "⚠️  SKIP_PG=1 set; deliberately skipping PostgreSQL suite (CI will run it)." | tee -a "$LOGFILE"
+    echo "✅ Step 5/6: PostgreSQL suite skipped (SKIP_PG=1)"
+    echo ""
+else
 DOCKER_COMPOSE=""
 if docker compose version >/dev/null 2>&1; then
     DOCKER_COMPOSE="docker compose"
@@ -213,7 +221,15 @@ elif command -v docker-compose >/dev/null 2>&1; then
 fi
 
 if [ -z "$DOCKER_COMPOSE" ] || ! docker info >/dev/null 2>&1; then
-    echo "⚠️  Docker not available; skipping PostgreSQL suite (CI will run it)." | tee -a "$LOGFILE"
+    echo ""
+    echo "❌ Docker is not available — the PostgreSQL suite cannot run, so this"
+    echo "   push would NOT mirror remote CI. Push aborted."
+    echo "   → Start Docker Desktop and re-push, or run with SKIP_PG=1 to"
+    echo "     deliberately defer the Postgres suite to CI (not recommended)."
+    echo "❌ Docker not available; PostgreSQL suite could not run. Push aborted." >> "$LOGFILE"
+    notify "FAILED" "Docker unavailable; PostgreSQL suite could not run"
+    echo "📝 Full log saved to: $LOGFILE"
+    exit 1
 else
     PG_TESTDB="mizzou_prepush"
     export TEST_DATABASE_URL="postgresql://mizzou_user:mizzou_pass@127.0.0.1:5432/${PG_TESTDB}"
@@ -231,7 +247,14 @@ else
     done
 
     if [ -z "$PG_READY" ]; then
-        echo "⚠️  PostgreSQL did not become ready; skipping PostgreSQL suite (CI will run it)." | tee -a "$LOGFILE"
+        echo ""
+        echo "❌ PostgreSQL container did not become ready in time; the suite could"
+        echo "   not run, so this push would NOT mirror remote CI. Push aborted."
+        echo "   → Check 'docker compose logs postgres', then re-push."
+        echo "❌ PostgreSQL did not become ready; suite could not run. Push aborted." >> "$LOGFILE"
+        notify "FAILED" "PostgreSQL did not become ready; suite could not run"
+        echo "📝 Full log saved to: $LOGFILE"
+        exit 1
     else
         # Fresh throwaway database, migrated to head, then run the suite.
         $DOCKER_COMPOSE exec -T postgres dropdb -U mizzou_user --if-exists "$PG_TESTDB" >>"$LOGFILE" 2>&1
@@ -258,6 +281,7 @@ fi
 
 echo "✅ Step 5/6: PostgreSQL suite complete"
 echo ""
+fi  # end SKIP_PG guard
 
 # Step 6: Combined coverage gate. Steps 4 and 5 accumulated coverage via
 # --cov-append; enforce the 78% threshold on the COMBINED total here. If the

--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -1127,7 +1127,16 @@ def handle_extract_url_command(args) -> int:
                     "title": content.get("title"),
                     "author": cleaned_author,
                     "publish_date": content.get("publish_date"),
-                    "content": cleaned_text,
+                    # content holds the RAW capture, text the cleaned body.
+                    # These used to receive the same cleaned string, which threw
+                    # the raw copy away: `content` was byte-identical to `text`
+                    # for 96,169 of 96,170 stored articles. With no before/after
+                    # pair, nothing could measure what cleaning removed — or
+                    # notice that it had stopped removing anything.
+                    # The rest of the pipeline already assumes this split:
+                    # cleaning reads a.content as its input, entity extraction
+                    # reads a.text as the cleaned result.
+                    "content": content_text,
                     "text": cleaned_text,
                     "status": article_status,
                     "metadata": json.dumps(metadata_value),
@@ -2363,7 +2372,11 @@ def _run_post_extraction_cleaning(domains_to_articles, db=None):
                             session,
                             ARTICLE_UPDATE_SQL,
                             {
-                                "content": cleaned_content,
+                                # Re-cleaning writes only the cleaned side. The
+                                # raw capture stays as it was, so this can be
+                                # re-run against improved rules and the result
+                                # compared with what it replaced.
+                                "content": original_content,
                                 "text": cleaned_content,
                                 "text_hash": new_hash,
                                 "excerpt": excerpt,

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -4129,20 +4129,39 @@ class ContentExtractor:
                     session = tls_client.Session(
                         client_identifier="chrome_143", random_tls_extension_order=False
                     )
+                    # tls_client is NOT requests-compatible: its execute_request
+                    # signature is (..., insecure_skip_verify, timeout_seconds,
+                    # proxy). Calling it with requests' names — proxies=/timeout=/
+                    # verify= — raises TypeError on the first one, so this rung
+                    # never actually ran and every request quietly fell through
+                    # to plain `requests`, losing the Chrome TLS fingerprint that
+                    # is the whole point of the rung.
                     tls_resp = session.get(
                         url,
                         headers=headers,
-                        proxies={"http": proxy_url, "https": proxy_url},
-                        timeout=30,
-                        verify=False,
+                        proxy=proxy_url,
+                        timeout_seconds=30,
+                        insecure_skip_verify=True,
                     )
                     response = tls_resp
-                except (
-                    Exception
-                ) as exc:  # pragma: no cover - optional dependency/fallback
+                except ImportError as exc:
+                    # Genuinely optional: not installed in this image.
                     logger.info(
-                        "tls_client not available or failed: %s; falling back to requests",
+                        "tls_client not installed (%s); falling back to requests",
                         exc,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive fallback
+                    # Installed but the call failed. Louder than ImportError on
+                    # purpose: the fallback still returns a page, so this degrades
+                    # silently and the capture rung disappears without anything
+                    # failing. That is exactly how the signature drift above went
+                    # unnoticed for 28 occurrences in a single sweep.
+                    logger.warning(
+                        "tls_client request failed (%s: %s); falling back to requests "
+                        "— the Chrome TLS fingerprint is NOT in effect for %s",
+                        type(exc).__name__,
+                        exc,
+                        url,
                     )
 
                 if response is None:

--- a/src/utils/boilerplate.py
+++ b/src/utils/boilerplate.py
@@ -1,0 +1,226 @@
+"""What is furniture and what is an article.
+
+One definition, shared by everything that needs to tell reporting apart from the
+scaffolding around it: the content cleaner, which removes furniture, and
+telemetry, which decides whether an extraction actually captured a story.
+
+Two ideas, in order:
+
+1. **Vocabulary.** Some text is furniture wherever it appears. A phrase that a
+   human cleaner removed from articles on many different publishers is site
+   plumbing, not one newsroom's prose. That list is derived, not guessed — see
+   BOILERPLATE_MARKERS.
+2. **Shape.** What survives is then judged on whether it reads like writing:
+   function-word density, capitalisation, and how much of the vocabulary belongs
+   to websites rather than to the world.
+
+Neither alone is enough, and the failures of each are what motivate the other —
+recorded at each threshold below so the next person can retune against fresh
+data rather than taste.
+"""
+
+from __future__ import annotations
+
+import re
+
+# --------------------------------------------------------------------------
+# Vocabulary
+# --------------------------------------------------------------------------
+
+# DERIVED, NOT GUESSED. Produced by diffing 15,656 hand-cleaned articles against
+# the same records as extracted (BigQuery mizzou_analytics.articles, joined on
+# url), keeping only segments the cleaner removed on FOUR OR MORE distinct
+# hosts. That host count is the test of whether a phrase is site furniture or
+# one publisher's prose.
+#
+# An earlier hand-written list of plausible-sounding paywall phrases scored 2%
+# recall against labelled data. These are what the corpus actually contains, and
+# the counts are why they matter: "Please enable it in your browser settings"
+# appeared 953 times, "Login to continue reading" 548 times across 16 hosts.
+#
+# Datelines ("KANSAS CITY, Mo.") and photo credits survive that diff too, but
+# they are article content being MOVED to another field rather than discarded,
+# so they are deliberately absent here.
+#
+# Phrase-level on purpose: bare words like "subscribe" appear inside real
+# articles ("subscribers to the service said..."); whole prompts do not.
+BOILERPLATE_MARKERS: tuple[str, ...] = (
+    # paywall / registration walls
+    "javascript is required for you to be able to read premium content",
+    "please enable it in your browser settings",
+    "login to continue reading",
+    "sign up for complimentary access",
+    "please log in to continue",
+    "need an account?",
+    "this item is available in full to subscribers",
+    "non-subscribers",
+    "click here to see your options for becoming a subscriber",
+    "otherwise, click here to view your options for subscribing",
+    "print and web subscribers",
+    "subscribe now!",
+    # consent / advertising furniture
+    "we use cookies to help our site function properly",
+    "featured local savings",
+    # comment-policy block (ships as many short lines, hence the fragments)
+    "please avoid obscene, vulgar, lewd",
+    "racist or sexually-oriented language",
+    "threats of harming another",
+    "person will not be tolerated",
+    "don't knowingly lie about anyone",
+    "no racism, sexism or any sort of -ism",
+    "that is degrading to another person",
+    "use the 'report' link on",
+    "each comment to let us know of abusive posts",
+    "we'd love to hear eyewitness",
+    "accounts, the history behind an article",
+    # recirculation
+    "previous post",
+    "next post",
+)
+
+# Words belonging to the plumbing of a website rather than to a story. Unlike
+# the phrases above these are single words, so they are counted as a RATE rather
+# than matched: an article may mention a subscriber once, while a registration
+# form says "account", "password" and "e-mail" every other line.
+UTILITY_WORDS = re.compile(
+    r"\b(subscribe|subscriber|account|password|login|log in|sign up|e-?mail|"
+    r"cookies|advertisement|newsletter|click here|browser)\b",
+    re.IGNORECASE,
+)
+
+# Function words. Their density is what separates written English from a
+# scraped control.
+FUNCTION_WORDS = frozenset(
+    "the a an and or but of to in on for with is are was were said he she it "
+    "that this from at by as has have had not".split()
+)
+
+_SEGMENT_SPLIT = re.compile(r"[\n\r]+|(?<=[.!?])\s+")
+
+# --------------------------------------------------------------------------
+# Thresholds, with the measurements that chose them
+# --------------------------------------------------------------------------
+
+# Function-word density below which text is a list, a form or a menu.
+# Measured on 1,036 labelled production extractions: median 0.137 for bodies
+# flagged as boilerplate/paywall against 0.286 for the rest.
+#     < 0.12 -> 38% of flagged bodies caught,  2.5% collateral
+#     < 0.16 -> 64% caught,                    4.9% collateral
+# The known false positive is agate — sports scores, election returns, real
+# estate transfers — legitimate local copy carrying almost no function words.
+MIN_PROSE_DENSITY = 0.14
+
+# Capitalisation above which text is a run of proper nouns rather than prose.
+# Density alone is fooled by the corpus's most common non-article: a country
+# dropdown scraped from a registration form (5,308 chars, byte-identical across
+# four hosts) scores 0.21 on density because "United States of America" is full
+# of function words. Median capitalisation was 0.664 for flagged bodies against
+# 0.217 for the rest — a cleaner 3x separation than density's 2x.
+MAX_CAPITALIZATION = 0.60
+
+# Utility words per 100 words, above which the text is site plumbing.
+# The sharpest of the three: median 4.13 for flagged bodies against 0.00 for the
+# rest — most real articles contain none of these words at all. Adding it took
+# recall from 39% to 85%.
+MAX_UTILITY_WORD_RATE = 3.0
+
+
+# --------------------------------------------------------------------------
+# Measures
+# --------------------------------------------------------------------------
+
+
+def segments(text: str) -> list[str]:
+    """Split into lines and sentences — the unit boilerplate travels in."""
+    if not text:
+        return []
+    return [s.strip() for s in _SEGMENT_SPLIT.split(text) if s and s.strip()]
+
+
+def is_boilerplate_segment(segment: str) -> bool:
+    """Whether a single line or sentence is known furniture."""
+    lowered = segment.lower()
+    return any(marker in lowered for marker in BOILERPLATE_MARKERS)
+
+
+def strip_boilerplate(body: str) -> str:
+    """Remove the segments of a body that are walls or furniture.
+
+    Segment-level rather than whole-body, so a single "subscribe today" line at
+    the foot of a real story removes that line and keeps the story. A whole-body
+    keyword test cannot do this — it would discard the article too.
+    """
+    if not body:
+        return ""
+    kept = [s for s in segments(body) if not is_boilerplate_segment(s)]
+    return " ".join(kept).strip()
+
+
+def prose_density(text: str) -> float:
+    """Share of words that are function words — how much this reads as writing."""
+    words = re.findall(r"[a-zA-Z']+", text.lower())
+    if not words:
+        return 0.0
+    return sum(1 for w in words if w in FUNCTION_WORDS) / len(words)
+
+
+def capitalization_ratio(text: str) -> float:
+    """Share of words beginning with a capital.
+
+    Reporting is mostly lowercase; a scraped list of proper nouns — countries,
+    place names, section menus — is mostly not.
+    """
+    words = re.findall(r"[A-Za-z][A-Za-z']*", text)
+    if not words:
+        return 0.0
+    return sum(1 for w in words if w[0].isupper()) / len(words)
+
+
+def utility_word_rate(text: str) -> float:
+    """Website-plumbing words per 100 words.
+
+    Shape misses text that reads like writing but is about the site rather than
+    the world — registration prompts, newsletter pitches, cookie notices.
+    """
+    words = re.findall(r"[a-zA-Z']+", text)
+    if not words:
+        return 0.0
+    return 100 * len(UTILITY_WORDS.findall(text)) / len(words)
+
+
+def looks_like_article(body: str | None) -> bool:
+    """Whether a body is a story rather than a wall, a form or a menu.
+
+    Content-first: a paywall prompt fails however many characters it runs to,
+    because what is measured is the writing that survives the strip, not the
+    byte count of whatever the page returned.
+
+    There is deliberately no word-count floor. One was measured and was actively
+    harmful: a >=60-word floor caught 2% of flagged bodies while failing 13.7%
+    of good ones, because local news genuinely runs short.
+    """
+    if not body or not body.strip():
+        return False
+    stripped = strip_boilerplate(body)
+    if prose_density(stripped) < MIN_PROSE_DENSITY:
+        return False  # a list or a menu, not writing
+    if capitalization_ratio(stripped) > MAX_CAPITALIZATION:
+        return False  # a run of proper nouns: a dropdown, a section index
+    return utility_word_rate(stripped) <= MAX_UTILITY_WORD_RATE
+
+
+def looks_like_furniture(text: str) -> bool:
+    """Whether a candidate block is furniture — the inverse question.
+
+    Used by the content cleaner to decide whether a block it is considering for
+    removal really is scaffolding. Deliberately NOT `not looks_like_article(...)`:
+    that would call anything short furniture, and a two-sentence paragraph in the
+    middle of a story is not. This asks for positive evidence of scaffolding.
+    """
+    if not text or not text.strip():
+        return False
+    if is_boilerplate_segment(text):
+        return True
+    if utility_word_rate(text) > MAX_UTILITY_WORD_RATE:
+        return True
+    return capitalization_ratio(text) > MAX_CAPITALIZATION

--- a/src/utils/comprehensive_telemetry.py
+++ b/src/utils/comprehensive_telemetry.py
@@ -7,6 +7,7 @@ methods, publishers, and error conditions to optimize extraction strategies.
 
 import json
 import logging
+import re
 import time
 from collections import defaultdict
 from collections.abc import Sequence
@@ -20,11 +21,204 @@ from src.telemetry.store import TelemetryStore, get_store
 logger = logging.getLogger(__name__)
 
 
+# An article is defined by what its text IS, not by how much of it there is.
+# Judging raw length answers the wrong question: 2,000 characters of navigation,
+# advertising and "subscribe to continue" passes any byte count while containing
+# no story, and a genuinely short local item fails one. So qualify in two steps —
+# discard the boilerplate, then ask whether prose survived.
+#
+# The vocabulary below is the language of walls and furniture, not of reporting.
+# It is deliberately phrase-level: bare words like "subscribe" appear inside real
+# articles ("subscribers to the service said..."), whole prompts do not.
+#
+# DERIVED, NOT GUESSED. Produced by diffing 15,656 hand-cleaned articles against
+# the same records as extracted (BigQuery mizzou_analytics.articles), keeping
+# only segments the cleaner removed on FOUR OR MORE distinct hosts — the test of
+# whether a phrase is site furniture or one publisher's prose. An earlier
+# hand-written list scored 2% recall against labelled data; these phrases are
+# what the corpus actually contains.
+#
+# Datelines ("KANSAS CITY, Mo.") and photo credits survive that diff too, but
+# they are article content being MOVED to another field rather than discarded,
+# so they are deliberately excluded here.
+_BOILERPLATE_MARKERS = (
+    # paywall / registration walls
+    "javascript is required for you to be able to read premium content",
+    "please enable it in your browser settings",
+    "login to continue reading",
+    "sign up for complimentary access",
+    "please log in to continue",
+    "need an account?",
+    "this item is available in full to subscribers",
+    "non-subscribers",
+    "click here to see your options for becoming a subscriber",
+    "otherwise, click here to view your options for subscribing",
+    "print and web subscribers",
+    "subscribe now!",
+    # consent / advertising furniture
+    "we use cookies to help our site function properly",
+    "featured local savings",
+    # comment-policy block (ships as many short lines, hence the fragments)
+    "please avoid obscene, vulgar, lewd",
+    "racist or sexually-oriented language",
+    "threats of harming another",
+    "person will not be tolerated",
+    "don't knowingly lie about anyone",
+    "no racism, sexism or any sort of -ism",
+    "that is degrading to another person",
+    "use the 'report' link on",
+    "each comment to let us know of abusive posts",
+    "we'd love to hear eyewitness",
+    "accounts, the history behind an article",
+    # recirculation
+    "previous post",
+    "next post",
+)
+
+# Minimum WORDS of surviving prose. Words, not characters, because the question
+# is whether someone wrote something. ~60 words is roughly the 400 characters the
+# Selenium guard uses, but measured on what is left after the walls come down
+# rather than on whatever bytes arrived.
+MIN_ARTICLE_WORDS = 60  # retained for callers; not used by looks_like_article
+
+# Function words. Their density is what separates written English from a scraped
+# control: prose is roughly a third function words, while a country dropdown, a
+# nav menu or a tag cloud is almost none.
+_FUNCTION_WORDS = frozenset(
+    "the a an and or but of to in on for with is are was were said he she it "
+    "that this from at by as has have had not".split()
+)
+
+# Below this density the text is a list, a form or a menu rather than writing.
+#
+# Derived from 1,036 labelled production extractions (2026-07-22 sample, ~40
+# Missouri publishers), not chosen by taste. Median function-word density was
+# 0.137 for bodies flagged as boilerplate/paywall and 0.286 for the rest — a 2x
+# separation. Measured operating points, after excluding empty bodies:
+#
+#     density < 0.12  ->  38% of flagged bodies caught,  2.5% collateral
+#     density < 0.16  ->  64% caught,                    4.9% collateral
+#     density < 0.20  ->  66% caught,                   10.8% collateral
+#
+# The known false positive is agate — sports scores, election returns, real
+# estate transfers — legitimate local copy carrying almost no function words.
+MIN_PROSE_DENSITY = 0.14
+
+# Share of words starting with a capital. Function-word density alone is fooled
+# by the single most common non-article in the corpus: the country dropdown
+# scraped from a registration form ("United States of America", "Commonwealth of
+# the ...", 5,308 chars, byte-identical across four hosts) scores 0.21 because
+# country names are full of "of" and "the". What gives it away is that nearly
+# every word is a proper noun.
+#
+# Measured on the labelled sample: median capitalisation was 0.664 for flagged
+# bodies against 0.217 for the rest — a cleaner 3x separation than density's 2x.
+# Together, `density < 0.14 or capitalisation > 0.60` catches 67% of flagged
+# bodies at 4.9% collateral, against 39% for density alone.
+MAX_CAPITALIZATION = 0.60
+
+# Words that belong to the plumbing of a website rather than to a story. Unlike
+# the phrase list above these are single words, so they are counted as a RATE
+# rather than matched: a story may mention a subscriber once, a registration
+# form says "account", "password" and "e-mail" every other line.
+_UTILITY_WORDS = re.compile(
+    r"\b(subscribe|subscriber|account|password|login|log in|sign up|e-?mail|"
+    r"cookies|advertisement|newsletter|click here|browser)\b",
+    re.IGNORECASE,
+)
+
+# Utility words per 100 words, above which the text is site plumbing.
+#
+# The sharpest of the three signals on the labelled sample: median rate 4.13 for
+# flagged bodies against 0.00 for the rest — most real articles contain none of
+# these words at all. Adding it took recall from 39% to 85%.
+MAX_UTILITY_WORD_RATE = 3.0
+
 # Proxy status codes for telemetry database (integer field)
 PROXY_STATUS_DISABLED = 0
 PROXY_STATUS_SUCCESS = 1
 PROXY_STATUS_FAILED = 2
 PROXY_STATUS_BYPASSED = 3
+
+
+def strip_boilerplate(body: str) -> str:
+    """Drop the segments of a body that are walls or furniture, not reporting.
+
+    Splits on line and sentence boundaries and discards any segment carrying a
+    boilerplate phrase. Segment-level rather than whole-body, so one "subscribe
+    today" line at the foot of a real story removes that line and keeps the
+    story — the reason a whole-body keyword test cannot be used for this.
+    """
+    if not body:
+        return ""
+    segments = re.split(r"[\n\r]+|(?<=[.!?])\s+", body)
+    kept = [
+        seg
+        for seg in segments
+        if seg.strip() and not any(m in seg.lower() for m in _BOILERPLATE_MARKERS)
+    ]
+    return " ".join(seg.strip() for seg in kept).strip()
+
+
+def prose_density(text: str) -> float:
+    """Share of words that are function words — how much this reads as writing.
+
+    Prose is roughly a third function words. A country dropdown, a nav menu or a
+    tag cloud is close to none, which is what makes this separate written English
+    from a scraped form control without knowing any site's markup.
+    """
+    words = re.findall(r"[a-zA-Z']+", text.lower())
+    if not words:
+        return 0.0
+    return sum(1 for w in words if w in _FUNCTION_WORDS) / len(words)
+
+
+def capitalization_ratio(text: str) -> float:
+    """Share of words beginning with a capital.
+
+    Reporting is mostly lowercase; a scraped list of proper nouns — countries,
+    place names, section menus — is mostly not. This is what catches the bodies
+    that slip past prose_density because their proper nouns happen to contain
+    function words.
+    """
+    words = re.findall(r"[A-Za-z][A-Za-z']*", text)
+    if not words:
+        return 0.0
+    return sum(1 for w in words if w[0].isupper()) / len(words)
+
+
+def utility_word_rate(text: str) -> float:
+    """Website-plumbing words per 100 words.
+
+    Shape signals miss text that reads like writing but is about the site rather
+    than the world — registration prompts, newsletter pitches, cookie notices.
+    Vocabulary catches those: most real articles use none of these words at all.
+    """
+    words = re.findall(r"[a-zA-Z']+", text)
+    if not words:
+        return 0.0
+    return 100 * len(_UTILITY_WORDS.findall(text)) / len(words)
+
+
+def looks_like_article(body: str | None) -> bool:
+    """Whether a body is a story rather than a wall, a form or a menu.
+
+    Content-first by design. A paywall prompt fails however many characters it
+    runs to, because what is measured is the writing that survives the strip —
+    not the byte count of whatever the page happened to return.
+    """
+    if not body or not body.strip():
+        return False
+    # No word-count floor. It was measured against the labelled sample and is
+    # actively harmful here: a >=60-word floor caught 2% of flagged bodies while
+    # failing 13.7% of good ones, because local news genuinely runs short. The
+    # two shape signals do the work; length does not.
+    stripped = strip_boilerplate(body)
+    if prose_density(stripped) < MIN_PROSE_DENSITY:
+        return False  # a list or a menu, not writing
+    if capitalization_ratio(stripped) > MAX_CAPITALIZATION:
+        return False  # a run of proper nouns: a dropdown, a section index
+    return utility_word_rate(stripped) <= MAX_UTILITY_WORD_RATE
 
 
 def proxy_status_to_int(status: str | None) -> int | None:
@@ -111,6 +305,14 @@ class ExtractionMetrics:
         self.methods_attempted.append(method_name)
         self.method_timings[method_name] = time.time()
 
+    def was_attempted(self, method_name: str) -> bool:
+        """Whether a method ran at all, regardless of which one won.
+
+        The honest answer to "did we pay for Selenium on this article?".
+        `successful_method` cannot answer it — see end_method.
+        """
+        return method_name in self.methods_attempted
+
     def end_method(
         self,
         method_name: str,
@@ -127,6 +329,13 @@ class ExtractionMetrics:
         if error:
             self.method_errors[method_name] = error
 
+        # NOTE: this is the FIRST method to return a result, not "the methods
+        # that ran". It is not a usage counter and must not be read as one.
+        # Selenium is usually invoked to backfill a field after an HTTP parser
+        # already won the content, so it leaves `successful_method` untouched —
+        # counting `successful_method = 'selenium'` understates how often
+        # Selenium actually ran by roughly 10x. Use `methods_attempted` (also
+        # persisted) or `was_attempted()` for that question.
         if success and not self.successful_method:
             self.successful_method = method_name
 
@@ -300,13 +509,17 @@ class ExtractionMetrics:
             if extraction_methods:
                 self.final_field_attribution = extraction_methods
 
-            self.content_length = len(final_result.get("content") or "")
-            has_title = bool(final_result.get("title"))
-            has_content = bool(final_result.get("content"))
-            # Match ContentExtractor logic: success if title OR meaningful content
-            # Allows articles with missing author/date to be successful
-            content_long_enough = has_content and self.content_length > 100
-            self.is_success = has_title or content_long_enough
+            body = final_result.get("content") or ""
+            self.content_length = len(body)
+            # An extraction succeeded when it came back with a story. Missing
+            # author or date does not make it a failure; a missing BODY does.
+            #
+            # This used to read `has_title or content_length > 100`, which let
+            # two kinds of non-article through: rows carrying a headline and no
+            # body at all, and paywall teasers a sentence or two long. Neither a
+            # raw character count nor a title fixes that, because a wall can be
+            # arbitrarily wordy — so qualify on what survives the boilerplate.
+            self.is_success = looks_like_article(body)
 
 
 class ComprehensiveExtractionTelemetry:
@@ -363,12 +576,13 @@ class ComprehensiveExtractionTelemetry:
 
         def _do_insert(conn) -> None:
             """Perform the core INSERT for extraction telemetry."""
+            # Record the finalized verdict as-is. This used to promote a failure
+            # back to a success whenever any method reported success, which
+            # silently overrode finalize() and is how extractions that persisted
+            # no article at all still landed in the table as successes. A parser
+            # returning cleanly is not the same as an article being captured;
+            # only finalize() has seen the body.
             is_success = bool(metrics.is_success)
-            if not is_success:
-                if metrics.successful_method:
-                    is_success = True
-                else:
-                    is_success = any(metrics.method_success.values())
 
             conn.execute(
                 """

--- a/src/utils/comprehensive_telemetry.py
+++ b/src/utils/comprehensive_telemetry.py
@@ -7,7 +7,6 @@ methods, publishers, and error conditions to optimize extraction strategies.
 
 import json
 import logging
-import re
 import time
 from collections import defaultdict
 from collections.abc import Sequence
@@ -21,204 +20,15 @@ from src.telemetry.store import TelemetryStore, get_store
 logger = logging.getLogger(__name__)
 
 
-# An article is defined by what its text IS, not by how much of it there is.
-# Judging raw length answers the wrong question: 2,000 characters of navigation,
-# advertising and "subscribe to continue" passes any byte count while containing
-# no story, and a genuinely short local item fails one. So qualify in two steps —
-# discard the boilerplate, then ask whether prose survived.
-#
-# The vocabulary below is the language of walls and furniture, not of reporting.
-# It is deliberately phrase-level: bare words like "subscribe" appear inside real
-# articles ("subscribers to the service said..."), whole prompts do not.
-#
-# DERIVED, NOT GUESSED. Produced by diffing 15,656 hand-cleaned articles against
-# the same records as extracted (BigQuery mizzou_analytics.articles), keeping
-# only segments the cleaner removed on FOUR OR MORE distinct hosts — the test of
-# whether a phrase is site furniture or one publisher's prose. An earlier
-# hand-written list scored 2% recall against labelled data; these phrases are
-# what the corpus actually contains.
-#
-# Datelines ("KANSAS CITY, Mo.") and photo credits survive that diff too, but
-# they are article content being MOVED to another field rather than discarded,
-# so they are deliberately excluded here.
-_BOILERPLATE_MARKERS = (
-    # paywall / registration walls
-    "javascript is required for you to be able to read premium content",
-    "please enable it in your browser settings",
-    "login to continue reading",
-    "sign up for complimentary access",
-    "please log in to continue",
-    "need an account?",
-    "this item is available in full to subscribers",
-    "non-subscribers",
-    "click here to see your options for becoming a subscriber",
-    "otherwise, click here to view your options for subscribing",
-    "print and web subscribers",
-    "subscribe now!",
-    # consent / advertising furniture
-    "we use cookies to help our site function properly",
-    "featured local savings",
-    # comment-policy block (ships as many short lines, hence the fragments)
-    "please avoid obscene, vulgar, lewd",
-    "racist or sexually-oriented language",
-    "threats of harming another",
-    "person will not be tolerated",
-    "don't knowingly lie about anyone",
-    "no racism, sexism or any sort of -ism",
-    "that is degrading to another person",
-    "use the 'report' link on",
-    "each comment to let us know of abusive posts",
-    "we'd love to hear eyewitness",
-    "accounts, the history behind an article",
-    # recirculation
-    "previous post",
-    "next post",
-)
-
-# Minimum WORDS of surviving prose. Words, not characters, because the question
-# is whether someone wrote something. ~60 words is roughly the 400 characters the
-# Selenium guard uses, but measured on what is left after the walls come down
-# rather than on whatever bytes arrived.
-MIN_ARTICLE_WORDS = 60  # retained for callers; not used by looks_like_article
-
-# Function words. Their density is what separates written English from a scraped
-# control: prose is roughly a third function words, while a country dropdown, a
-# nav menu or a tag cloud is almost none.
-_FUNCTION_WORDS = frozenset(
-    "the a an and or but of to in on for with is are was were said he she it "
-    "that this from at by as has have had not".split()
-)
-
-# Below this density the text is a list, a form or a menu rather than writing.
-#
-# Derived from 1,036 labelled production extractions (2026-07-22 sample, ~40
-# Missouri publishers), not chosen by taste. Median function-word density was
-# 0.137 for bodies flagged as boilerplate/paywall and 0.286 for the rest — a 2x
-# separation. Measured operating points, after excluding empty bodies:
-#
-#     density < 0.12  ->  38% of flagged bodies caught,  2.5% collateral
-#     density < 0.16  ->  64% caught,                    4.9% collateral
-#     density < 0.20  ->  66% caught,                   10.8% collateral
-#
-# The known false positive is agate — sports scores, election returns, real
-# estate transfers — legitimate local copy carrying almost no function words.
-MIN_PROSE_DENSITY = 0.14
-
-# Share of words starting with a capital. Function-word density alone is fooled
-# by the single most common non-article in the corpus: the country dropdown
-# scraped from a registration form ("United States of America", "Commonwealth of
-# the ...", 5,308 chars, byte-identical across four hosts) scores 0.21 because
-# country names are full of "of" and "the". What gives it away is that nearly
-# every word is a proper noun.
-#
-# Measured on the labelled sample: median capitalisation was 0.664 for flagged
-# bodies against 0.217 for the rest — a cleaner 3x separation than density's 2x.
-# Together, `density < 0.14 or capitalisation > 0.60` catches 67% of flagged
-# bodies at 4.9% collateral, against 39% for density alone.
-MAX_CAPITALIZATION = 0.60
-
-# Words that belong to the plumbing of a website rather than to a story. Unlike
-# the phrase list above these are single words, so they are counted as a RATE
-# rather than matched: a story may mention a subscriber once, a registration
-# form says "account", "password" and "e-mail" every other line.
-_UTILITY_WORDS = re.compile(
-    r"\b(subscribe|subscriber|account|password|login|log in|sign up|e-?mail|"
-    r"cookies|advertisement|newsletter|click here|browser)\b",
-    re.IGNORECASE,
-)
-
-# Utility words per 100 words, above which the text is site plumbing.
-#
-# The sharpest of the three signals on the labelled sample: median rate 4.13 for
-# flagged bodies against 0.00 for the rest — most real articles contain none of
-# these words at all. Adding it took recall from 39% to 85%.
-MAX_UTILITY_WORD_RATE = 3.0
+# The definition of an article lives in one place so the content cleaner and
+# telemetry cannot drift apart.
+from src.utils.boilerplate import looks_like_article  # noqa: E402
 
 # Proxy status codes for telemetry database (integer field)
 PROXY_STATUS_DISABLED = 0
 PROXY_STATUS_SUCCESS = 1
 PROXY_STATUS_FAILED = 2
 PROXY_STATUS_BYPASSED = 3
-
-
-def strip_boilerplate(body: str) -> str:
-    """Drop the segments of a body that are walls or furniture, not reporting.
-
-    Splits on line and sentence boundaries and discards any segment carrying a
-    boilerplate phrase. Segment-level rather than whole-body, so one "subscribe
-    today" line at the foot of a real story removes that line and keeps the
-    story — the reason a whole-body keyword test cannot be used for this.
-    """
-    if not body:
-        return ""
-    segments = re.split(r"[\n\r]+|(?<=[.!?])\s+", body)
-    kept = [
-        seg
-        for seg in segments
-        if seg.strip() and not any(m in seg.lower() for m in _BOILERPLATE_MARKERS)
-    ]
-    return " ".join(seg.strip() for seg in kept).strip()
-
-
-def prose_density(text: str) -> float:
-    """Share of words that are function words — how much this reads as writing.
-
-    Prose is roughly a third function words. A country dropdown, a nav menu or a
-    tag cloud is close to none, which is what makes this separate written English
-    from a scraped form control without knowing any site's markup.
-    """
-    words = re.findall(r"[a-zA-Z']+", text.lower())
-    if not words:
-        return 0.0
-    return sum(1 for w in words if w in _FUNCTION_WORDS) / len(words)
-
-
-def capitalization_ratio(text: str) -> float:
-    """Share of words beginning with a capital.
-
-    Reporting is mostly lowercase; a scraped list of proper nouns — countries,
-    place names, section menus — is mostly not. This is what catches the bodies
-    that slip past prose_density because their proper nouns happen to contain
-    function words.
-    """
-    words = re.findall(r"[A-Za-z][A-Za-z']*", text)
-    if not words:
-        return 0.0
-    return sum(1 for w in words if w[0].isupper()) / len(words)
-
-
-def utility_word_rate(text: str) -> float:
-    """Website-plumbing words per 100 words.
-
-    Shape signals miss text that reads like writing but is about the site rather
-    than the world — registration prompts, newsletter pitches, cookie notices.
-    Vocabulary catches those: most real articles use none of these words at all.
-    """
-    words = re.findall(r"[a-zA-Z']+", text)
-    if not words:
-        return 0.0
-    return 100 * len(_UTILITY_WORDS.findall(text)) / len(words)
-
-
-def looks_like_article(body: str | None) -> bool:
-    """Whether a body is a story rather than a wall, a form or a menu.
-
-    Content-first by design. A paywall prompt fails however many characters it
-    runs to, because what is measured is the writing that survives the strip —
-    not the byte count of whatever the page happened to return.
-    """
-    if not body or not body.strip():
-        return False
-    # No word-count floor. It was measured against the labelled sample and is
-    # actively harmful here: a >=60-word floor caught 2% of flagged bodies while
-    # failing 13.7% of good ones, because local news genuinely runs short. The
-    # two shape signals do the work; length does not.
-    stripped = strip_boilerplate(body)
-    if prose_density(stripped) < MIN_PROSE_DENSITY:
-        return False  # a list or a menu, not writing
-    if capitalization_ratio(stripped) > MAX_CAPITALIZATION:
-        return False  # a run of proper nouns: a dropdown, a section index
-    return utility_word_rate(stripped) <= MAX_UTILITY_WORD_RATE
 
 
 def proxy_status_to_int(status: str | None) -> int | None:

--- a/src/utils/content_cleaner_balanced.py
+++ b/src/utils/content_cleaner_balanced.py
@@ -11,6 +11,8 @@ from typing import Any
 from sqlalchemy import text as sql_text
 
 from src.models.database import DatabaseManager, safe_session_execute
+from src.utils.boilerplate import is_boilerplate_segment as bp_is_boilerplate_segment
+from src.utils.boilerplate import segments as bp_segments
 
 from .byline_cleaner import BylineCleaner
 from .content_cleaning_telemetry import ContentCleaningTelemetry
@@ -1254,6 +1256,47 @@ class BalancedBoundaryContentCleaner:
         removed_text = "\n".join(removed_segments)
         return {"cleaned_text": cleaned_text, "removed_text": removed_text}
 
+    def _remove_known_boilerplate(self, text: str) -> dict[str, Any]:
+        """Remove furniture that is boilerplate on ANY publisher.
+
+        This exists because the learned path structurally cannot reach it.
+        `_remove_persistent_patterns` only fires once a phrase has recurred at
+        least `min_occurrences` times *within a single source*, and
+        `analyze_domain` gives up entirely on sources with fewer than that many
+        articles. Cross-publisher walls never satisfy that: "Login to continue
+        reading" appears on 16 different hosts, a handful of times each, so it
+        looks like ordinary prose to every source in isolation.
+
+        The consequence was measurable. Across 96,766 stored articles, 11,684
+        (12.1%) still contained one of these phrases in their body, and
+        `content` was byte-identical to `text` for 96,169 of 96,170 records —
+        the cleaning stage was changing essentially nothing.
+
+        The vocabulary is derived from 15,656 hand-cleaned articles diffed
+        against their extracted originals; see src/utils/boilerplate.py.
+        """
+        kept: list[str] = []
+        removed_segments: list[str] = []
+        for segment in bp_segments(text):
+            if bp_is_boilerplate_segment(segment):
+                removed_segments.append(segment)
+            else:
+                kept.append(segment)
+
+        if not removed_segments:
+            return {
+                "cleaned_text": text,
+                "removed_segments": [],
+                "chars_removed": 0,
+            }
+
+        cleaned = " ".join(kept).strip()
+        return {
+            "cleaned_text": cleaned,
+            "removed_segments": removed_segments,
+            "chars_removed": len(text) - len(cleaned),
+        }
+
     def _remove_video_player_ui(self, text: str) -> dict[str, Any]:
         """Remove video player UI garbage text from various CMS platforms.
 
@@ -1478,6 +1521,39 @@ class BalancedBoundaryContentCleaner:
 
         if removed_by_persistent["cleaned_text"] != text:
             text = removed_by_persistent["cleaned_text"]
+
+        # Now sweep up furniture that is boilerplate on ANY publisher, which the
+        # learned pass above structurally cannot reach.
+        #
+        # Order matters, and not in the obvious direction. Running this FIRST
+        # looks tidier and breaks the learned pass: this rebuilds the body from
+        # its segments, and the persistent patterns are stored as exact strings
+        # matched against the text as it was captured. Editing the text before
+        # they run makes them miss, so removing some boilerplate early leaves
+        # more behind than doing nothing. Precise per-source matches go first,
+        # against untouched text; the general vocabulary mops up what is left.
+        known_removal = self._remove_known_boilerplate(text)
+        if known_removal["chars_removed"] > 0:
+            text = known_removal["cleaned_text"]
+            for segment in known_removal["removed_segments"]:
+                removal_details.append(
+                    {
+                        "pattern_type": "known_boilerplate",
+                        "pattern_name": "cross_publisher_boilerplate",
+                        "confidence_score": 1.0,
+                        "removed_text": segment,
+                        "removal_reason": (
+                            "Phrase removed by human cleaners on 4+ distinct "
+                            "publishers; site furniture, not reporting"
+                        ),
+                    }
+                )
+            self.logger.debug(
+                "Removed %d chars of known boilerplate from article %s (%d segments)",
+                known_removal["chars_removed"],
+                article_id,
+                len(known_removal["removed_segments"]),
+            )
 
         share_removal = self._remove_social_share_header(text)
         share_header_removed = bool(share_removal["removed_text"])

--- a/tests/test_known_boilerplate_removal.py
+++ b/tests/test_known_boilerplate_removal.py
@@ -1,0 +1,105 @@
+"""The cleaner must remove furniture it has never seen on that source before.
+
+BalancedBoundaryContentCleaner learns per-source: a phrase has to recur several
+times within ONE publisher before it is removed, and sources with fewer than
+`min_occurrences` articles are skipped entirely. Cross-publisher walls never
+satisfy that — "Login to continue reading" is spread thinly over 16 hosts — so
+they survived indefinitely. Measured consequence: 11,684 of 96,766 stored
+articles still carried one of these phrases.
+
+These tests pin the learning-free pass that closes that gap, using the phrases
+as they actually appear in production.
+"""
+
+from src.utils.boilerplate import looks_like_furniture, strip_boilerplate
+from src.utils.content_cleaner_balanced import BalancedBoundaryContentCleaner
+
+STORY = (
+    "The county commission voted 4-1 on Tuesday to approve the measure. "
+    "Residents said the work would begin in the spring."
+)
+# Verbatim from the corpus, 16 hosts, 548 occurrences each.
+WALL = (
+    "Login to continue reading. Sign up for complimentary access. "
+    "Javascript is required for you to be able to read premium content."
+)
+
+
+def _cleaner() -> BalancedBoundaryContentCleaner:
+    # Bypass __init__: this pass is pure text handling with no DB or telemetry.
+    return BalancedBoundaryContentCleaner.__new__(BalancedBoundaryContentCleaner)
+
+
+class TestKnownBoilerplateRemoval:
+    def test_removes_a_cross_publisher_wall(self):
+        result = _cleaner()._remove_known_boilerplate(STORY + " " + WALL)
+        assert result["chars_removed"] > 0
+        assert "complimentary access" not in result["cleaned_text"].lower()
+        assert "premium content" not in result["cleaned_text"].lower()
+
+    def test_keeps_the_story(self):
+        result = _cleaner()._remove_known_boilerplate(WALL + " " + STORY)
+        assert "county commission" in result["cleaned_text"]
+        assert "would begin in the spring" in result["cleaned_text"]
+
+    def test_reports_what_it_removed(self):
+        result = _cleaner()._remove_known_boilerplate(STORY + " " + WALL)
+        assert len(result["removed_segments"]) == 3
+        assert all(
+            "continue reading" in s.lower()
+            or "complimentary" in s.lower()
+            or "premium content" in s.lower()
+            for s in result["removed_segments"]
+        )
+
+    def test_clean_article_is_untouched(self):
+        """No match must mean no edit — not even whitespace normalisation."""
+        result = _cleaner()._remove_known_boilerplate(STORY)
+        assert result["chars_removed"] == 0
+        assert result["removed_segments"] == []
+        assert result["cleaned_text"] == STORY
+
+    def test_empty_input_is_safe(self):
+        result = _cleaner()._remove_known_boilerplate("")
+        assert result["cleaned_text"] == ""
+        assert result["chars_removed"] == 0
+
+    def test_comment_policy_block_removed(self):
+        body = (
+            STORY + " Please avoid obscene, vulgar, lewd, racist or "
+            "sexually-oriented language. Threats of harming another "
+            "person will not be tolerated."
+        )
+        cleaned = _cleaner()._remove_known_boilerplate(body)["cleaned_text"].lower()
+        assert "obscene" not in cleaned
+        assert "county commission" in cleaned
+
+
+class TestFurnitureIsNotJustShortText:
+    """looks_like_furniture must demand positive evidence, not just brevity."""
+
+    def test_a_short_paragraph_is_not_furniture(self):
+        assert looks_like_furniture("The vote was unanimous.") is False
+
+    def test_a_wall_is_furniture(self):
+        assert looks_like_furniture("Login to continue reading") is True
+
+    def test_a_proper_noun_run_is_furniture(self):
+        assert looks_like_furniture("Canada Mexico Bahamas Cuba Haiti Jamaica") is True
+
+    def test_registration_prose_is_furniture(self):
+        assert (
+            looks_like_furniture(
+                "Enter your e-mail and choose a password to create your account."
+            )
+            is True
+        )
+
+
+class TestSharedDefinition:
+    """The cleaner and telemetry must strip identically."""
+
+    def test_cleaner_pass_matches_strip_boilerplate(self):
+        body = STORY + " " + WALL
+        via_cleaner = _cleaner()._remove_known_boilerplate(body)["cleaned_text"]
+        assert via_cleaner == strip_boilerplate(body)

--- a/tests/test_telemetry_article_qualification.py
+++ b/tests/test_telemetry_article_qualification.py
@@ -10,14 +10,14 @@ data (15,656 cleaned/uncleaned pairs and 1,036 labelled extractions), so these
 tests use the real strings rather than invented ones.
 """
 
-from src.utils.comprehensive_telemetry import (
-    ExtractionMetrics,
+from src.utils.boilerplate import (
     capitalization_ratio,
     looks_like_article,
     prose_density,
     strip_boilerplate,
     utility_word_rate,
 )
+from src.utils.comprehensive_telemetry import ExtractionMetrics
 
 STORY = (
     "The county commission voted 4-1 on Tuesday to approve the measure. "

--- a/tests/test_telemetry_article_qualification.py
+++ b/tests/test_telemetry_article_qualification.py
@@ -1,0 +1,182 @@
+"""What telemetry is allowed to call a successful extraction.
+
+An article is defined by what its text IS, not by how much of it there is. These
+tests pin that: a wall of subscription prose fails however long it runs, a short
+local story passes, and the two ways a non-article used to be recorded as a
+success cannot come back.
+
+The boilerplate phrases and the density threshold are derived from production
+data (15,656 cleaned/uncleaned pairs and 1,036 labelled extractions), so these
+tests use the real strings rather than invented ones.
+"""
+
+from src.utils.comprehensive_telemetry import (
+    ExtractionMetrics,
+    capitalization_ratio,
+    looks_like_article,
+    prose_density,
+    strip_boilerplate,
+    utility_word_rate,
+)
+
+STORY = (
+    "The county commission voted 4-1 on Tuesday to approve the measure. "
+    "Residents said the decision had been a long time coming, and the board "
+    "agreed that the work would begin in the spring. "
+)
+# Verbatim from the corpus: the most common wall across 16-17 hosts.
+WALL = (
+    "Login to continue reading. Sign up for complimentary access. "
+    "Javascript is required for you to be able to read premium content. "
+    "Please enable it in your browser settings."
+)
+
+
+def _metrics() -> ExtractionMetrics:
+    return ExtractionMetrics("op-1", "art-1", "https://example.com/a", "Example")
+
+
+class TestArticleIsContentNotLength:
+    def test_real_story_qualifies(self):
+        assert looks_like_article(STORY) is True
+
+    def test_paywall_wall_is_not_an_article(self):
+        assert looks_like_article(WALL) is False
+
+    def test_a_LONG_wall_is_still_not_an_article(self):
+        """The point of the change: no byte count can rescue this."""
+        padded = (
+            WALL + " " + ("Featured Local Savings. Previous Post. Next Post. " * 40)
+        )
+        assert len(padded) > 2000
+        assert looks_like_article(padded) is False
+
+    def test_short_local_story_qualifies(self):
+        """Local news runs short; a word floor would have failed this."""
+        assert (
+            looks_like_article(
+                "The board met on Monday and agreed to the plan for the new park."
+            )
+            is True
+        )
+
+    def test_empty_bodies_fail(self):
+        # 107 of 1,036 production rows had exactly this and were recorded as
+        # successes whenever a title was present.
+        assert looks_like_article("") is False
+        assert looks_like_article("   \n  ") is False
+        assert looks_like_article(None) is False
+
+    def test_scraped_form_control_is_not_an_article(self):
+        """The country dropdown: 5,308 chars, identical across four hosts."""
+        countries = (
+            "Country United States of America US Virgin Islands United States "
+            "Minor Outlying Islands Canada Mexico Bahamas Cuba Dominican "
+            "Republic Haiti Jamaica Afghanistan Albania Algeria Andorra Angola "
+        ) * 6
+        assert len(countries) > 1000
+        assert looks_like_article(countries) is False
+
+
+class TestStripBoilerplate:
+    def test_trailing_wall_does_not_disqualify_a_story(self):
+        assert looks_like_article(STORY * 3 + " " + WALL) is True
+
+    def test_the_wall_is_actually_removed(self):
+        stripped = strip_boilerplate(STORY + " " + WALL).lower()
+        assert "complimentary access" not in stripped
+        assert "county commission" in stripped
+
+    def test_comment_policy_block_removed(self):
+        body = (
+            STORY
+            + " Please avoid obscene, vulgar, lewd, racist or sexually-oriented language."
+        )
+        stripped = strip_boilerplate(body).lower()
+        assert "obscene" not in stripped
+        assert "county commission" in stripped
+
+    def test_dateline_is_kept_not_stripped(self):
+        """Datelines are content moved to another field, not furniture."""
+        assert "kansas city" in strip_boilerplate("KANSAS CITY, Mo. " + STORY).lower()
+
+
+class TestProseDensity:
+    def test_prose_scores_higher_than_a_form(self):
+        assert prose_density(STORY) > prose_density("Canada Mexico Albania Angola")
+
+    def test_empty_text_is_zero(self):
+        assert prose_density("") == 0.0
+
+
+class TestCapitalization:
+    """Catches proper-noun runs that prose_density is fooled by."""
+
+    def test_country_list_is_mostly_capitalised(self):
+        # "United States of America" contains 'of' — density alone scores this
+        # 0.21 and lets it through. Capitalisation is what rejects it.
+        countries = "United States of America Canada Mexico Bahamas Cuba Haiti"
+        assert capitalization_ratio(countries) > 0.60
+        assert capitalization_ratio(STORY) < 0.60
+
+
+class TestUtilityWords:
+    """Vocabulary catches text that reads like writing but is about the site."""
+
+    def test_registration_prose_is_rejected(self):
+        signup = (
+            "Create your account below. Enter your e-mail and choose a password. "
+            "You can sign up for our newsletter and manage your account settings "
+            "in your browser at any time. Click here to subscribe."
+        )
+        # Reads like sentences, so density and capitalisation both pass it.
+        assert prose_density(signup) >= 0.14
+        assert capitalization_ratio(signup) <= 0.60
+        # Vocabulary is what rejects it.
+        assert utility_word_rate(signup) > 3.0
+        assert looks_like_article(signup) is False
+
+    def test_a_story_mentioning_a_subscriber_once_still_qualifies(self):
+        assert utility_word_rate(STORY * 3 + " One subscriber objected.") <= 3.0
+        assert looks_like_article(STORY * 3 + " One subscriber objected.") is True
+
+
+class TestFinalizeSuccessVerdict:
+    def test_story_is_success(self):
+        m = _metrics()
+        m.finalize({"title": "T", "content": STORY})
+        assert m.is_success is True
+
+    def test_title_with_no_body_is_not_success(self):
+        """Previously `has_title or ...` made this a success with no article."""
+        m = _metrics()
+        m.finalize({"title": "A headline", "content": ""})
+        assert m.is_success is False
+
+    def test_paywall_body_is_not_success(self):
+        m = _metrics()
+        m.finalize({"title": "A headline", "content": WALL})
+        assert m.is_success is False
+
+
+class TestSeleniumUsageIsCountable:
+    """successful_method is not a usage counter; methods_attempted is."""
+
+    def test_selenium_backfill_leaves_successful_method_as_the_http_parser(self):
+        m = _metrics()
+        m.start_method("mcmetadata")
+        m.end_method("mcmetadata", True, None, {})
+        m.start_method("selenium")
+        m.end_method("selenium", True, None, {})
+
+        # This is the ~10x undercount: selenium ran but did not win overall.
+        assert m.successful_method == "mcmetadata"
+        # The honest signal, and it is persisted alongside successful_method:
+        assert m.was_attempted("selenium") is True
+        assert "selenium" in m.methods_attempted
+
+    def test_was_attempted_is_false_when_selenium_never_ran(self):
+        m = _metrics()
+        m.start_method("mcmetadata")
+        m.end_method("mcmetadata", True, None, {})
+        assert m.was_attempted("selenium") is False

--- a/tests/test_telemetry_system.py
+++ b/tests/test_telemetry_system.py
@@ -517,10 +517,15 @@ class TestComprehensiveExtractionTelemetry:
         }
         metrics.end_method("newspaper4k", True, None, extracted_fields)
 
-        # Finalize the metrics with final result
+        # Finalize the metrics with final result. The body is real prose because
+        # success is now decided by what the text is; a placeholder like
+        # "Article content" is not an article and would record as a failure.
         final_result = {
             "title": "Test Article",
-            "content": "Article content",
+            "content": (
+                "The council approved the budget on Tuesday after a long debate, "
+                "and the mayor said the work would begin in the spring."
+            ),
             "author": "John Doe",
         }
         metrics.finalize(final_result)
@@ -987,7 +992,13 @@ class TestTelemetrySystemEndToEnd:
                 metrics.start_method("newspaper4k")
                 extracted_fields = {
                     "title": f"Article {i} Title",
-                    "content": f"Article {i} content...",
+                    # Real prose: the good-site branch is meant to record a
+                    # success, and success is decided by what the body is.
+                    "content": (
+                        f"Story {i}. The council approved the budget on Tuesday "
+                        "after a long debate, and the mayor said the work would "
+                        "begin in the spring."
+                    ),
                     "author": "Test Author",
                     "metadata": {"http_status": 200},
                 }
@@ -1013,6 +1024,11 @@ class TestTelemetrySystemEndToEnd:
                 )
 
             metrics.end_time = datetime.utcnow() + timedelta(seconds=2)
+            # Finalize before recording, as every production call site does
+            # (src/cli/commands/extraction.py finalizes immediately before each
+            # record_extraction, with {} on the error paths). Without this the
+            # verdict is never computed and success would come from nowhere.
+            metrics.finalize(extracted_fields if "good-site" in host else {})
             telemetry.record_extraction(metrics)
 
         # Verify results using API-style queries with PostgreSQL

--- a/tests/test_telemetry_system.py
+++ b/tests/test_telemetry_system.py
@@ -131,18 +131,37 @@ class TestExtractionMetrics:
         assert field_stats["metadata"] is False
 
     def test_finalize_marks_success_from_content_only(self):
-        """Finalize should mark success when content is substantial."""
+        """Finalize marks success on a body alone, with no title.
+
+        Updated when success stopped being a character count. The body here is
+        real prose rather than the previous `"lorem ipsum " * 20`, which passed
+        only because it cleared 100 characters — placeholder text contains no
+        function words and is not an article by the current definition.
+        """
         metrics = ExtractionMetrics("op-final", "art-final", "https://test", "test")
         metrics.start_time = datetime.utcnow()
         metrics.end_time = metrics.start_time
 
-        long_content = "lorem ipsum " * 20  # > 100 characters
-        metrics.finalize({"title": "", "content": long_content})
+        body = (
+            "The council approved the budget on Tuesday after a long debate, and "
+            "the mayor said the work would begin in the spring."
+        )
+        metrics.finalize({"title": "", "content": body})
 
         assert metrics.is_success is True
-        assert metrics.content_length == len(long_content)
+        assert metrics.content_length == len(body)
         assert metrics.extracted_fields["content"] is True
         assert metrics.extracted_fields["title"] is False
+
+    def test_finalize_rejects_a_body_that_is_not_writing(self):
+        """A character count is not the test; what the text is, is."""
+        metrics = ExtractionMetrics("op-final2", "art-final2", "https://test", "test")
+        metrics.start_time = datetime.utcnow()
+        metrics.end_time = metrics.start_time
+
+        metrics.finalize({"title": "A headline", "content": "lorem ipsum " * 20})
+
+        assert metrics.is_success is False
 
     def test_proxy_and_driver_metrics_sanitization(self):
         """Proxy + driver metrics should normalize inputs safely."""

--- a/tests/utils/test_comprehensive_telemetry_metrics.py
+++ b/tests/utils/test_comprehensive_telemetry_metrics.py
@@ -56,9 +56,12 @@ def test_extraction_metrics_tracks_methods(monkeypatch):
     assert metrics.http_error_type == "4xx_client_error"
     assert metrics.alternative_extractions["fallback"]["title"]["values_differ"] is True
     assert metrics.final_field_attribution["title"] == "primary"
-    assert metrics.is_success is True
     assert metrics.content_length == len("Body")
     assert metrics.field_extraction["primary"]["metadata"] is True
+    # A four-character body is not an article. This previously read True only
+    # because a title was present; success no longer follows from a headline.
+    # Method tracking and attribution above are what this test is really for.
+    assert metrics.is_success is False
 
 
 def test_set_driver_metrics_sanitizes_payload():


### PR DESCRIPTION
Stacked on #402 (shares `src/utils/boilerplate.py`); merge that first.

## The cleaner could not see its most common target

`BalancedBoundaryContentCleaner` learns **per source**: a phrase must recur at least `min_occurrences` (3) times within ONE publisher before it is removed, and `analyze_domain` gives up entirely on sources with fewer articles than that.

Cross-publisher furniture never satisfies that test. `"Login to continue reading"` is spread over **16 hosts** a handful of times each, so to every source in isolation it looks like ordinary prose. Measured across production:

- **11,684 of 96,766 stored articles (12.1%)** still contained one of these phrases in the body
- **`content` was byte-identical to `text` for 96,169 of 96,170 records** — the cleaning stage was changing essentially nothing

`_remove_known_boilerplate` closes the gap with a learning-free pass over a vocabulary derived from 15,656 hand-cleaned articles diffed against their extracted originals, keeping only segments a human removed on **4+ distinct hosts**. It removes **segments, not articles** — a subscribe line at the foot of a story takes the line and leaves the story.

## Ordering, which is not the obvious way round

The pass runs **after** the learned patterns, not before.

Running it first is tidier and **breaks them**: it rebuilds the body from its segments, while persistent patterns are stored as exact strings matched against the text as captured. Edit the text before they run and they miss — so removing some boilerplate early leaves **more** behind than doing nothing.

This was caught by `test_subscription_module_cleaning`, which **passed on the base commit and failed on mine** — verified rather than assumed to be a stale test. The ordering is now pinned by that test and by a comment explaining why it cannot be reordered.

## content is the raw capture, text is the cleaned body

Extraction bound the same cleaned string to both columns (`"text": content_text,  # Same as content`), throwing the raw copy away. With no before/after pair, nothing could measure what cleaning removed — or notice it had stopped removing anything, which is how the above went unseen.

The rest of the pipeline already assumed this split: `cleaning.py` reads `a.content` as its input, `entity_extraction.py` reads `a.text` as the cleaned result. This makes the columns mean what their readers already believe. Re-cleaning now writes only the cleaned side, so it can be re-run against improved rules and compared with what it replaced.

Note: this accumulates going forward only. Existing rows have `content == text`, so there is no raw copy to recover for them.

## One definition

`src/utils/boilerplate.py` holds the vocabulary and the shape measures, imported by both the cleaner and telemetry, replacing the four-word subscription lists duplicated across five cleaner variants. Every threshold carries the measurement that chose it.

## Tests

13 new, and 774 pass across the extraction/cleaning/telemetry suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)