### PR TITLE
fix(extraction): store the cleaned body in text, keep the raw in content

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -1757,7 +1757,30 @@ def _process_batch(
                             raise
                         continue  # Skip to next article
 
-                    text_hash = calculate_content_hash(content_text)
+                    # Keep BOTH sides of the clean. The cleaner already ran above,
+                    # but only to sniff for paywall patterns — its output was
+                    # discarded and the raw capture was written to `content` AND
+                    # `text`. That is why the two columns were byte-identical for
+                    # 96,169 of 96,170 stored articles, why 12.1% of them still
+                    # carried boilerplate, and why the smoke test's "content
+                    # reduction" metric could only ever read 0%.
+                    #
+                    # `content` = raw capture, `text` = cleaned body. That is the
+                    # pair every consumer already assumes: content_cleaner reads
+                    # a.content as its input, entity extraction reads a.text as
+                    # the cleaned result.
+                    #
+                    # Fall back to the raw text if cleaning returned nothing, so a
+                    # cleaner failure degrades to today's behaviour rather than
+                    # storing an empty body. Paywall rows reach here with a short
+                    # stripped_content by design — that IS the finding, and the
+                    # raw prose is still preserved in `content`.
+                    cleaned_text = stripped_content or content_text
+
+                    # Hash the cleaned side: text_hash describes `text`, and entity
+                    # extraction records it as article_entities.article_text_hash to
+                    # mark which version of the text its entities came from.
+                    text_hash = calculate_content_hash(cleaned_text)
 
                     metrics.set_content_type_detection(detection_payload)
                     _attach_driver_metrics(metrics, extractor, domain)
@@ -1817,7 +1840,7 @@ def _process_batch(
                             "author": cleaned_author,
                             "publish_date": content.get("publish_date"),
                             "content": content_text,
-                            "text": content_text,  # Same as content
+                            "text": cleaned_text,  # cleaned; raw stays in content
                             "status": article_status,
                             "metadata": json.dumps(content.get("metadata", {})),
                             "wire": wire_service_info,

--- a/tests/test_batch_stores_cleaned_text.py
+++ b/tests/test_batch_stores_cleaned_text.py
@@ -1,0 +1,71 @@
+"""The batch extraction path must keep BOTH sides of the clean.
+
+`_process_batch` already ran the content cleaner, but in dry_run mode and only
+to sniff for paywall patterns — the cleaned output was discarded and the raw
+capture was written to `content` AND `text`. The consequences were measurable in
+production: `content` was byte-identical to `text` for 96,169 of 96,170 stored
+articles, 12.1% still carried boilerplate, and the smoke suite's "content
+reduction" metric could only ever read 0%.
+
+These tests pin the contract the rest of the pipeline already assumes:
+content_cleaner reads `a.content` as its input, entity extraction reads `a.text`
+as the cleaned result.
+"""
+
+import inspect
+
+import src.cli.commands.extraction as extraction
+
+
+def _batch_source() -> str:
+    return inspect.getsource(extraction._process_batch)
+
+
+class TestBatchPathKeepsBothSides:
+    def test_text_is_bound_to_the_cleaned_body(self):
+        src = _batch_source()
+        assert (
+            '"text": cleaned_text' in src
+        ), "the batch INSERT must store the cleaned body in `text`"
+
+    def test_content_is_bound_to_the_raw_capture(self):
+        src = _batch_source()
+        assert (
+            '"content": content_text' in src
+        ), "the batch INSERT must keep the raw capture in `content`"
+
+    def test_the_two_columns_are_no_longer_the_same_binding(self):
+        """The regression this exists to prevent."""
+        src = _batch_source()
+        assert '"text": content_text' not in src, (
+            "storing the raw capture in `text` is what made content == text for "
+            "96,169 of 96,170 articles"
+        )
+
+    def test_cleaned_text_falls_back_to_raw(self):
+        """A cleaner failure must degrade to today's behaviour, not an empty body."""
+        src = _batch_source()
+        assert "cleaned_text = stripped_content or content_text" in src
+
+    def test_hash_describes_the_cleaned_side(self):
+        """text_hash is recorded as article_entities.article_text_hash."""
+        src = _batch_source()
+        assert "calculate_content_hash(cleaned_text)" in src
+        assert "calculate_content_hash(content_text)" not in src
+
+
+class TestCleanerOutputIsStillUsedForPaywallDetection:
+    """The fix must not disturb the paywall check that shares stripped_content."""
+
+    def test_paywall_check_still_reads_stripped_content(self):
+        src = _batch_source()
+        assert "len(stripped_content.strip()) < MIN_CONTENT_LENGTH" in src
+
+    def test_dry_run_is_preserved(self):
+        """dry_run only gates wire-marking and suppression, not the cleaning.
+
+        Keeping it True avoids re-introducing those side effects on a path that
+        handles wire status separately.
+        """
+        src = _batch_source()
+        assert "dry_run=True" in src


### PR DESCRIPTION
## The batch path already ran the cleaner — and threw the result away

`_process_batch` calls `process_single_article(dry_run=True)` purely to sniff for paywall patterns, then writes the **raw** capture to both `content` and `text`. The cleaned output is computed and discarded on every article.

That one binding explains every symptom chased over the last two days:

- `content` was byte-identical to `text` for **96,169 of 96,170** stored articles
- **11,684 of 96,766 (12.1%)** still carried boilerplate in the body
- the smoke suite's "content reduction" metric could only ever read **0%**
- a 114-article production run on `47cf3f0` produced **0 rows** where the two columns differed — even with the cleaner hardened in #403

So the cleaner was never weak on this path. Its output was discarded.

## This reached the researcher-facing output, not just an internal column

The daily sheet export selects the cleaned column from BigQuery:

```sql
IFNULL(SUBSTR(a.text, 0, 50000), '') as text
FROM `mizzou-news-crawler.mizzou_analytics.articles` a
WHERE a.status NOT IN ('wire', 'obituary', 'opinion')
```

Because `text` held the raw capture, the paywall walls, cookie notices and "Featured Local Savings" blocks have been flowing straight into the exported sheet — across all 96,804 rows in that table.

## The fix

`content` = raw capture, `text` = cleaned body. That is the pair the rest of the pipeline already assumed: `content_cleaner` reads `a.content` as its input, entity extraction reads `a.text` as the cleaned result.

Details worth keeping:

- **Falls back to raw** when cleaning returns nothing, so a cleaner failure degrades to today's behaviour rather than storing an empty body.
- **Paywall rows deliberately reach the insert with a short cleaned body** — that IS the finding, and the raw prose is still preserved in `content`.
- **`text_hash` now hashes the cleaned side**, because it describes `text` and entity extraction records it as `article_entities.article_text_hash` to mark which version of the text its entities came from. Nothing dedups on it.
- **`dry_run` stays `True`** — it gates only wire-marking and suppression recording, not the cleaning itself, and this path handles wire status separately.

## Tests

7 new tests pin the contract, including the specific regression (`"text": content_text` must not reappear). 794 pass across the extraction/cleaning/telemetry suites.

## Note on existing data

This applies going forward. The ~96k existing rows have `content == text` with no raw copy to recover, so their `text` stays uncleaned until re-cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)