### PR TITLE
Add reverify-candidates command to re-screen stale backlog

### DIFF
--- a/src/cli/cli_modular.py
+++ b/src/cli/cli_modular.py
@@ -109,6 +109,7 @@ def _load_command_parser(command: str) -> tuple[Callable, Callable] | None:
         "llm": "llm",
         "pipeline-status": "pipeline_status",
         "cleanup-candidates": "cleanup_candidates",
+        "reverify-candidates": "reverify",
         "housekeeping": "housekeeping",
     }
 

--- a/src/cli/commands/reverify.py
+++ b/src/cli/commands/reverify.py
@@ -1,0 +1,146 @@
+"""Re-verify already-classified candidate links against current rules.
+
+The verification service only ever screens status='discovered' links, so
+rows that reached 'article' long ago -- or were manually unpaused straight
+back to 'article' -- keep whatever classification the rules of that era
+gave them. Junk approved under old rules then flows to extraction, wasting
+fetches and burning per-domain reputation (rate-limit backoffs on 502s,
+etc.).
+
+This command closes that gap two ways:
+
+  reverify-candidates                     # re-screen the 'article' backlog
+  reverify-candidates --release-paused    # paused -> discovered, so the
+                                          # normal verification loop
+                                          # re-screens them (the sanctioned
+                                          # unpause path)
+
+Verification here is pattern rules + StorySniffer only (no HTTP prechecks,
+no proxy traffic), so re-screening tens of thousands of rows is cheap.
+"""
+
+import argparse
+import logging
+
+from src.services.url_verification import URLVerificationService
+
+logger = logging.getLogger(__name__)
+
+
+def add_reverify_candidates_parser(subparsers) -> argparse.ArgumentParser:
+    """Add reverify-candidates command parser to subparsers."""
+    parser = subparsers.add_parser(
+        "reverify-candidates",
+        help="Re-run current verification over already-classified backlog",
+    )
+
+    parser.add_argument(
+        "--status",
+        default="article",
+        help="Candidate status to re-verify (default: article)",
+    )
+    parser.add_argument(
+        "--release-paused",
+        action="store_true",
+        help=(
+            "Instead of re-verifying in place, move paused links back to "
+            "'discovered' so the normal verification loop re-screens them"
+        ),
+    )
+    parser.add_argument(
+        "--older-than-days",
+        type=int,
+        help="Only touch candidates created more than this many days ago",
+    )
+    parser.add_argument(
+        "--host",
+        help="Only touch candidates from this source host",
+    )
+    parser.add_argument(
+        "--dataset-id",
+        help="Only touch candidates belonging to this dataset id",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum number of candidates to process",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Progress-log interval while re-verifying (default: 500)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without updating any rows",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging level (default: INFO)",
+    )
+
+    parser.set_defaults(func=handle_reverify_candidates_command)
+    return parser
+
+
+def handle_reverify_candidates_command(args) -> int:
+    """Handle the reverify-candidates command."""
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    try:
+        service = URLVerificationService()
+
+        if args.release_paused:
+            count = service.release_paused(
+                older_than_days=args.older_than_days,
+                host=args.host,
+                dataset_id=args.dataset_id,
+                dry_run=args.dry_run,
+            )
+            verb = "Would release" if args.dry_run else "Released"
+            print(f"✅ {verb} {count} paused candidates back to 'discovered'")
+            return 0
+
+        candidates = service.get_reverify_candidates(
+            status=args.status,
+            older_than_days=args.older_than_days,
+            host=args.host,
+            dataset_id=args.dataset_id,
+            limit=args.limit,
+        )
+        if not candidates:
+            print(f"No '{args.status}' candidates matched the filters")
+            return 0
+
+        mode = " (dry run)" if args.dry_run else ""
+        print(
+            f"🔎 Re-verifying {len(candidates)} '{args.status}' " f"candidates{mode}..."
+        )
+        metrics = service.reverify_candidates(
+            candidates,
+            dry_run=args.dry_run,
+            progress_every=args.batch_size,
+        )
+
+        reclassified_total = sum(metrics["reclassified"].values())
+        print(f"✅ Processed {metrics['total']} candidates:")
+        print(f"   kept as '{args.status}': {metrics['kept']}")
+        print(f"   reclassified: {reclassified_total}")
+        for status, count in sorted(
+            metrics["reclassified"].items(), key=lambda kv: -kv[1]
+        ):
+            print(f"     -> {status}: {count}")
+        print(f"   errors (left untouched): {metrics['errors']}")
+        return 0
+
+    except Exception as e:
+        logger.exception("reverify-candidates failed")
+        print(f"❌ Error: {e}")
+        return 1

