### PR TITLE
fix(rot47): decode on the write path, and unescape before decoding

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -28,6 +28,10 @@ from src.models.database import (
     safe_session_execute,
     save_article_entities,
 )
+
+# stdlib-only module (re + collections.abc), so this stays safe to import in the
+# crawler image, which carries no ML dependencies.
+from src.pipeline.text_cleaning import decode_rot47_segments
 from src.services.wire_detection import resolve_api_token
 
 # Lazy import: entity_extraction only needed for entity-extraction command
@@ -119,6 +123,37 @@ def _initial_wire_check_status(article_status: str) -> str:
     # Default to pending for safety - includes "extracted", "wire", "cleaned", "labeled"
     # This ensures even incorrectly-set "wire" status gets verified
     return WIRE_CHECK_STATUS_PENDING
+
+
+def _decode_capture(raw: str | None) -> str:
+    """Decode ROT47-obfuscated body text before anything reads it as prose.
+
+    Lee Enterprises / TownNews sites serve premium paragraphs ROT47-encoded
+    rather than withholding them, so a capture looks healthy: the free preview
+    is plain text and the ciphertext starts several sentences in, past the point
+    where a reader — or a reviewer spot-checking the corpus — stops looking.
+
+    The decoder itself has been in the tree and correct all along, but it was
+    only ever called from two places: entity extraction, which decodes into a
+    local and writes nothing back, and the standalone `clean` command. This
+    module is what writes `content` and `text` for every crawled article and it
+    never called it, so the ciphertext was stored and every later consumer
+    inherited it. Entity extraction decoding on read is what hid the problem —
+    that stage's output looked right while the cleaner, the classifier, word
+    counts and the researcher export all saw scrambled text.
+
+    Decode is applied to the CLEANING INPUT, not to the stored `content`.
+    `content` keeps the raw capture verbatim so the before/after pair stays
+    intact and the decode can be re-run or audited later; `text` gets the
+    decoded, cleaned body.
+
+    Returns *raw* unchanged when no ROT47 markers are present, which is the
+    overwhelmingly common case.
+    """
+
+    if not raw:
+        return raw or ""
+    return decode_rot47_segments(raw) or raw
 
 
 def _get_canonical_url(original_url: str, metadata: dict) -> str:
@@ -1096,12 +1131,13 @@ def handle_extract_url_command(args) -> int:
             return 1
 
         # If necessary, run content cleaning to obtain text
+        decoded_text = _decode_capture(content_text)
         try:
             cleaned_text, _cleaned_meta = content_cleaner.process_single_article(
-                content_text, domain, dry_run=False
+                decoded_text, domain, dry_run=False
             )
         except Exception:
-            cleaned_text = content_text
+            cleaned_text = decoded_text
             _cleaned_meta = {}
 
         text_hash = calculate_content_hash(cleaned_text)
