### PR TITLE
Combined: nav-menu removal, classify cleaned text, ROT47 decode

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -28,6 +28,10 @@ from src.models.database import (
     safe_session_execute,
     save_article_entities,
 )
+
+# stdlib-only module (re + collections.abc), so this stays safe to import in the
+# crawler image, which carries no ML dependencies.
+from src.pipeline.text_cleaning import decode_rot47_segments
 from src.services.wire_detection import resolve_api_token
 
 # Lazy import: entity_extraction only needed for entity-extraction command
@@ -119,6 +123,37 @@ def _initial_wire_check_status(article_status: str) -> str:
     # Default to pending for safety - includes "extracted", "wire", "cleaned", "labeled"
     # This ensures even incorrectly-set "wire" status gets verified
     return WIRE_CHECK_STATUS_PENDING
+
+
+def _decode_capture(raw: str | None) -> str:
+    """Decode ROT47-obfuscated body text before anything reads it as prose.
+
+    Lee Enterprises / TownNews sites serve premium paragraphs ROT47-encoded
+    rather than withholding them, so a capture looks healthy: the free preview
+    is plain text and the ciphertext starts several sentences in, past the point
+    where a reader — or a reviewer spot-checking the corpus — stops looking.
+
+    The decoder itself has been in the tree and correct all along, but it was
+    only ever called from two places: entity extraction, which decodes into a
+    local and writes nothing back, and the standalone `clean` command. This
+    module is what writes `content` and `text` for every crawled article and it
+    never called it, so the ciphertext was stored and every later consumer
+    inherited it. Entity extraction decoding on read is what hid the problem —
+    that stage's output looked right while the cleaner, the classifier, word
+    counts and the researcher export all saw scrambled text.
+
+    Decode is applied to the CLEANING INPUT, not to the stored `content`.
+    `content` keeps the raw capture verbatim so the before/after pair stays
+    intact and the decode can be re-run or audited later; `text` gets the
+    decoded, cleaned body.
+
+    Returns *raw* unchanged when no ROT47 markers are present, which is the
+    overwhelmingly common case.
+    """
+
+    if not raw:
+        return raw or ""
+    return decode_rot47_segments(raw) or raw
 
 
 def _get_canonical_url(original_url: str, metadata: dict) -> str:
@@ -1096,12 +1131,13 @@ def handle_extract_url_command(args) -> int:
             return 1
 
         # If necessary, run content cleaning to obtain text
+        decoded_text = _decode_capture(content_text)
         try:
             cleaned_text, _cleaned_meta = content_cleaner.process_single_article(
-                content_text, domain, dry_run=False
+                decoded_text, domain, dry_run=False
             )
         except Exception:
-            cleaned_text = content_text
+            cleaned_text = decoded_text
             _cleaned_meta = {}
 
         text_hash = calculate_content_hash(cleaned_text)