--- a/src/services/url_verification.py
+++ b/src/services/url_verification.py
@@ -715,6 +715,35 @@ class URLVerificationService:
 
         self.logger.debug(f"Updated candidate {candidate_id} to: {new_status}")
 
+    def decide_status(self, verification_result: dict) -> tuple[str, str | None]:
+        """Map a verify_url() result to (new_status, error_message).
+
+        Shared by the normal verification loop (process_batch) and the
+        backlog re-verification path (reverify_candidates) so both always
+        classify identically.
+        """
+        if verification_result.get("error"):
+            # If we ran HTTP pre-checks (production opt-in), treat
+            # exhausted HTTP failures as a terminal verification
+            # failure so orchestration can move candidates to the
+            # failed bucket. When running the default sniffer-first
+            # test-friendly path, preserve the non-terminal
+            # 'verification_uncertain' status so unit tests and
+            # manual review flows can retry or inspect candidates.
+            if self.run_http_precheck:
+                return "verification_failed", verification_result["error"]
+            return "verification_uncertain", verification_result["error"]
+        if verification_result.get("wire_filtered"):
+            return "wire", None
+        if verification_result.get("pattern_filtered"):
+            return (
+                verification_result.get("pattern_status") or "not_article",
+                None,
+            )
+        if verification_result.get("storysniffer_result"):
+            return "article", None
+        return "not_article", None
+
     def process_batch(self, candidates: list[dict]) -> dict:
         """Process a batch of candidates and return metrics."""
         batch_metrics: dict = {
@@ -734,44 +763,13 @@ class URLVerificationService:
             verification_result = self.verify_url(candidate["url"])
             batch_metrics["total_processed"] += 1
 
-            # Determine new status and update metrics
+            new_status, error_message = self.decide_status(verification_result)
             if verification_result.get("error"):
                 batch_metrics["verification_errors"] += 1
-                # If we ran HTTP pre-checks (production opt-in), treat
-                # exhausted HTTP failures as a terminal verification
-                # failure so orchestration can move candidates to the
-                # failed bucket. When running the default sniffer-first
-                # test-friendly path, preserve the non-terminal
-                # 'verification_uncertain' status so unit tests and
-                # manual review flows can retry or inspect candidates.
-                if self.run_http_precheck:
-                    new_status = "verification_failed"
-                else:
-                    new_status = "verification_uncertain"
-                error_message = verification_result["error"]
-            elif verification_result.get("wire_filtered"):
-                # Wire service URL detected - mark as wire
-                batch_metrics["verified_non_articles"] += 1
-                new_status = "wire"
-                error_message = None
-            elif verification_result.get("pattern_filtered"):
-                pattern_status = (
-                    verification_result.get("pattern_status") or "not_article"
-                )
-                if pattern_status == "article":
-                    batch_metrics["verified_articles"] += 1
-                else:
-                    batch_metrics["verified_non_articles"] += 1
-                new_status = pattern_status
-                error_message = None
-            elif verification_result.get("storysniffer_result"):
+            elif new_status == "article":
                 batch_metrics["verified_articles"] += 1
-                new_status = "article"
-                error_message = None
             else:
                 batch_metrics["verified_non_articles"] += 1
-                new_status = "not_article"
-                error_message = None
 
             batch_metrics["total_time_ms"] += verification_result.get(
                 "verification_time_ms", 0
@@ -789,6 +787,160 @@ class URLVerificationService:
         )
 
         return batch_metrics
+
+    def get_reverify_candidates(
+        self,
+        status: str = "article",
+        older_than_days: int | None = None,
+        host: str | None = None,
+        dataset_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """Select existing candidates for re-verification.
+
+        Unlike get_unverified_urls (status='discovered' only), this targets
+        candidates that already carry a terminal-ish status -- typically
+        'article' rows verified long ago under older rules, or links that
+        were manually unpaused straight back to 'article' without passing
+        through verification again.
+        """
+        query = """
+            SELECT id, url, source_name, source_city, source_county, status
+            FROM candidate_links
+            WHERE status = :status
+        """
+        params: dict = {"status": status}
+
+        if older_than_days is not None:
+            query += (
+                " AND created_at < NOW() - CAST(:older_days || ' days' AS INTERVAL)"
+            )
+            params["older_days"] = str(older_than_days)
+        if host:
+            query += " AND (source = :host OR url LIKE :host_like)"
+            params["host"] = host
+            params["host_like"] = f"%{host}%"
+        if dataset_id:
+            query += " AND dataset_id = :dataset_id"
+            params["dataset_id"] = dataset_id
+
+        query += " ORDER BY created_at ASC"
+        if limit:
+            query += f" LIMIT {int(limit)}"
+
+        with self.db.engine.connect() as conn:
+            result = safe_execute(conn, query, params)
+            return [dict(row._mapping) for row in result.fetchall()]
+
+    def reverify_candidates(
+        self,
+        candidates: list[dict],
+        dry_run: bool = False,
+        progress_every: int = 500,
+    ) -> dict:
+        """Re-run current verification over already-classified candidates.
+
+        Each candidate is re-classified with the same verify_url() +
+        decide_status() logic the normal verification loop uses. Candidates
+        whose status would not change are left untouched; the rest are
+        updated in place (unless dry_run).
+
+        Returns metrics: {"total", "kept", "reclassified": {status: count},
+        "errors"}.
+        """
+        metrics: dict = {
+            "total": 0,
+            "kept": 0,
+            "reclassified": {},
+            "errors": 0,
+        }
+
+        for candidate in candidates:
+            metrics["total"] += 1
+            result = self.verify_url(candidate["url"])
+            new_status, error_message = self.decide_status(result)
+
+            if result.get("error"):
+                # Don't demote existing rows on a transient verification
+                # error -- an error tells us nothing about the URL itself.
+                metrics["errors"] += 1
+            elif new_status == candidate.get("status"):
+                metrics["kept"] += 1
+            else:
+                metrics["reclassified"][new_status] = (
+                    metrics["reclassified"].get(new_status, 0) + 1
+                )
+                if not dry_run:
+                    self.update_candidate_status(
+                        candidate["id"], new_status, error_message
+                    )
+                self.logger.info(
+                    "%sReclassified %s: %s -> %s",
+                    "[dry-run] " if dry_run else "",
+                    candidate["url"],
+                    candidate.get("status"),
+                    new_status,
+                )
+
+            if progress_every and metrics["total"] % progress_every == 0:
+                self.logger.info(
+                    "Reverify progress: %d processed, %d kept, %d reclassified, "
+                    "%d errors",
+                    metrics["total"],
+                    metrics["kept"],
+                    sum(metrics["reclassified"].values()),
+                    metrics["errors"],
+                )
+
+        return metrics
+
+    def release_paused(
+        self,
+        older_than_days: int | None = None,
+        host: str | None = None,
+        dataset_id: str | None = None,
+        dry_run: bool = False,
+    ) -> int:
+        """Move paused candidates back to 'discovered' so the normal
+        verification loop re-screens them with current rules.
+
+        This is the sanctioned unpause path: paused links must never go
+        straight back to 'article' -- that skips verification entirely and
+        feeds stale junk to extraction.
+        """
+        where = "WHERE status = 'paused'"
+        params: dict = {}
+        if older_than_days is not None:
+            where += (
+                " AND created_at < NOW() - CAST(:older_days || ' days' AS INTERVAL)"
+            )
+            params["older_days"] = str(older_than_days)
+        if host:
+            where += " AND (source = :host OR url LIKE :host_like)"
+            params["host"] = host
+            params["host_like"] = f"%{host}%"
+        if dataset_id:
+            where += " AND dataset_id = :dataset_id"
+            params["dataset_id"] = dataset_id
+
+        with self.db.engine.connect() as conn:
+            if dry_run:
+                result = safe_execute(
+                    conn, f"SELECT COUNT(*) FROM candidate_links {where}", params
+                )
+                return int(result.scalar() or 0)
+
+            result = safe_execute(
+                conn,
+                "UPDATE candidate_links SET status = 'discovered', "
+                f"error_message = NULL {where}",
+                params,
+            )
+            try:
+                conn.commit()
+            except Exception:
+                pass
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def save_telemetry_summary(
         self, batch_metrics: dict, candidates: list[dict], job_name: str

--- a/tests/integration/test_reverify_candidates_postgres.py
+++ b/tests/integration/test_reverify_candidates_postgres.py
@@ -1,0 +1,222 @@
+"""Integration tests for backlog re-verification against PostgreSQL.
+
+Exercises get_reverify_candidates / reverify_candidates / release_paused
+end-to-end against real candidate_links rows: junk that slipped into
+status='article' under old rules gets demoted, good rows stay untouched,
+and paused rows can be released back through the verification funnel.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+
+from src.models import CandidateLink, Source
+
+pytestmark = [pytest.mark.postgres, pytest.mark.integration]
+
+
+@pytest.fixture
+def reverify_source(cloud_sql_session):
+    source = Source(
+        id=str(uuid.uuid4()),
+        host="test-reverify.example.com",
+        host_norm="test-reverify.example.com",
+        canonical_name="Test Reverify Source",
+    )
+    cloud_sql_session.add(source)
+    cloud_sql_session.commit()
+    cloud_sql_session.refresh(source)
+    return source
+
+
+def _add_candidate(session, source, url, status):
+    candidate = CandidateLink(
+        id=str(uuid.uuid4()),
+        url=url,
+        source=source.canonical_name,
+        source_host_id=source.id,
+        crawl_depth=0,
+        status=status,
+        discovered_at=datetime.now(timezone.utc),
+        discovered_by="test_reverify",
+    )
+    session.add(candidate)
+    session.commit()
+    session.refresh(candidate)
+    return candidate
+
+
+@pytest.fixture
+def reverify_service(cloud_sql_session, monkeypatch):
+    # The cloud_sql_session fixture keeps everything inside ONE
+    # connection-level transaction that is rolled back at teardown -- a
+    # fresh engine.connect() in the service would get a separate
+    # connection that can't see any fixture data. Shim engine.connect()
+    # to hand back the fixture's own connection, with commit() a no-op so
+    # the service can't accidentally commit the outer test transaction.
+    class _ConnShim:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, *args, **kwargs):
+            return self._conn.execute(*args, **kwargs)
+
+        def commit(self):
+            pass
+
+    class _EngineShim:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def connect(self):
+            return _ConnShim(self._conn)
+
+    class _PatchedDatabaseManager:
+        def __init__(self):
+            self.engine = _EngineShim(cloud_sql_session.get_bind())
+
+        def get_session(self):
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _session_context():
+                yield cloud_sql_session
+
+            return _session_context()
+
+    monkeypatch.setattr(
+        "src.services.url_verification.DatabaseManager",
+        lambda *_, **__: _PatchedDatabaseManager(),
+    )
+
+    class _FakeTelemetry:
+        def record_verification_batch(self, *args, **kwargs):
+            return None
+
+    from src.services.url_verification import URLVerificationService
+
+    service = URLVerificationService(
+        run_http_precheck=False, telemetry_tracker=_FakeTelemetry()
+    )
+    service._pattern_cache = None
+    service._pattern_cache_expiry = 0
+    return service
+
+
+def _status_of(session, candidate_id):
+    return session.execute(
+        text("SELECT status FROM candidate_links WHERE id = :id"),
+        {"id": candidate_id},
+    ).scalar()
+
+
+class TestReverifyPostgres:
+    def test_asset_url_in_article_backlog_gets_demoted(
+        self, cloud_sql_session, reverify_source, reverify_service
+    ):
+        """A favicon that old rules let through gets caught by the current
+        asset-extension filter and demoted from 'article'."""
+        junk = _add_candidate(
+            cloud_sql_session,
+            reverify_source,
+            "https://test-reverify.example.com/wp-content/favicon-16x16.png",
+            "article",
+        )
+
+        candidates = reverify_service.get_reverify_candidates(
+            status="article", host="test-reverify.example.com"
+        )
+        assert any(c["id"] == junk.id for c in candidates)
+
+        metrics = reverify_service.reverify_candidates(
+            [c for c in candidates if c["id"] == junk.id]
+        )
+
+        assert metrics["reclassified"].get("not_article") == 1
+        cloud_sql_session.expire_all()
+        assert _status_of(cloud_sql_session, junk.id) == "not_article"
+
+    def test_genuine_article_stays_article(
+        self, cloud_sql_session, reverify_source, reverify_service, monkeypatch
+    ):
+        keeper = _add_candidate(
+            cloud_sql_session,
+            reverify_source,
+            "https://test-reverify.example.com/news/city-council-votes",
+            "article",
+        )
+        monkeypatch.setattr(reverify_service.sniffer, "guess", lambda _: True)
+
+        candidates = reverify_service.get_reverify_candidates(
+            status="article", host="test-reverify.example.com"
+        )
+        metrics = reverify_service.reverify_candidates(
+            [c for c in candidates if c["id"] == keeper.id]
+        )
+
+        assert metrics["kept"] == 1
+        cloud_sql_session.expire_all()
+        assert _status_of(cloud_sql_session, keeper.id) == "article"
+
+    def test_dry_run_leaves_rows_untouched(
+        self, cloud_sql_session, reverify_source, reverify_service
+    ):
+        junk = _add_candidate(
+            cloud_sql_session,
+            reverify_source,
+            "https://test-reverify.example.com/assets/logo.jpg",
+            "article",
+        )
+
+        candidates = reverify_service.get_reverify_candidates(
+            status="article", host="test-reverify.example.com"
+        )
+        metrics = reverify_service.reverify_candidates(
+            [c for c in candidates if c["id"] == junk.id], dry_run=True
+        )
+
+        assert metrics["reclassified"].get("not_article") == 1
+        cloud_sql_session.expire_all()
+        assert _status_of(cloud_sql_session, junk.id) == "article"
+
+    def test_release_paused_moves_to_discovered(
+        self, cloud_sql_session, reverify_source, reverify_service
+    ):
+        paused = _add_candidate(
+            cloud_sql_session,
+            reverify_source,
+            "https://test-reverify.example.com/paused-story",
+            "paused",
+        )
+
+        count = reverify_service.release_paused(host="test-reverify.example.com")
+
+        assert count >= 1
+        cloud_sql_session.expire_all()
+        assert _status_of(cloud_sql_session, paused.id) == "discovered"
+
+    def test_release_paused_dry_run_counts_only(
+        self, cloud_sql_session, reverify_source, reverify_service
+    ):
+        paused = _add_candidate(
+            cloud_sql_session,
+            reverify_source,
+            "https://test-reverify.example.com/paused-story-2",
+            "paused",
+        )
+
+        count = reverify_service.release_paused(
+            host="test-reverify.example.com", dry_run=True
+        )
+
+        assert count >= 1
+        cloud_sql_session.expire_all()
+        assert _status_of(cloud_sql_session, paused.id) == "paused"

--- a/tests/services/test_reverify_candidates.py
+++ b/tests/services/test_reverify_candidates.py
@@ -1,0 +1,181 @@
+"""Unit tests for backlog re-verification (reverify_candidates et al.).
+
+Postgres integration coverage lives in
+tests/integration/test_reverify_candidates_postgres.py.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.services import url_verification
+
+
+def _service() -> url_verification.URLVerificationService:
+    return url_verification.URLVerificationService(
+        batch_size=100,
+        http_backoff_seconds=0,
+        run_http_precheck=False,
+    )
+
+
+class TestDecideStatus:
+    def test_error_maps_to_uncertain_without_precheck(self) -> None:
+        service = _service()
+        status, error = service.decide_status(
+            {"error": "boom", "storysniffer_result": None}
+        )
+        assert status == "verification_uncertain"
+        assert error == "boom"
+
+    def test_error_maps_to_failed_with_precheck(self) -> None:
+        service = url_verification.URLVerificationService(
+            http_backoff_seconds=0, run_http_precheck=True
+        )
+        status, _ = service.decide_status(
+            {"error": "boom", "storysniffer_result": None}
+        )
+        assert status == "verification_failed"
+
+    def test_wire_beats_everything_else(self) -> None:
+        service = _service()
+        status, error = service.decide_status(
+            {"wire_filtered": True, "storysniffer_result": True}
+        )
+        assert status == "wire"
+        assert error is None
+
+    def test_pattern_status_used_when_pattern_filtered(self) -> None:
+        service = _service()
+        status, _ = service.decide_status(
+            {"pattern_filtered": True, "pattern_status": "obituary"}
+        )
+        assert status == "obituary"
+
+    def test_sniffer_true_is_article(self) -> None:
+        service = _service()
+        status, _ = service.decide_status({"storysniffer_result": True})
+        assert status == "article"
+
+    def test_default_is_not_article(self) -> None:
+        service = _service()
+        status, _ = service.decide_status({"storysniffer_result": False})
+        assert status == "not_article"
+
+
+class TestReverifyCandidates:
+    def test_junk_is_reclassified_and_updated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = _service()
+        updates: list[tuple] = []
+        monkeypatch.setattr(
+            service,
+            "update_candidate_status",
+            lambda cid, status, err=None: updates.append((cid, status)),
+        )
+        monkeypatch.setattr(
+            service,
+            "verify_url",
+            lambda url: {
+                "pattern_filtered": True,
+                "pattern_status": "not_article",
+            },
+        )
+
+        metrics = service.reverify_candidates(
+            [{"id": "c1", "url": "https://x.com/scripts/junk.php", "status": "article"}]
+        )
+
+        assert metrics["total"] == 1
+        assert metrics["kept"] == 0
+        assert metrics["reclassified"] == {"not_article": 1}
+        assert updates == [("c1", "not_article")]
+
+    def test_still_article_is_kept_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = _service()
+        update_mock = Mock()
+        monkeypatch.setattr(service, "update_candidate_status", update_mock)
+        monkeypatch.setattr(
+            service, "verify_url", lambda url: {"storysniffer_result": True}
+        )
+
+        metrics = service.reverify_candidates(
+            [{"id": "c1", "url": "https://x.com/real-story", "status": "article"}]
+        )
+
+        assert metrics["kept"] == 1
+        assert metrics["reclassified"] == {}
+        update_mock.assert_not_called()
+
+    def test_verification_error_leaves_row_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A transient verify error must never demote an existing row."""
+        service = _service()
+        update_mock = Mock()
+        monkeypatch.setattr(service, "update_candidate_status", update_mock)
+        monkeypatch.setattr(
+            service,
+            "verify_url",
+            lambda url: {"error": "sniffer exploded", "storysniffer_result": None},
+        )
+
+        metrics = service.reverify_candidates(
+            [{"id": "c1", "url": "https://x.com/a", "status": "article"}]
+        )
+
+        assert metrics["errors"] == 1
+        assert metrics["kept"] == 0
+        assert metrics["reclassified"] == {}
+        update_mock.assert_not_called()
+
+    def test_dry_run_reports_without_updating(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = _service()
+        update_mock = Mock()
+        monkeypatch.setattr(service, "update_candidate_status", update_mock)
+        monkeypatch.setattr(
+            service,
+            "verify_url",
+            lambda url: {"wire_filtered": True},
+        )
+
+        metrics = service.reverify_candidates(
+            [{"id": "c1", "url": "https://x.com/ap-wire", "status": "article"}],
+            dry_run=True,
+        )
+
+        assert metrics["reclassified"] == {"wire": 1}
+        update_mock.assert_not_called()
+
+    def test_mixed_batch_counts_are_correct(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = _service()
+        monkeypatch.setattr(service, "update_candidate_status", lambda *a, **k: None)
+        results = {
+            "https://x.com/keep": {"storysniffer_result": True},
+            "https://x.com/wire": {"wire_filtered": True},
+            "https://x.com/junk": {
+                "pattern_filtered": True,
+                "pattern_status": "not_article",
+            },
+        }
+        monkeypatch.setattr(service, "verify_url", lambda url: results[url])
+
+        metrics = service.reverify_candidates(
+            [
+                {"id": "1", "url": "https://x.com/keep", "status": "article"},
+                {"id": "2", "url": "https://x.com/wire", "status": "article"},
+                {"id": "3", "url": "https://x.com/junk", "status": "article"},
+            ]
+        )
+
+        assert metrics["total"] == 3
+        assert metrics["kept"] == 1
+        assert metrics["reclassified"] == {"wire": 1, "not_article": 1}
+        assert metrics["errors"] == 0


### PR DESCRIPTION
## Summary
Extraction workers are pulling junk from the verified backlog: links marked `article` months ago under old verification rules (or manually unpaused straight back to `article`) never re-pass current verification. Today's validation run served a 10-month-old `/scripts/classifieds/post.php` URL to a worker — its 502 put the whole domain into rate-limit backoff, skipping legit articles.

New `reverify-candidates` CLI command:
- Default mode: re-runs **current** verification (DB patterns + StorySniffer + asset-extension rejection — no HTTP or proxy traffic) over the `article` backlog in place. Junk gets demoted (`not_article`/`wire`/`obituary`/...), good rows stay untouched, transient verification errors never demote a row.
- `--release-paused`: moves `paused` links back to `discovered` so the normal verification loop re-screens them — the sanctioned unpause path (unpausing must never skip verification).
- Filters: `--older-than-days`, `--host`, `--dataset-id`, `--limit`; plus `--dry-run` and progress logging.

`decide_status()` is extracted from `process_batch()` so the normal loop and the reverify path always classify identically (pure refactor, metrics behavior unchanged).

## Test plan
- [x] 11 unit tests (`tests/services/test_reverify_candidates.py`): decide_status mapping, reclassify/keep/error/dry-run/mixed-batch behavior
- [x] 5 postgres integration tests (`tests/integration/test_reverify_candidates_postgres.py`): real DB round-trips — favicon demotion, keeper stays, dry-run untouched, paused→discovered release (+dry-run)
- [x] Full verification + CLI test suites pass (311 tests)
- [x] Pre-push gate green (lint, mypy, full suite, postgres suite)

## After merge
Planned prod run: `reverify-candidates --dry-run` first against the 15,363-row `article` backlog, review the reclassification breakdown, then run for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)