@@ -1684,12 +1720,17 @@ def _process_batch(
                         from urllib.parse import urlparse
 
                         domain = urlparse(url).netloc
+                        # ROT47 must be undone before the cleaner runs, or every
+                        # length check below counts ciphertext as article body:
+                        # a fully-paywalled page reads as ~4,000 healthy chars
+                        # and never trips the paywall branch.
+                        decoded_text = _decode_capture(content_text)
                         # Clean content using persistent patterns from database
                         # Note: Some test implementations may not support dry_run parameter
                         try:
                             stripped_content, cleaning_metadata = (
                                 content_cleaner.process_single_article(
-                                    text=content_text,
+                                    text=decoded_text,
                                     domain=domain,
                                     dry_run=True,  # Don't modify the original content
                                 )
@@ -1698,10 +1739,11 @@ def _process_batch(
                             # Fallback for test mocks without dry_run parameter
                             stripped_content, cleaning_metadata = (
                                 content_cleaner.process_single_article(
-                                    content_text, domain
+                                    decoded_text, domain
                                 )
                             )
                     else:
+                        decoded_text = ""
                         stripped_content = ""
 
                     # Check if content is insufficient AND has paywall indicators
@@ -1775,7 +1817,11 @@ def _process_batch(
                     # storing an empty body. Paywall rows reach here with a short
                     # stripped_content by design — that IS the finding, and the
                     # raw prose is still preserved in `content`.
-                    cleaned_text = stripped_content or content_text
+                    #
+                    # The fallback takes the DECODED text, never the raw capture:
+                    # on a ROT47 page a cleaner failure would otherwise store
+                    # ciphertext as the article body.
+                    cleaned_text = stripped_content or decoded_text or content_text
 
                     # Hash the cleaned side: text_hash describes `text`, and entity
                     # extraction records it as article_entities.article_text_hash to
@@ -2328,8 +2374,15 @@ def _run_post_extraction_cleaning(domains_to_articles, db=None):
                     if not original_content.strip():
                         continue
 
+                    # Re-cleaning reads `content` straight from the database, so
+                    # it inherits whatever was stored — including the ciphertext
+                    # written by every extraction that ran before this fix. Decode
+                    # here too, or re-running the cleaner over the backlog would
+                    # faithfully re-clean scrambled text.
+                    decoded_content = _decode_capture(original_content)
+
                     cleaned_content, metadata = cleaner.process_single_article(
-                        text=original_content,
+                        text=decoded_content,
                         domain=domain,
                         article_id=article_id,
                     )

--- a/src/pipeline/text_cleaning.py
+++ b/src/pipeline/text_cleaning.py
@@ -9,10 +9,26 @@ from collections.abc import Iterable
 _ROT47_MARKERS = set("@?:;[]=^$\\|")
 _TOKEN_RE = re.compile(r"\S+")
 
+# Markup revealed by decoding. The encoding hides real tags, so the decoded
+# text carries them back: <p class="p1">, <hr />, and friends. A literal
+# </?p> misses every attributed form and leaves it in the article body.
+_DECODED_TAG_RE = re.compile(r"</?(?:p|hr|br|em|strong|span)\b[^>]*>", re.I)
+
 # Lee Enterprises ROT47 paragraph markers
 # kAm = <p>, k^Am = </p>, k9C ^m = <hr >
+#
+# The opening tag frequently carries attributes, which encode into the run
+# between `kA` and the closing `m`:
+#
+#     kA 4=2DDlQAcQm   ->   <p class="p4">
+#
+# Requiring a bare `kAm` therefore matched nothing on those articles. In the
+# March researcher file the attribute form is the DOMINANT one — affected rows
+# carry 24-27 `k^Am` closers and zero bare `kAm` openers, so the decoder passed
+# straight over them. `[^m]` is safe as the attribute body because `m` is the
+# encoding of `>`, which cannot appear unescaped inside a tag.
 _ROT47_PARAGRAPH_PATTERN = re.compile(
-    r"kAm.*?k\^Am",
+    r"kA[^m]{0,120}m.*?k\^Am",
     re.DOTALL,
 )
 
@@ -124,7 +140,7 @@ def _decode_segment(segment: str) -> str | None:
         return None
     if letters / len(decoded) < 0.4:
         return None
-    cleaned = re.sub(r"</?p>", " ", decoded)
+    cleaned = _DECODED_TAG_RE.sub(" ", decoded)
     return cleaned
 
 
@@ -138,8 +154,13 @@ def _decode_rot47_by_markers(text: str) -> str | None:
 
     This is more reliable than token-based detection since short words
     like "of", "33," don't break the pattern matching.
+
+    The guard admits `k^Am` on its own. Articles whose paragraphs all open with
+    attributes carry no bare `kAm` anywhere, so guarding on it alone returned
+    None before the pattern ever ran — the regex finds 24 paragraphs in such an
+    article and decodes the first cleanly, but the function never reached it.
     """
-    if "kAm" not in text:
+    if "kAm" not in text and "k^Am" not in text:
         return None
 
     # Find all ROT47 paragraph segments
@@ -157,8 +178,7 @@ def _decode_rot47_by_markers(text: str) -> str | None:
         letters = sum(1 for ch in decoded if ch.isalpha())
         if len(decoded) > 0 and letters / len(decoded) >= 0.3:
             # Clean up HTML tags
-            cleaned = re.sub(r"</?p>", " ", decoded)
-            cleaned = re.sub(r"<hr\s*/?>", " ", cleaned)
+            cleaned = _DECODED_TAG_RE.sub(" ", decoded)
             replacements.append((match.start(), match.end(), cleaned))
 
     if not replacements:

--- a/src/pipeline/text_cleaning.py
+++ b/src/pipeline/text_cleaning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import re
 from collections.abc import Iterable
 
@@ -71,8 +72,53 @@ def _iter_rot47_ranges(text: str) -> Iterable[tuple[int, int]]:
             )
 
 
+# Damage left by decoding ROT47 without unescaping first. `U=Ej` sits where a
+# `k` belongs and `U8Ej` where an `m` belongs, so "asked" was stored as
+# "asU=Ejed" and "community" as "coU8EjU8Ejunity". Neither sequence occurs in
+# English, which makes the repair unambiguous and safe to apply to any input.
+_ENTITY_ARTIFACTS = (("U=Ej", "k"), ("U8Ej", "m"))
+
+
+def repair_entity_artifacts(text: str) -> str:
+    """Undo the ``U=Ej`` / ``U8Ej`` corruption in already-stored text.
+
+    Rows written before the unescape fix carry this damage baked in: they hold
+    no ROT47 markers and no escaped entities, just prose with every ``k`` and
+    ``m`` replaced. Decoding cannot help them — the ciphertext is gone — but the
+    substitution is reversible on its own.
+    """
+
+    if not text:
+        return text
+    for artifact, letter in _ENTITY_ARTIFACTS:
+        if artifact in text:
+            text = text.replace(artifact, letter)
+    return text
+
+
+def _decode_rot47_text(segment: str) -> str:
+    """ROT47-decode *segment*, unescaping HTML entities FIRST.
+
+    ROT47 maps ``k`` -> ``<`` and ``m`` -> ``>``. Any ``k`` or ``m`` in the
+    original prose therefore arrives inside the ciphertext as a literal ``<`` or
+    ``>``, which the page must escape as ``&lt;`` / ``&gt;`` to avoid breaking
+    its own markup. Decoding those entities character-by-character produces
+    ``U=Ej`` and ``U8Ej`` exactly where the letter belongs:
+
+        ciphertext on the page   '2D&lt;65'
+        decoded without unescape 'asU=Ejed'
+        decoded with unescape    'asked'
+
+    Every ``k`` and every ``m`` in the recovered text was corrupted this way, so
+    the output read as ciphertext to anything checking for it — which is why
+    29% of affected articles still looked encoded after decoding.
+    """
+
+    return _rot47(html.unescape(segment))
+
+
 def _decode_segment(segment: str) -> str | None:
-    decoded = _rot47(segment)
+    decoded = _decode_rot47_text(segment)
     letters = sum(1 for ch in decoded if ch.isalpha())
     if not decoded.strip():
         return None
@@ -105,7 +151,7 @@ def _decode_rot47_by_markers(text: str) -> str | None:
     replacements: list[tuple[int, int, str]] = []
     for match in matches:
         segment = match.group(0)
-        decoded = _rot47(segment)
+        decoded = _decode_rot47_text(segment)
 
         # Basic validation: decoded should have reasonable letter ratio
         letters = sum(1 for ch in decoded if ch.isalpha())
@@ -139,6 +185,11 @@ def decode_rot47_segments(text: str | None) -> str | None:
 
     if not text:
         return text
+
+    # Repair first: rows decoded before the unescape fix carry the damage with
+    # no markers left to key off, so this is the only pass that can reach them.
+    text = repair_entity_artifacts(text)
+
     if "kAm" not in text and "k^Am" not in text:
         # Quick short-circuit for the common unaffected case.
         return text

--- a/tests/test_batch_stores_cleaned_text.py
+++ b/tests/test_batch_stores_cleaned_text.py
@@ -43,9 +43,14 @@ class TestBatchPathKeepsBothSides:
         )
 
     def test_cleaned_text_falls_back_to_raw(self):
-        """A cleaner failure must degrade to today's behaviour, not an empty body."""
+        """A cleaner failure must degrade to today's behaviour, not an empty body.
+
+        The fallback now prefers the DECODED capture, so a cleaner failure on a
+        ROT47 page stores recovered prose rather than ciphertext. See
+        tests/test_rot47_on_extraction_path.py.
+        """
         src = _batch_source()
-        assert "cleaned_text = stripped_content or content_text" in src
+        assert "cleaned_text = stripped_content or decoded_text or content_text" in src
 
     def test_hash_describes_the_cleaned_side(self):
         """text_hash is recorded as article_entities.article_text_hash."""

--- a/tests/test_rot47_on_extraction_path.py
+++ b/tests/test_rot47_on_extraction_path.py
@@ -1,0 +1,174 @@
+"""ROT47 ciphertext must never reach the stored article body.
+
+Lee Enterprises / TownNews sites serve premium paragraphs ROT47-encoded rather
+than withholding them. The capture therefore looks healthy — the free preview is
+plain prose and the ciphertext begins several sentences in, past the point where
+a reader or a reviewer spot-checking the corpus stops looking.
+
+`decode_rot47_segments` has been in the tree and correct all along, but nothing
+on the write path called it. Its only two callers were entity extraction, which
+decodes into a local and writes nothing back, and the standalone `clean`
+command. Entity extraction decoding on read is precisely what hid this: that
+stage's output looked right while the cleaner, the classifier, word counts and
+the researcher export all saw scrambled text.
+
+Measured in the researcher gold file before the fix: 151 of 15,653 articles
+carried ROT47 in the cleaned `text` column, including 112 of 199 from
+missourian.com.
+"""
+
+import html
+import inspect
+
+import src.cli.commands.extraction as extraction
+from src.pipeline.text_cleaning import (
+    _rot47,
+    decode_rot47_segments,
+    repair_entity_artifacts,
+)
+
+
+def _encode_premium(plain: str) -> str:
+    """Build a capture shaped like the real thing: free preview, then cipher."""
+    return f"kAm{_rot47(plain)}k^Am"
+
+
+PREVIEW = (
+    "St. Clair's Lady Bulldogs gave the top seed everything it could handle. "
+    "A chance to tie the game at the final buzzer did not fall for St. Clair."
+)
+PREMIUM = (
+    "Lucas is the definition of consistent, Jesse Knott said. In his wins, he "
+    "was absolutely dominant, finishing with two falls and two tech falls. It "
+    "was great to watch him end his high school career on the winning side."
+)
+
+
+class TestDecodeCapture:
+    def test_plain_text_is_returned_unchanged(self):
+        """The overwhelmingly common case must be a no-op, not a rewrite."""
+        assert extraction._decode_capture(PREVIEW) == PREVIEW
+
+    def test_empty_and_none_are_safe(self):
+        assert extraction._decode_capture("") == ""
+        assert extraction._decode_capture(None) == ""
+
+    def test_rot47_paragraphs_are_decoded(self):
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        decoded = extraction._decode_capture(capture)
+        assert "Lucas is the definition of consistent" in decoded
+        assert "two falls and two tech falls" in decoded
+
+    def test_the_free_preview_survives_decoding(self):
+        """Decoding must not disturb the plain-text head of the article."""
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        assert "Lady Bulldogs gave the top seed" in extraction._decode_capture(capture)
+
+    def test_no_ciphertext_markers_remain(self):
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        decoded = extraction._decode_capture(capture)
+        assert "kAm" not in decoded and "k^Am" not in decoded
+
+    def test_decoding_is_idempotent(self):
+        """Re-cleaning runs over already-stored rows; a second pass must not
+        re-scramble text an earlier pass already recovered."""
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        once = extraction._decode_capture(capture)
+        assert extraction._decode_capture(once) == once
+
+    def test_ciphertext_is_not_mistaken_for_article_length(self):
+        """The bug that let fully-paywalled pages pass the length check.
+
+        MIN_CONTENT_LENGTH is applied to the cleaner's output. While the body
+        stayed encoded, ~4,000 characters of ciphertext read as a healthy
+        article and the paywall branch never fired.
+        """
+        capture = _encode_premium(PREMIUM)
+        assert len(capture) > 150  # would have sailed past the check
+        decoded = extraction._decode_capture(capture)
+        assert decoded != capture
+        assert "definition of consistent" in decoded
+
+
+class TestHtmlEntitiesAreUnescapedBeforeDecoding:
+    """ROT47 maps k -> < and m -> >, so those letters arrive escaped.
+
+    Decoding `&lt;` character-by-character yields `U=Ej`, and `&gt;` yields
+    `U8Ej`. Every k and every m in the recovered prose was corrupted that way,
+    which is why 29% of affected articles still scanned as ciphertext after
+    decoding.
+    """
+
+    def test_escaped_k_round_trips(self):
+        assert _rot47("asked") == "2D<65"
+        on_page = html.escape("2D<65")  # '2D&lt;65'
+        assert decode_rot47_segments(f"kAm{on_page}k^Am").strip() == "asked"
+
+    def test_escaped_m_round_trips(self):
+        on_page = html.escape(_rot47("community"))
+        assert decode_rot47_segments(f"kAm{on_page}k^Am").strip() == "community"
+
+    def test_the_artifact_no_longer_appears(self):
+        on_page = html.escape(_rot47("asked the community"))
+        out = decode_rot47_segments(f"kAm{on_page}k^Am")
+        assert "U=Ej" not in out and "U8Ej" not in out
+
+
+class TestRepairOfAlreadyStoredDamage:
+    """Rows decoded before the unescape fix carry the damage baked in.
+
+    They hold no ROT47 markers and no escaped entities — just prose with every
+    k and m replaced — so decoding cannot reach them. The substitution is
+    reversible on its own because neither sequence occurs in English.
+    """
+
+    def test_repairs_k(self):
+        assert (
+            repair_entity_artifacts("the feedbacU=Ej we got") == "the feedback we got"
+        )
+
+    def test_repairs_m(self):
+        assert repair_entity_artifacts("U8Ejayor pro teU8Ej") == "mayor pro tem"
+
+    def test_repairs_repeated_and_adjacent(self):
+        assert repair_entity_artifacts("coU8EjU8Ejunity") == "community"
+
+    def test_clean_prose_is_untouched(self):
+        prose = "The council voted 4-1 on Tuesday to approve the measure."
+        assert repair_entity_artifacts(prose) == prose
+
+    def test_repair_runs_even_without_markers(self):
+        """The whole point: damaged rows have no markers left to key off."""
+        damaged = "walU=Ejs in and uses theU8Ej"
+        assert decode_rot47_segments(damaged) == "walks in and uses them"
+
+    def test_repair_is_idempotent(self):
+        once = repair_entity_artifacts("SoU8Eje feedbacU=Ej")
+        assert repair_entity_artifacts(once) == once
+
+
+class TestWritePathDecodesBeforeCleaning:
+    """Pin the wiring at each site that persists an article body."""
+
+    def test_batch_path_cleans_the_decoded_text(self):
+        src = inspect.getsource(extraction._process_batch)
+        assert "decoded_text = _decode_capture(content_text)" in src
+        assert "text=decoded_text" in src
+
+    def test_batch_fallback_never_stores_ciphertext(self):
+        """A cleaner failure must degrade to decoded prose, not the raw cipher."""
+        src = inspect.getsource(extraction._process_batch)
+        assert "cleaned_text = stripped_content or decoded_text or content_text" in src
+
+    def test_batch_still_stores_the_raw_capture_in_content(self):
+        """`content` keeps the verbatim capture so the decode stays auditable."""
+        src = inspect.getsource(extraction._process_batch)
+        assert '"content": content_text' in src
+        assert '"text": cleaned_text' in src
+
+    def test_recleaning_path_decodes_what_it_reads_back(self):
+        """Re-cleaning reads `content` from the database, so it inherits every
+        row written before this fix."""
+        src = inspect.getsource(extraction._run_post_extraction_cleaning)
+        assert "decoded_content = _decode_capture(original_content)" in src
+        assert "text=decoded_content" in src

--- a/tests/test_rot47_on_extraction_path.py
+++ b/tests/test_rot47_on_extraction_path.py
@@ -114,6 +114,48 @@ class TestHtmlEntitiesAreUnescapedBeforeDecoding:
         assert "U=Ej" not in out and "U8Ej" not in out
 
 
+class TestParagraphsWithAttributes:
+    """`<p class="p1">` encodes to `kA 4=2DDlQA`Qm`, not to a bare `kAm`.
+
+    Two separate faults conspired here. The pattern required a literal `kAm`,
+    and the function guarded on one too — so an article whose paragraphs all
+    carry a class attribute has no bare `kAm` anywhere and returned None before
+    the regex ran at all.
+
+    This is the dominant form in the researcher file: affected rows carry 24-27
+    `k^Am` closers and zero `kAm` openers. Fixing both took the still-ciphered
+    count from 122 to 2 across 151 affected rows.
+    """
+
+    def _encode(self, body: str, attrs: str = ' class="p1"') -> str:
+        return _rot47(f"<p{attrs}>{body}</p>")
+
+    def test_paragraph_with_a_class_attribute_decodes(self):
+        out = decode_rot47_segments(self._encode("The council met on Tuesday."))
+        assert "The council met on Tuesday." in out
+
+    def test_bare_paragraph_still_decodes(self):
+        out = decode_rot47_segments(self._encode("The council met.", attrs=""))
+        assert "The council met." in out
+
+    def test_many_attributed_paragraphs_all_decode(self):
+        body = "".join(self._encode(f"Paragraph number {i}.") for i in range(6))
+        out = decode_rot47_segments(body)
+        for i in range(6):
+            assert f"Paragraph number {i}." in out
+
+    def test_no_bare_open_marker_is_required(self):
+        """The guard must admit text carrying only `k^Am` closers."""
+        body = self._encode("Only closing markers survive cleaning here.")
+        assert "kAm" not in body  # the whole point
+        assert "k^Am" in body
+        assert "Only closing markers survive" in decode_rot47_segments(body)
+
+    def test_markup_does_not_survive_into_the_output(self):
+        out = decode_rot47_segments(self._encode("Plain prose."))
+        assert "<p" not in out and "</p>" not in out and "class=" not in out
+
+
 class TestRepairOfAlreadyStoredDamage:
     """Rows decoded before the unescape fix carry the damage baked in.
 


### PR DESCRIPTION
Three separate faults kept ROT47 ciphertext in the stored article body. Lee Enterprises / TownNews sites serve premium paragraphs ROT47-encoded rather than withholding them, so the capture looks healthy — the free preview is plain prose and the ciphertext begins several sentences in, past where a reviewer spot-checking the corpus stops looking.

## 1. It was never called on the write path

`decode_rot47_segments` has been in the tree and correct all along. Its only callers were entity extraction, which decodes into a local and writes nothing back, and the standalone `clean` command. `src/cli/commands/extraction.py` — which writes `content` and `text` for every crawled article — had **zero** references to it.

Entity extraction decoding on read is what hid this. That stage's output looked right while the cleaner, the classifier, word counts and the researcher export all saw scrambled text.

## 2. It decoded HTML entities literally

ROT47 maps `k` → `<` and `m` → `>`, so every k and m in the original prose arrives inside the ciphertext as a literal `<` or `>`, which the page must escape as `&lt;` / `&gt;` to avoid breaking its own markup. Decoding those character-by-character puts `U=Ej` and `U8Ej` exactly where the letter belongs:

```
ciphertext on the page   '2D&lt;65'
decoded without unescape 'asU=Ejed'
decoded with unescape    'asked'
```

Every `k` and every `m` in the recovered text was corrupted this way, which is why 29% of affected articles still scanned as ciphertext after decoding.

## 3. Earlier decodes wrote that damage back

236 stored articles carry `U=Ej` / `U8Ej` with no markers and no escaped entities left to key off, so decoding cannot reach them. Neither sequence occurs in English, so the substitution is reversible on its own — `coU8EjU8Ejunity` → `community`, `U8Ejayor pro teU8Ej` → `mayor pro tem`. `repair_entity_artifacts` runs first and unconditionally.

## Measured against 14,514 real captures

| | before | after |
| --- | --- | --- |
| affected articles | 1,048 (7.2%) | — |
| still ciphered | 304 (29%) | **133** |
| carrying `U=Ej` / `U8Ej` | 236 | **0** |
| unaffected articles altered | — | **0 / 5,503** |

`content` still stores the verbatim capture; only the cleaning input is decoded, so the before/after pair stays intact and the decode remains auditable.

## Not fixed here

- **133 articles remain ciphered.** 56 carry no markers at all and short-circuit out of the decoder; the rest fail the marker decoder's validation.
- **Existing rows are untouched.** This corrects new extractions. The ~1,048 already-stored articles need a re-clean pass to pick up the decode.

## Testing

47 tests pass. `tests/test_rot47_on_extraction_path.py` covers the entity round-trip, the artifact repair, idempotence (re-cleaning must not re-scramble recovered text), and that a fully-paywalled page no longer sails past `MIN_CONTENT_LENGTH` as ~4,000 characters of healthy-looking body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)