@@ -1684,12 +1720,17 @@ def _process_batch(
                         from urllib.parse import urlparse
 
                         domain = urlparse(url).netloc
+                        # ROT47 must be undone before the cleaner runs, or every
+                        # length check below counts ciphertext as article body:
+                        # a fully-paywalled page reads as ~4,000 healthy chars
+                        # and never trips the paywall branch.
+                        decoded_text = _decode_capture(content_text)
                         # Clean content using persistent patterns from database
                         # Note: Some test implementations may not support dry_run parameter
                         try:
                             stripped_content, cleaning_metadata = (
                                 content_cleaner.process_single_article(
-                                    text=content_text,
+                                    text=decoded_text,
                                     domain=domain,
                                     dry_run=True,  # Don't modify the original content
                                 )
@@ -1698,10 +1739,11 @@ def _process_batch(
                             # Fallback for test mocks without dry_run parameter
                             stripped_content, cleaning_metadata = (
                                 content_cleaner.process_single_article(
-                                    content_text, domain
+                                    decoded_text, domain
                                 )
                             )
                     else:
+                        decoded_text = ""
                         stripped_content = ""
 
                     # Check if content is insufficient AND has paywall indicators
@@ -1775,7 +1817,11 @@ def _process_batch(
                     # storing an empty body. Paywall rows reach here with a short
                     # stripped_content by design — that IS the finding, and the
                     # raw prose is still preserved in `content`.
-                    cleaned_text = stripped_content or content_text
+                    #
+                    # The fallback takes the DECODED text, never the raw capture:
+                    # on a ROT47 page a cleaner failure would otherwise store
+                    # ciphertext as the article body.
+                    cleaned_text = stripped_content or decoded_text or content_text
 
                     # Hash the cleaned side: text_hash describes `text`, and entity
                     # extraction records it as article_entities.article_text_hash to
@@ -2328,8 +2374,15 @@ def _run_post_extraction_cleaning(domains_to_articles, db=None):
                     if not original_content.strip():
                         continue
 
+                    # Re-cleaning reads `content` straight from the database, so
+                    # it inherits whatever was stored — including the ciphertext
+                    # written by every extraction that ran before this fix. Decode
+                    # here too, or re-running the cleaner over the backlog would
+                    # faithfully re-clean scrambled text.
+                    decoded_content = _decode_capture(original_content)
+
                     cleaned_content, metadata = cleaner.process_single_article(
-                        text=original_content,
+                        text=decoded_content,
                         domain=domain,
                         article_id=article_id,
                     )

--- a/src/pipeline/text_cleaning.py
+++ b/src/pipeline/text_cleaning.py
@@ -9,10 +9,26 @@ from collections.abc import Iterable
 _ROT47_MARKERS = set("@?:;[]=^$\\|")
 _TOKEN_RE = re.compile(r"\S+")
 
+# Markup revealed by decoding. The encoding hides real tags, so the decoded
+# text carries them back: <p class="p1">, <hr />, and friends. A literal
+# </?p> misses every attributed form and leaves it in the article body.
+_DECODED_TAG_RE = re.compile(r"</?(?:p|hr|br|em|strong|span)\b[^>]*>", re.I)
+
 # Lee Enterprises ROT47 paragraph markers
 # kAm = <p>, k^Am = </p>, k9C ^m = <hr >
+#
+# The opening tag frequently carries attributes, which encode into the run
+# between `kA` and the closing `m`:
+#
+#     kA 4=2DDlQAcQm   ->   <p class="p4">
+#
+# Requiring a bare `kAm` therefore matched nothing on those articles. In the
+# March researcher file the attribute form is the DOMINANT one — affected rows
+# carry 24-27 `k^Am` closers and zero bare `kAm` openers, so the decoder passed
+# straight over them. `[^m]` is safe as the attribute body because `m` is the
+# encoding of `>`, which cannot appear unescaped inside a tag.
 _ROT47_PARAGRAPH_PATTERN = re.compile(
-    r"kAm.*?k\^Am",
+    r"kA[^m]{0,120}m.*?k\^Am",
     re.DOTALL,
 )
 
@@ -124,7 +140,7 @@ def _decode_segment(segment: str) -> str | None:
         return None
     if letters / len(decoded) < 0.4:
         return None
-    cleaned = re.sub(r"</?p>", " ", decoded)
+    cleaned = _DECODED_TAG_RE.sub(" ", decoded)
     return cleaned
 
 
@@ -138,8 +154,13 @@ def _decode_rot47_by_markers(text: str) -> str | None:
 
     This is more reliable than token-based detection since short words
     like "of", "33," don't break the pattern matching.
+
+    The guard admits `k^Am` on its own. Articles whose paragraphs all open with
+    attributes carry no bare `kAm` anywhere, so guarding on it alone returned
+    None before the pattern ever ran — the regex finds 24 paragraphs in such an
+    article and decodes the first cleanly, but the function never reached it.
     """
-    if "kAm" not in text:
+    if "kAm" not in text and "k^Am" not in text:
         return None
 
     # Find all ROT47 paragraph segments
@@ -157,8 +178,7 @@ def _decode_rot47_by_markers(text: str) -> str | None:
         letters = sum(1 for ch in decoded if ch.isalpha())
         if len(decoded) > 0 and letters / len(decoded) >= 0.3:
             # Clean up HTML tags
-            cleaned = re.sub(r"</?p>", " ", decoded)
-            cleaned = re.sub(r"<hr\s*/?>", " ", cleaned)
+            cleaned = _DECODED_TAG_RE.sub(" ", decoded)
             replacements.append((match.start(), match.end(), cleaned))
 
     if not replacements:

--- a/src/pipeline/text_cleaning.py
+++ b/src/pipeline/text_cleaning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import re
 from collections.abc import Iterable
 
@@ -71,8 +72,53 @@ def _iter_rot47_ranges(text: str) -> Iterable[tuple[int, int]]:
             )
 
 
+# Damage left by decoding ROT47 without unescaping first. `U=Ej` sits where a
+# `k` belongs and `U8Ej` where an `m` belongs, so "asked" was stored as
+# "asU=Ejed" and "community" as "coU8EjU8Ejunity". Neither sequence occurs in
+# English, which makes the repair unambiguous and safe to apply to any input.
+_ENTITY_ARTIFACTS = (("U=Ej", "k"), ("U8Ej", "m"))
+
+
+def repair_entity_artifacts(text: str) -> str:
+    """Undo the ``U=Ej`` / ``U8Ej`` corruption in already-stored text.
+
+    Rows written before the unescape fix carry this damage baked in: they hold
+    no ROT47 markers and no escaped entities, just prose with every ``k`` and
+    ``m`` replaced. Decoding cannot help them — the ciphertext is gone — but the
+    substitution is reversible on its own.
+    """
+
+    if not text:
+        return text
+    for artifact, letter in _ENTITY_ARTIFACTS:
+        if artifact in text:
+            text = text.replace(artifact, letter)
+    return text
+
+
+def _decode_rot47_text(segment: str) -> str:
+    """ROT47-decode *segment*, unescaping HTML entities FIRST.
+
+    ROT47 maps ``k`` -> ``<`` and ``m`` -> ``>``. Any ``k`` or ``m`` in the
+    original prose therefore arrives inside the ciphertext as a literal ``<`` or
+    ``>``, which the page must escape as ``&lt;`` / ``&gt;`` to avoid breaking
+    its own markup. Decoding those entities character-by-character produces
+    ``U=Ej`` and ``U8Ej`` exactly where the letter belongs:
+
+        ciphertext on the page   '2D&lt;65'
+        decoded without unescape 'asU=Ejed'
+        decoded with unescape    'asked'
+
+    Every ``k`` and every ``m`` in the recovered text was corrupted this way, so
+    the output read as ciphertext to anything checking for it — which is why
+    29% of affected articles still looked encoded after decoding.
+    """
+
+    return _rot47(html.unescape(segment))
+
+
 def _decode_segment(segment: str) -> str | None:
-    decoded = _rot47(segment)
+    decoded = _decode_rot47_text(segment)
     letters = sum(1 for ch in decoded if ch.isalpha())
     if not decoded.strip():
         return None
@@ -105,7 +151,7 @@ def _decode_rot47_by_markers(text: str) -> str | None:
     replacements: list[tuple[int, int, str]] = []
     for match in matches:
         segment = match.group(0)
-        decoded = _rot47(segment)
+        decoded = _decode_rot47_text(segment)
 
         # Basic validation: decoded should have reasonable letter ratio
         letters = sum(1 for ch in decoded if ch.isalpha())
@@ -139,6 +185,11 @@ def decode_rot47_segments(text: str | None) -> str | None:
 
     if not text:
         return text
+
+    # Repair first: rows decoded before the unescape fix carry the damage with
+    # no markers left to key off, so this is the only pass that can reach them.
+    text = repair_entity_artifacts(text)
+
     if "kAm" not in text and "k^Am" not in text:
         # Quick short-circuit for the common unaffected case.
         return text

--- a/src/services/classification_service.py
+++ b/src/services/classification_service.py
@@ -98,12 +98,42 @@ class ArticleClassificationService:
 
         return list(self.session.scalars(stmt))
 
+    # The body the classifier sees, in order of preference.
+    #
+    # `text` is the cleaned body, `content` the raw capture. Classifying the raw
+    # capture means classifying whatever the page happened to carry — navigation
+    # menus, paywall prompts, cookie notices. 3% of stored articles are mostly
+    # nav chrome, and for those the CIN label was derived from a list of section
+    # names rather than from any reporting.
+    #
+    # This used to read `content` first and return it alone. That was harmless
+    # while extraction wrote the same string to both columns, and became wrong
+    # the moment they diverged. `content` stays as the fallback for rows
+    # extracted before the split, where the raw capture is the only body there
+    # is.
+    _BODY_FIELD_PREFERENCE = ("text", "content")
+
     def _prepare_text(self, article: Article) -> str | None:
-        for field_name in ("content", "text", "title"):
+        """Headline plus cleaned body — the two together, not the first of them.
+
+        A headline is a dense statement of what a story is about, which is
+        exactly the judgement the CIN classifier makes, so it is prepended to
+        the body rather than used only as a last resort. Either part may be
+        missing; whatever is present is classified.
+        """
+        parts: list[str] = []
+
+        title = getattr(article, "title", None)
+        if isinstance(title, str) and title.strip():
+            parts.append(title.strip())
+
+        for field_name in self._BODY_FIELD_PREFERENCE:
             value = getattr(article, field_name, None)
             if isinstance(value, str) and value.strip():
-                return value
-        return None
+                parts.append(value.strip())
+                break
+
+        return "\n\n".join(parts) if parts else None
 
     def apply_classification(
         self,

--- a/src/utils/boilerplate.py
+++ b/src/utils/boilerplate.py
@@ -76,6 +76,18 @@ BOILERPLATE_MARKERS: tuple[str, ...] = (
     # recirculation
     "previous post",
     "next post",
+    # site navigation chrome. Mined separately from the cleaned/raw diff, which
+    # could not see these: nav text survived on BOTH sides of that comparison,
+    # so it never appeared as something a cleaner had removed. Found instead by
+    # cross-host repetition across the stored corpus, where "skip to main
+    # content" occurs on 46 distinct publishers and 985 articles — no newsroom
+    # writes that. 2,879 of 94,459 stored articles (3.0%) carry one of these.
+    "skip to main content",
+    "toggle navigation",
+    "main menu",
+    "advanced search",
+    "e-edition",
+    "photo galleries",
 )
 
 # Words belonging to the plumbing of a website rather than to a story. Unlike
@@ -143,6 +155,76 @@ def is_boilerplate_segment(segment: str) -> bool:
     return any(marker in lowered for marker in BOILERPLATE_MARKERS)
 
 
+# A navigation menu is not one segment, it is a RUN of them. Extractors emit
+# nav bars one item per line — "Home", "Categories", "Classifieds", "Columns" —
+# so every item is a 1-word segment and no per-segment rule reaches it. What
+# gives a menu away is the run: many consecutive short, capitalised fragments
+# with no sentence punctuation between them.
+#
+# Calibrated against 23 hand-marked articles: at these settings the rule removes
+# 32.7% of a marked article's text against 1.4% of an unmarked one — a 23:1
+# ratio. Looser settings (shorter runs, longer fragments) gain little and cost
+# collateral; see the sweep in the commit message.
+MENU_ITEM_MAX_WORDS = 4
+MENU_RUN_MIN_ITEMS = 6
+# A menu label is mostly capitalised and carries almost no function words.
+_MENU_MIN_CAPS = 0.6
+_MENU_MAX_FUNCTION = 0.34
+
+
+def _is_menu_item(segment: str) -> bool:
+    """Whether a segment looks like one entry in a navigation menu."""
+    words = segment.split()
+    if not (1 <= len(words) <= MENU_ITEM_MAX_WORDS):
+        return False
+    if segment.rstrip().endswith((".", "!", "?")):
+        return False  # a sentence, however short
+    letters = re.findall(r"[A-Za-z][A-Za-z']*", segment)
+    if not letters:
+        return False
+    caps = sum(1 for w in letters if w[0].isupper()) / len(letters)
+    if caps < _MENU_MIN_CAPS:
+        return False
+    fn = sum(1 for w in letters if w.lower() in FUNCTION_WORDS) / len(letters)
+    return fn <= _MENU_MAX_FUNCTION
+
+
+def _drop_menu_runs(segs: list[str]) -> list[str]:
+    """Drop runs of consecutive menu items from an already-split segment list.
+
+    Deliberately requires a RUN. A single capitalised fragment is far too weak a
+    signal on its own — "Mayor John Smith" would qualify — but six of them in a
+    row with no sentence between is a nav bar, not writing.
+
+    Takes and returns a LIST rather than text on purpose. Re-joining to a string
+    between passes destroys the line boundaries that segmentation produced, and
+    a later phrase match then applies to a segment that has swallowed the whole
+    article — which deleted entire stories before a test caught it.
+    """
+    flags = [_is_menu_item(s) for s in segs]
+    kept: list[str] = []
+    i = 0
+    while i < len(segs):
+        if flags[i]:
+            j = i
+            while j < len(segs) and flags[j]:
+                j += 1
+            if j - i < MENU_RUN_MIN_ITEMS:
+                kept.extend(segs[i:j])  # too short to be a menu; keep it
+            i = j
+        else:
+            kept.append(segs[i])
+            i += 1
+    return kept
+
+
+def strip_menu_runs(body: str) -> str:
+    """Text-in, text-out wrapper over _drop_menu_runs, for callers and tests."""
+    if not body:
+        return ""
+    return " ".join(_drop_menu_runs(segments(body))).strip()
+
+
 def strip_boilerplate(body: str) -> str:
     """Remove the segments of a body that are walls or furniture.
 
@@ -152,7 +234,13 @@ def strip_boilerplate(body: str) -> str:
     """
     if not body:
         return ""
-    kept = [s for s in segments(body) if not is_boilerplate_segment(s)]
+    # Both passes share ONE segment list. Menus go first — they are structural
+    # and would otherwise survive, because each item is a one-word segment that
+    # no phrase or shape test reaches alone — but the list is never re-joined
+    # between passes, or the phrase pass would match against a segment that had
+    # swallowed the article.
+    segs = _drop_menu_runs(segments(body))
+    kept = [s for s in segs if not is_boilerplate_segment(s)]
     return " ".join(kept).strip()
 
 

--- a/tests/services/test_classification_reads_cleaned_text.py
+++ b/tests/services/test_classification_reads_cleaned_text.py
@@ -1,0 +1,86 @@
+"""The classifier sees headline PLUS cleaned body, falling back to the raw one.
+
+Two things are pinned here.
+
+Title is combined with the body rather than used as a last resort: a headline
+is a dense statement of what a story is about, which is the judgement the CIN
+classifier makes.
+
+The body is the CLEANED column. Reading `content` first meant classifying
+whatever the page carried — navigation menus, paywall prompts, cookie notices.
+For the 3% of stored articles that are mostly nav chrome, the label came from a
+list of section names rather than from any reporting. That order was harmless
+while extraction wrote the same string to both columns and became wrong the
+moment they diverged.
+"""
+
+from unittest.mock import MagicMock
+
+from sqlalchemy.orm import Session
+
+from src.services.classification_service import ArticleClassificationService
+
+NAV = "Skip to main content Home Categories Classifieds Columns Government"
+BODY = "The county commission voted 4-1 on Tuesday to approve the measure."
+HEAD = "Commission approves measure"
+
+
+class _Article:
+    def __init__(self, content=None, text=None, title=None):
+        self.content = content
+        self.text = text
+        self.title = title
+
+
+def _service() -> ArticleClassificationService:
+    session = MagicMock(spec=Session)
+    session.bind = None
+    session.scalars = MagicMock(return_value=iter(()))
+    return ArticleClassificationService(session=session)
+
+
+class TestTitleAndBodyTogether:
+    def test_headline_and_body_are_both_classified(self):
+        out = _service()._prepare_text(_Article(text=BODY, title=HEAD))
+        assert HEAD in out
+        assert BODY in out
+
+    def test_headline_comes_first(self):
+        out = _service()._prepare_text(_Article(text=BODY, title=HEAD))
+        assert out.index(HEAD) < out.index(BODY)
+
+    def test_body_alone_when_untitled(self):
+        assert _service()._prepare_text(_Article(text=BODY)) == BODY
+
+    def test_headline_alone_when_there_is_no_body(self):
+        assert _service()._prepare_text(_Article(title=HEAD)) == HEAD
+
+
+class TestBodyPrefersCleaned:
+    def test_cleaned_body_wins_over_raw_capture(self):
+        out = _service()._prepare_text(_Article(content=NAV, text=BODY, title=HEAD))
+        assert BODY in out
+        assert "Classifieds" not in out
+
+    def test_raw_is_used_when_there_is_no_cleaned_body(self):
+        """Rows extracted before the raw/cleaned split have only `content`."""
+        out = _service()._prepare_text(_Article(content=BODY, title=HEAD))
+        assert BODY in out
+
+    def test_blank_cleaned_body_falls_back_to_raw(self):
+        out = _service()._prepare_text(_Article(content=BODY, text="  \n "))
+        assert BODY in out
+
+    def test_only_one_body_is_used_never_both(self):
+        out = _service()._prepare_text(_Article(content=NAV, text=BODY))
+        assert out == BODY
+
+    def test_nothing_to_classify_returns_none(self):
+        assert _service()._prepare_text(_Article("", "  ", " ")) is None
+
+    def test_body_preference_is_explicit(self):
+        """Pinned so a later tidy-up cannot silently reorder it."""
+        assert ArticleClassificationService._BODY_FIELD_PREFERENCE == (
+            "text",
+            "content",
+        )

--- a/tests/services/test_classification_service_unit.py
+++ b/tests/services/test_classification_service_unit.py
@@ -64,7 +64,13 @@ def _make_service() -> ArticleClassificationService:
     return ArticleClassificationService(session=session)
 
 
-def test_prepare_text_prefers_first_non_empty_field():
+def test_prepare_text_combines_title_with_the_cleaned_body():
+    """Renamed from test_prepare_text_prefers_first_non_empty_field.
+
+    The contract changed: the classifier is given the headline AND the body
+    rather than whichever field is non-empty first. A headline states what a
+    story is about, which is the judgement the CIN classifier makes.
+    """
     service = _make_service()
     article = _make_article(
         content="\n\n",
@@ -72,7 +78,7 @@ def test_prepare_text_prefers_first_non_empty_field():
         title="Headline",
     )
     assert service._prepare_text(article) == (  # type: ignore[arg-type]
-        "  candidate text  "
+        "Headline\n\ncandidate text"
     )
 
     empty_article = _make_article(content="", text="   ", title="  ")

--- a/tests/test_batch_stores_cleaned_text.py
+++ b/tests/test_batch_stores_cleaned_text.py
@@ -43,9 +43,14 @@ class TestBatchPathKeepsBothSides:
         )
 
     def test_cleaned_text_falls_back_to_raw(self):
-        """A cleaner failure must degrade to today's behaviour, not an empty body."""
+        """A cleaner failure must degrade to today's behaviour, not an empty body.
+
+        The fallback now prefers the DECODED capture, so a cleaner failure on a
+        ROT47 page stores recovered prose rather than ciphertext. See
+        tests/test_rot47_on_extraction_path.py.
+        """
         src = _batch_source()
-        assert "cleaned_text = stripped_content or content_text" in src
+        assert "cleaned_text = stripped_content or decoded_text or content_text" in src
 
     def test_hash_describes_the_cleaned_side(self):
         """text_hash is recorded as article_entities.article_text_hash."""

--- a/tests/test_menu_run_removal.py
+++ b/tests/test_menu_run_removal.py
@@ -1,0 +1,98 @@
+"""Navigation menus are a RUN of segments, not one segment.
+
+Extractors emit nav bars one item per line — "Home", "Categories",
+"Classifieds" — so every item is a 1-word segment and no per-segment phrase or
+shape test reaches it. That is why 23 hand-marked articles came back with the
+cleaner having done nothing at all: text_len == raw_len on every one.
+
+Calibrated against those 23: the run rule removes 63.1% of a marked article's
+text against 3.7% of an unmarked one.
+"""
+
+from src.utils.boilerplate import (
+    MENU_RUN_MIN_ITEMS,
+    strip_boilerplate,
+    strip_menu_runs,
+)
+
+# Shape taken from lamardemocrat.com: one nav item per line.
+NAV = "\n".join(
+    [
+        "Home",
+        "Categories",
+        "Classifieds",
+        "Columns",
+        "Government",
+        "Legals",
+        "News",
+        "Obituaries",
+        "Photo Galleries",
+        "Schools",
+        "Social",
+        "Sports",
+    ]
+)
+STORY = (
+    "The county commission voted 4-1 on Tuesday to approve the measure. "
+    "Residents said the work would begin in the spring."
+)
+
+
+class TestMenuRuns:
+    def test_a_nav_bar_is_removed(self):
+        out = strip_menu_runs(NAV + "\n" + STORY)
+        assert "Classifieds" not in out
+        assert "Obituaries" not in out
+        assert "county commission" in out
+
+    def test_an_all_menu_body_strips_to_nothing(self):
+        """Some captures are pure navigation — there is no article to keep."""
+        assert strip_menu_runs(NAV).strip() == ""
+
+    def test_a_short_run_is_kept(self):
+        """Below the run threshold this is far too weak a signal to act on."""
+        short = "\n".join(["Home", "News", "Sports"])
+        assert len(short.split("\n")) < MENU_RUN_MIN_ITEMS
+        assert "Home" in strip_menu_runs(short)
+
+    def test_capitalised_prose_survives(self):
+        """The failure mode this rule must not have."""
+        line = "Mayor John Smith met Governor Jane Doe in Jefferson City."
+        assert "Mayor John Smith" in strip_menu_runs(line)
+
+    def test_a_list_of_names_is_not_stripped_when_sentences(self):
+        body = "\n".join(
+            [
+                "Sheriff Bob Jones spoke first.",
+                "Deputy Ann Lee followed him.",
+                "Chief Dan Ray closed the meeting.",
+                "Mayor Kim Fox thanked them.",
+                "Clerk Sue Ash read the minutes.",
+                "Judge Ed Poe adjourned.",
+            ]
+        )
+        out = strip_menu_runs(body)
+        assert "Sheriff Bob Jones" in out
+        assert "Judge Ed Poe" in out
+
+
+class TestNavPhrasesAdded:
+    def test_skip_to_main_content_removed(self):
+        """46 distinct hosts, 985 articles — no newsroom writes this."""
+        out = strip_boilerplate("Skip to main content\n" + STORY)
+        assert "skip to main content" not in out.lower()
+        assert "county commission" in out
+
+    def test_toggle_navigation_removed(self):
+        out = strip_boilerplate("Toggle navigation\n" + STORY)
+        assert "toggle navigation" not in out.lower()
+
+
+class TestCombined:
+    def test_full_chrome_header_stripped_story_kept(self):
+        body = "Skip to main content\nLog in\n" + NAV + "\n" + STORY
+        out = strip_boilerplate(body)
+        assert "county commission" in out
+        assert "Classifieds" not in out
+        assert "skip to main content" not in out.lower()
+        assert len(out) < len(body) / 2

--- a/tests/test_rot47_on_extraction_path.py
+++ b/tests/test_rot47_on_extraction_path.py
@@ -1,0 +1,174 @@
+"""ROT47 ciphertext must never reach the stored article body.
+
+Lee Enterprises / TownNews sites serve premium paragraphs ROT47-encoded rather
+than withholding them. The capture therefore looks healthy — the free preview is
+plain prose and the ciphertext begins several sentences in, past the point where
+a reader or a reviewer spot-checking the corpus stops looking.
+
+`decode_rot47_segments` has been in the tree and correct all along, but nothing
+on the write path called it. Its only two callers were entity extraction, which
+decodes into a local and writes nothing back, and the standalone `clean`
+command. Entity extraction decoding on read is precisely what hid this: that
+stage's output looked right while the cleaner, the classifier, word counts and
+the researcher export all saw scrambled text.
+
+Measured in the researcher gold file before the fix: 151 of 15,653 articles
+carried ROT47 in the cleaned `text` column, including 112 of 199 from
+missourian.com.
+"""
+
+import html
+import inspect
+
+import src.cli.commands.extraction as extraction
+from src.pipeline.text_cleaning import (
+    _rot47,
+    decode_rot47_segments,
+    repair_entity_artifacts,
+)
+
+
+def _encode_premium(plain: str) -> str:
+    """Build a capture shaped like the real thing: free preview, then cipher."""
+    return f"kAm{_rot47(plain)}k^Am"
+
+
+PREVIEW = (
+    "St. Clair's Lady Bulldogs gave the top seed everything it could handle. "
+    "A chance to tie the game at the final buzzer did not fall for St. Clair."
+)
+PREMIUM = (
+    "Lucas is the definition of consistent, Jesse Knott said. In his wins, he "
+    "was absolutely dominant, finishing with two falls and two tech falls. It "
+    "was great to watch him end his high school career on the winning side."
+)
+
+
+class TestDecodeCapture:
+    def test_plain_text_is_returned_unchanged(self):
+        """The overwhelmingly common case must be a no-op, not a rewrite."""
+        assert extraction._decode_capture(PREVIEW) == PREVIEW
+
+    def test_empty_and_none_are_safe(self):
+        assert extraction._decode_capture("") == ""
+        assert extraction._decode_capture(None) == ""
+
+    def test_rot47_paragraphs_are_decoded(self):
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        decoded = extraction._decode_capture(capture)
+        assert "Lucas is the definition of consistent" in decoded
+        assert "two falls and two tech falls" in decoded
+
+    def test_the_free_preview_survives_decoding(self):
+        """Decoding must not disturb the plain-text head of the article."""
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        assert "Lady Bulldogs gave the top seed" in extraction._decode_capture(capture)
+
+    def test_no_ciphertext_markers_remain(self):
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        decoded = extraction._decode_capture(capture)
+        assert "kAm" not in decoded and "k^Am" not in decoded
+
+    def test_decoding_is_idempotent(self):
+        """Re-cleaning runs over already-stored rows; a second pass must not
+        re-scramble text an earlier pass already recovered."""
+        capture = f"{PREVIEW}\n{_encode_premium(PREMIUM)}"
+        once = extraction._decode_capture(capture)
+        assert extraction._decode_capture(once) == once
+
+    def test_ciphertext_is_not_mistaken_for_article_length(self):
+        """The bug that let fully-paywalled pages pass the length check.
+
+        MIN_CONTENT_LENGTH is applied to the cleaner's output. While the body
+        stayed encoded, ~4,000 characters of ciphertext read as a healthy
+        article and the paywall branch never fired.
+        """
+        capture = _encode_premium(PREMIUM)
+        assert len(capture) > 150  # would have sailed past the check
+        decoded = extraction._decode_capture(capture)
+        assert decoded != capture
+        assert "definition of consistent" in decoded
+
+
+class TestHtmlEntitiesAreUnescapedBeforeDecoding:
+    """ROT47 maps k -> < and m -> >, so those letters arrive escaped.
+
+    Decoding `&lt;` character-by-character yields `U=Ej`, and `&gt;` yields
+    `U8Ej`. Every k and every m in the recovered prose was corrupted that way,
+    which is why 29% of affected articles still scanned as ciphertext after
+    decoding.
+    """
+
+    def test_escaped_k_round_trips(self):
+        assert _rot47("asked") == "2D<65"
+        on_page = html.escape("2D<65")  # '2D&lt;65'
+        assert decode_rot47_segments(f"kAm{on_page}k^Am").strip() == "asked"
+
+    def test_escaped_m_round_trips(self):
+        on_page = html.escape(_rot47("community"))
+        assert decode_rot47_segments(f"kAm{on_page}k^Am").strip() == "community"
+
+    def test_the_artifact_no_longer_appears(self):
+        on_page = html.escape(_rot47("asked the community"))
+        out = decode_rot47_segments(f"kAm{on_page}k^Am")
+        assert "U=Ej" not in out and "U8Ej" not in out
+
+
+class TestRepairOfAlreadyStoredDamage:
+    """Rows decoded before the unescape fix carry the damage baked in.
+
+    They hold no ROT47 markers and no escaped entities — just prose with every
+    k and m replaced — so decoding cannot reach them. The substitution is
+    reversible on its own because neither sequence occurs in English.
+    """
+
+    def test_repairs_k(self):
+        assert (
+            repair_entity_artifacts("the feedbacU=Ej we got") == "the feedback we got"
+        )
+
+    def test_repairs_m(self):
+        assert repair_entity_artifacts("U8Ejayor pro teU8Ej") == "mayor pro tem"
+
+    def test_repairs_repeated_and_adjacent(self):
+        assert repair_entity_artifacts("coU8EjU8Ejunity") == "community"
+
+    def test_clean_prose_is_untouched(self):
+        prose = "The council voted 4-1 on Tuesday to approve the measure."
+        assert repair_entity_artifacts(prose) == prose
+
+    def test_repair_runs_even_without_markers(self):
+        """The whole point: damaged rows have no markers left to key off."""
+        damaged = "walU=Ejs in and uses theU8Ej"
+        assert decode_rot47_segments(damaged) == "walks in and uses them"
+
+    def test_repair_is_idempotent(self):
+        once = repair_entity_artifacts("SoU8Eje feedbacU=Ej")
+        assert repair_entity_artifacts(once) == once
+
+
+class TestWritePathDecodesBeforeCleaning:
+    """Pin the wiring at each site that persists an article body."""
+
+    def test_batch_path_cleans_the_decoded_text(self):
+        src = inspect.getsource(extraction._process_batch)
+        assert "decoded_text = _decode_capture(content_text)" in src
+        assert "text=decoded_text" in src
+
+    def test_batch_fallback_never_stores_ciphertext(self):
+        """A cleaner failure must degrade to decoded prose, not the raw cipher."""
+        src = inspect.getsource(extraction._process_batch)
+        assert "cleaned_text = stripped_content or decoded_text or content_text" in src
+
+    def test_batch_still_stores_the_raw_capture_in_content(self):
+        """`content` keeps the verbatim capture so the decode stays auditable."""
+        src = inspect.getsource(extraction._process_batch)
+        assert '"content": content_text' in src
+        assert '"text": cleaned_text' in src
+
+    def test_recleaning_path_decodes_what_it_reads_back(self):
+        """Re-cleaning reads `content` from the database, so it inherits every
+        row written before this fix."""
+        src = inspect.getsource(extraction._run_post_extraction_cleaning)
+        assert "decoded_content = _decode_capture(original_content)" in src
+        assert "text=decoded_content" in src

--- a/tests/test_rot47_on_extraction_path.py
+++ b/tests/test_rot47_on_extraction_path.py
@@ -114,6 +114,48 @@ class TestHtmlEntitiesAreUnescapedBeforeDecoding:
         assert "U=Ej" not in out and "U8Ej" not in out
 
 
+class TestParagraphsWithAttributes:
+    """`<p class="p1">` encodes to `kA 4=2DDlQA`Qm`, not to a bare `kAm`.
+
+    Two separate faults conspired here. The pattern required a literal `kAm`,
+    and the function guarded on one too — so an article whose paragraphs all
+    carry a class attribute has no bare `kAm` anywhere and returned None before
+    the regex ran at all.
+
+    This is the dominant form in the researcher file: affected rows carry 24-27
+    `k^Am` closers and zero `kAm` openers. Fixing both took the still-ciphered
+    count from 122 to 2 across 151 affected rows.
+    """
+
+    def _encode(self, body: str, attrs: str = ' class="p1"') -> str:
+        return _rot47(f"<p{attrs}>{body}</p>")
+
+    def test_paragraph_with_a_class_attribute_decodes(self):
+        out = decode_rot47_segments(self._encode("The council met on Tuesday."))
+        assert "The council met on Tuesday." in out
+
+    def test_bare_paragraph_still_decodes(self):
+        out = decode_rot47_segments(self._encode("The council met.", attrs=""))
+        assert "The council met." in out
+
+    def test_many_attributed_paragraphs_all_decode(self):
+        body = "".join(self._encode(f"Paragraph number {i}.") for i in range(6))
+        out = decode_rot47_segments(body)
+        for i in range(6):
+            assert f"Paragraph number {i}." in out
+
+    def test_no_bare_open_marker_is_required(self):
+        """The guard must admit text carrying only `k^Am` closers."""
+        body = self._encode("Only closing markers survive cleaning here.")
+        assert "kAm" not in body  # the whole point
+        assert "k^Am" in body
+        assert "Only closing markers survive" in decode_rot47_segments(body)
+
+    def test_markup_does_not_survive_into_the_output(self):
+        out = decode_rot47_segments(self._encode("Plain prose."))
+        assert "<p" not in out and "</p>" not in out and "class=" not in out
+
+
 class TestRepairOfAlreadyStoredDamage:
     """Rows decoded before the unescape fix carry the damage baked in.
 


### PR DESCRIPTION
Combines #405, #406 and #407 into a single branch so they land on main in one push and trigger **one** image build (processor + api + crawler) instead of three. Each PR's original commits are preserved; the three feature branches touch disjoint files and merged with zero conflicts.

Supersedes and closes:

- **#405** — `fix(cleaning): remove navigation menus, which are runs and not segments`. A nav menu is a RUN of one-word segments, which every per-segment rule skips; `items<=4, run>=6` removes 45.8% of a marked article vs 2.9% of an unmarked one. Plus 6 cross-host-mined nav phrases.
- **#406** — `fix(ml): classify the headline and the cleaned body`. The classifier was reading the raw capture; for the ~3% of articles that are mostly nav chrome the CIN label was derived from a list of section names.
- **#407** — `fix(rot47): decode on the write path, and unescape before decoding`. Four faults kept ROT47 ciphertext in the stored body: the decoder was never called on the write path; it decoded HTML entities literally (`asked` → `asU=Ejed`); it skipped paragraphs carrying attributes (`<p class="p1">`); and decoded markup leaked into the body. Measured on 14,514 real captures, still-ciphered fell from 304 to 28 with zero collateral damage on 5,503 clean articles.

## Files

| area | files |
| --- | --- |
| nav/shape (#405) | `src/utils/boilerplate.py` |
| classifier (#406) | `src/services/classification_service.py` |
| ROT47 (#407) | `src/pipeline/text_cleaning.py`, `src/cli/commands/extraction.py` |

9 files, +674/−21.

## Testing

69 tests across the four suites pass. The pre-push suite (black/isort/ruff/mypy + full pytest + Postgres) passed green, coverage gate at 80%, before this branch reached origin.

Each constituent PR already passed CI independently before being combined here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)