### PR TITLE
Fetch once, parse many: close the proxy bypass and gate captures on article text

### DIFF
--- a/k8s/argo/base-pipeline-workflow.yaml
+++ b/k8s/argo/base-pipeline-workflow.yaml
@@ -225,6 +225,12 @@ spec:
           secretKeyRef:
             name: squid-proxy-credentials
             key: squid-proxy-url
+      - name: MIZZOU_SQUID_PROXY_URL
+        valueFrom:
+          secretKeyRef:
+            name: squid-proxy-credentials
+            key: mizzou-squid-proxy-url
+            optional: true
       - name: GOOGLE_CLOUD_PROJECT
         value: "mizzou-news-crawler"
       - name: NO_PROXY
@@ -317,6 +323,12 @@ spec:
           secretKeyRef:
             name: squid-proxy-credentials
             key: squid-proxy-url
+      - name: MIZZOU_SQUID_PROXY_URL
+        valueFrom:
+          secretKeyRef:
+            name: squid-proxy-credentials
+            key: mizzou-squid-proxy-url
+            optional: true
       - name: GOOGLE_CLOUD_PROJECT
         value: "mizzou-news-crawler"
       - name: NO_PROXY
@@ -419,6 +431,12 @@ spec:
           secretKeyRef:
             name: squid-proxy-credentials
             key: squid-proxy-url
+      - name: MIZZOU_SQUID_PROXY_URL
+        valueFrom:
+          secretKeyRef:
+            name: squid-proxy-credentials
+            key: mizzou-squid-proxy-url
+            optional: true
       - name: SELENIUM_PROXY
         valueFrom:
           secretKeyRef:

--- a/k8s/lehigh-extraction-job.yaml
+++ b/k8s/lehigh-extraction-job.yaml
@@ -82,6 +82,12 @@ spec:
             secretKeyRef:
               name: squid-proxy-credentials
               key: squid-proxy-url
+        - name: MIZZOU_SQUID_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              name: squid-proxy-credentials
+              key: mizzou-squid-proxy-url
+              optional: true
               optional: true
         - name: SELENIUM_PROXY
           valueFrom:

--- a/k8s/mizzou-discovery-job.yaml
+++ b/k8s/mizzou-discovery-job.yaml
@@ -88,6 +88,12 @@ spec:
             secretKeyRef:
               name: squid-proxy-credentials
               key: squid-proxy-url
+        - name: MIZZOU_SQUID_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              name: squid-proxy-credentials
+              key: mizzou-squid-proxy-url
+              optional: true
               optional: true
         - name: SELENIUM_PROXY
           valueFrom:

--- a/k8s/mizzou-extraction-job.yaml
+++ b/k8s/mizzou-extraction-job.yaml
@@ -88,6 +88,12 @@ spec:
             secretKeyRef:
               name: squid-proxy-credentials
               key: squid-proxy-url
+        - name: MIZZOU_SQUID_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              name: squid-proxy-credentials
+              key: mizzou-squid-proxy-url
+              optional: true
               optional: true
         - name: SELENIUM_PROXY
           valueFrom:

--- a/k8s/processor-deployment.yaml
+++ b/k8s/processor-deployment.yaml
@@ -116,6 +116,12 @@ spec:
             secretKeyRef:
               name: squid-proxy-credentials
               key: squid-proxy-url
+        - name: MIZZOU_SQUID_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              name: squid-proxy-credentials
+              key: mizzou-squid-proxy-url
+              optional: true
               optional: true
         - name: SELENIUM_PROXY
           valueFrom:

--- a/k8s/templates/dataset-discovery-job.yaml
+++ b/k8s/templates/dataset-discovery-job.yaml
@@ -93,6 +93,12 @@ spec:
               key: squid-proxy-url
               name: squid-proxy-credentials
               optional: true
+        - name: MIZZOU_SQUID_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              key: mizzou-squid-proxy-url
+              name: squid-proxy-credentials
+              optional: true
               name: squid-proxy-credentials
               optional: true
               name: squid-proxy-credentials

--- a/k8s/templates/dataset-extraction-job.yaml
+++ b/k8s/templates/dataset-extraction-job.yaml
@@ -93,6 +93,12 @@ spec:
               key: squid-proxy-url
               name: squid-proxy-credentials
               optional: true
+        - name: MIZZOU_SQUID_PROXY_URL
+          valueFrom:
+            secretKeyRef:
+              key: mizzou-squid-proxy-url
+              name: squid-proxy-credentials
+              optional: true
               name: squid-proxy-credentials
               optional: true
               name: squid-proxy-credentials

--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -678,11 +678,44 @@ def add_extraction_parser(subparsers):
     extract_parser.set_defaults(func=handle_extraction_command)
 
 
+def _set_proxy_env_safety_net() -> None:
+    """Point stray third-party fetchers at the proxy via env vars.
+
+    The session/router paths carry their own proxies explicitly; this is
+    the backstop for any library that opens its own connection (newspaper4k
+    internals, feedparser, future dependencies). Discovery has done the
+    same since day one (_set_global_proxy_env); extraction never did --
+    which is how mcmetadata's built-in fetcher, the week it went live as
+    the primary extractor, egressed directly from the pod IP with no test
+    or telemetry noticing.
+
+    NO_PROXY exempts cluster-internal services (work-queue), Google APIs
+    (Firestore/GCS/Cloud SQL admin), and the metadata server -- proxying
+    those through a residential Squid would break them.
+    """
+    proxy_url = os.getenv("SQUID_PROXY_URL")
+    if not proxy_url:
+        return
+
+    no_proxy = (
+        "localhost,127.0.0.1,169.254.169.254,metadata.google.internal,"
+        ".svc.cluster.local,.googleapis.com,.google.com"
+    )
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        os.environ.setdefault(key, proxy_url)
+    for key in ("NO_PROXY", "no_proxy"):
+        existing = os.environ.get(key)
+        os.environ[key] = f"{existing},{no_proxy}" if existing else no_proxy
+    logger.info("🌍 Proxy env safety net set for third-party libraries")
+
+
 def handle_extraction_command(args) -> int:
     """Execute extraction command logic."""
     _ensure_crawler_dependencies()
     if ContentExtractor is None:  # pragma: no cover - defensive fallback
         raise RuntimeError("ContentExtractor dependency is unavailable")
+
+    _set_proxy_env_safety_net()
 
     extractor_cls = ContentExtractor
     process_accepts_db = "db" in inspect.signature(_process_batch).parameters

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -25,6 +25,16 @@ import requests
 from bs4 import BeautifulSoup, Tag
 from dateutil import parser as dateparser
 
+from src.utils.boilerplate import (
+    MAX_CAPITALIZATION,
+    MAX_UTILITY_WORD_RATE,
+    MIN_PROSE_DENSITY,
+    capitalization_ratio,
+    looks_like_article,
+    prose_density,
+    strip_boilerplate,
+    utility_word_rate,
+)
 from src.utils.bot_sensitivity_manager import BotSensitivityManager
 from src.utils.comprehensive_telemetry import ExtractionMetrics
 
@@ -2987,6 +2997,14 @@ class ContentExtractor:
                 fallback_reason = (
                     "selenium_secondary" if skip_http_methods else "http_fallback"
                 )
+                # Why the HTTP capture was rejected -- "empty" / "stub" /
+                # "not_article_like". Without this a wall-vs-real-article
+                # rejection is indistinguishable in telemetry from an
+                # ordinary missing-fields escalation.
+                rejection = getattr(self, "_last_capture_rejection", None)
+                if rejection:
+                    fallback_reason = f"{fallback_reason}:{rejection}"
+                    result.setdefault("metadata", {})["capture_rejected_as"] = rejection
                 self._run_selenium_extraction(
                     url,
                     result,
@@ -5813,6 +5831,51 @@ class ContentExtractor:
     # saving: 1200 chars would still escalate on 31% of complete stories.
     PAYWALL_STUB_MAX_CHARS = 400
 
+    # Why the last capture was rejected ("empty" / "stub" /
+    # "not_article_like"), or None when it was accepted.
+    _last_capture_rejection: Optional[str] = None
+
+    def _assess_capture_quality(self, content: str) -> Dict[str, Any]:
+        """The measured signals behind a capture-quality verdict.
+
+        Returned for every capture the gate judges -- accepted or rejected --
+        so the heuristic can be EVALUATED rather than trusted: what share of
+        captures each reason rejects, where the density/capitalisation
+        distributions actually sit, and (paired with the Selenium body that
+        follows a rejection) whether escalating was right. The thresholds
+        that produced the verdict travel with it, so old rows stay readable
+        after a retune.
+        """
+        stripped = (content or "").strip()
+        quality: Dict[str, Any] = {
+            "chars": len(stripped),
+            "stub_threshold": self.PAYWALL_STUB_MAX_CHARS,
+        }
+        if not stripped:
+            quality["article_like"] = False
+            return quality
+
+        try:
+            body = strip_boilerplate(stripped)
+            quality.update(
+                {
+                    "chars_after_strip": len(body),
+                    "prose_density": round(prose_density(body), 4),
+                    "capitalization_ratio": round(capitalization_ratio(body), 4),
+                    "utility_word_rate": round(utility_word_rate(body), 4),
+                    "article_like": looks_like_article(stripped),
+                    "thresholds": {
+                        "min_prose_density": MIN_PROSE_DENSITY,
+                        "max_capitalization": MAX_CAPITALIZATION,
+                        "max_utility_word_rate": MAX_UTILITY_WORD_RATE,
+                    },
+                }
+            )
+        except Exception as exc:  # never let measurement break extraction
+            logger.debug("capture quality assessment failed: %s", exc)
+            quality["error"] = str(exc)[:120]
+        return quality
+
     def _selenium_would_add_value(self, result: dict, missing_fields: list) -> bool:
         """Whether launching a browser can plausibly recover the missing fields.
 
@@ -5832,12 +5895,40 @@ class ContentExtractor:
         and are only missing author/date.
         """
         content = (result.get("content") or result.get("text") or "").strip()
+        # Record the measured signals for EVERY decision, accept or reject.
+        # Logging only rejections makes the heuristic unfalsifiable: you
+        # cannot measure a false-positive rate, or retune MIN_PROSE_DENSITY /
+        # MAX_CAPITALIZATION / MAX_UTILITY_WORD_RATE, from a sample that
+        # excludes everything the gate let through.
+        quality = self._assess_capture_quality(content)
+        result.setdefault("metadata", {})["capture_quality"] = quality
+
         if not content:
+            self._last_capture_rejection = "empty"
             return True  # nothing captured at all — Selenium is the last resort
         if len(content) <= self.PAYWALL_STUB_MAX_CHARS:
+            self._last_capture_rejection = "stub"
             return True  # teaser above a paywall; a real browser may reveal the body
+
+        # Length alone says nothing about WHAT was captured. A consent wall, a
+        # bot-challenge interstitial or a nav dump can all clear the stub
+        # threshold and be accepted as an article. looks_like_article() already
+        # answers this (prose density / capitalisation / utility-word rate, no
+        # word-count floor) and comprehensive_telemetry already computes it to
+        # set is_success -- but only ever to RECORD the failure, never to act on
+        # it. Act on it: a body that is not writing is worth a browser.
+        if not looks_like_article(content):
+            self._last_capture_rejection = "not_article_like"
+            logger.info(
+                "Capture for %s is not article-like (%d chars); escalating",
+                result.get("url") or "?",
+                len(content),
+            )
+            return True
+
         # Full body in hand. Whatever metadata is still missing is missing from the
         # page itself, and re-fetching it will not conjure it.
+        self._last_capture_rejection = None
         return False
 
     def _page_has_article_content(self, driver) -> bool:

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -2693,7 +2693,7 @@ class ContentExtractor:
             if metrics:
                 metrics.start_method("http_fetch")
             try:
-                html_for_methods = self._fetch_page_html(url)
+                html_for_methods = self._fetch_page_html(url, metrics=metrics)
                 if metrics:
                     metrics.end_method("http_fetch", True, None, {})
             except (NotFoundError, RateLimitError) as e:
@@ -3385,7 +3385,7 @@ class ContentExtractor:
 
         return bool(title) or (bool(content) and len(content) > 100)
 
-    def _fetch_page_html(self, url: str) -> str:
+    def _fetch_page_html(self, url: str, metrics=None) -> str:
         """Fetch page HTML ONCE via the proxied per-domain session.
 
         This is the crawler's single HTTP capture step -- the ONLY place
@@ -3483,6 +3483,24 @@ class ContentExtractor:
                     )
 
             http_status = response.status_code
+            if metrics is not None:
+                # set_http_metrics also derives http_error_type and records
+                # size/timing, which the old newspaper fetch supplied.
+                # Wrapped: telemetry must never be able to discard a capture
+                # we already hold (it did exactly that twice while building
+                # this -- a Mock response_time, then a wrong method name).
+                try:
+                    try:
+                        response_ms = float(response.elapsed.total_seconds()) * 1000
+                    except (TypeError, ValueError, AttributeError):
+                        response_ms = 0.0
+                    try:
+                        body_size = len(response.text or "")
+                    except (TypeError, AttributeError):
+                        body_size = 0
+                    metrics.set_http_metrics(http_status, body_size, response_ms)
+                except Exception as exc:
+                    logger.warning("http metrics recording failed: %s", exc)
 
             session_proxies = getattr(session, "proxies", None)
             session_proxy_url = None
@@ -3553,17 +3571,25 @@ class ContentExtractor:
                 logger.warning(f"Permanent missing ({http_status}) for {url}; caching")
                 raise NotFoundError(f"URL returned {http_status}: {url}")
             elif http_status == 200:
-                self._reset_error_count(domain)
-                self.proxy_manager.record_success(
-                    response_time=response.elapsed.total_seconds()
-                )
-                self.proxy_manager.report_domain_result(
-                    domain,
-                    router_proxy,
-                    success=True,
-                    service="newscrawler",
-                )
+                # Take the payload FIRST. Everything after this is
+                # bookkeeping, and bookkeeping must never be able to discard
+                # a page we already hold -- a Mock response_time in a test
+                # once threw inside record_success() and the broad handler
+                # below turned a good 200 capture into "capture failed".
                 captured_html = response.text
+                self._reset_error_count(domain)
+                try:
+                    self.proxy_manager.record_success(
+                        response_time=response.elapsed.total_seconds()
+                    )
+                    self.proxy_manager.report_domain_result(
+                        domain,
+                        router_proxy,
+                        success=True,
+                        service="newscrawler",
+                    )
+                except Exception as exc:
+                    logger.warning("proxy bookkeeping failed for %s: %s", domain, exc)
                 ua = self.domain_user_agents.get(domain, "Unknown")
                 logger.info(
                     f"✅ Successfully fetched {len(captured_html)} bytes from "

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -2668,15 +2668,45 @@ class ContentExtractor:
                 f"(protection: {protection_type}) - skipping HTTP methods"
             )
 
-        # Try mcmetadata first if enabled (skip for selenium_only domains)
-        if self._mcmetadata_enabled() and not skip_http_methods:
+        # ── FETCH ONCE, PARSE MANY ─────────────────────────────────────
+        # The single proxied HTTP capture. Every parser below (mcmetadata,
+        # newspaper4k, BeautifulSoup) parses THIS html; none of them fetch.
+        # A Selenium capture (if selenium-first ran) wins via
+        # _capture_for_parsing. With no capture and HTTP allowed, fetch now:
+        # NotFound/RateLimit stop extraction; any other failure (bot block,
+        # transport error) leaves html None so the Selenium fallback runs.
+        html_for_methods = self._capture_for_parsing(html_for_methods)
+        if not html_for_methods and not skip_http_methods:
+            # Tracked as its own metrics step: the fetch can now fail
+            # (404/rate-limit/bot block) before any parser runs, and that
+            # outcome must still show up in telemetry.
+            if metrics:
+                metrics.start_method("http_fetch")
+            try:
+                html_for_methods = self._fetch_page_html(url)
+                if metrics:
+                    metrics.end_method("http_fetch", True, None, {})
+            except (NotFoundError, RateLimitError) as e:
+                if metrics:
+                    metrics.end_method("http_fetch", False, str(e), {})
+                raise
+            except Exception as e:
+                if metrics:
+                    metrics.end_method("http_fetch", False, str(e), {})
+                logger.info(f"HTTP capture failed for {url}: {e}; will try Selenium")
+                html_for_methods = None
+
+        # Try mcmetadata first if enabled (skip for selenium_only domains).
+        # Guarded on html_for_methods so mcmetadata can NEVER be handed a
+        # bare URL -- that would trip its vendored self-fetcher (un-proxied,
+        # pod-IP egress).
+        if self._mcmetadata_enabled() and not skip_http_methods and html_for_methods:
             try:
                 logger.info(f"Attempting mcmetadata extraction for {url}")
                 if metrics:
                     metrics.start_method("mcmetadata")
 
-                html_for_methods = self._capture_for_parsing(html_for_methods)
-                mcmetadata_result = self._extract_with_mcmetadata(
+                mcmetadata_result = self._parse_with_mcmetadata(
                     url,
                     html_for_methods,
                     include_other_metadata=self.mcmetadata_include_other_metadata,
@@ -2709,6 +2739,7 @@ class ContentExtractor:
             NEWSPAPER_AVAILABLE
             and (not self._mcmetadata_enabled() or missing_fields)
             and not skip_http_methods
+            and bool(html_for_methods)
         )
         if use_newspaper:
             try:
@@ -2716,8 +2747,7 @@ class ContentExtractor:
                 if metrics:
                     metrics.start_method("newspaper4k")
 
-                html_for_methods = self._capture_for_parsing(html_for_methods)
-                newspaper_result = self._extract_with_newspaper(url, html_for_methods)
+                newspaper_result = self._parse_with_newspaper(url, html_for_methods)
 
                 if newspaper_result:
                     self._merge_extraction_results(
@@ -2800,10 +2830,10 @@ class ContentExtractor:
         self._apply_cms_metadata_fallback(result)
         missing_fields = self._get_missing_fields(result)
 
-        # Try BeautifulSoup fallback for missing fields
-        # For selenium_only domains without pre-fetched HTML, skip to Selenium
-        has_html_for_bs = html_for_methods or (result.get("metadata", {}).get("html"))
-        if missing_fields and (has_html_for_bs or not skip_http_methods):
+        # Try BeautifulSoup fallback for missing fields. Parser-only now, so
+        # it only runs when we actually have a capture to parse; otherwise
+        # the Selenium fallback below is the next step.
+        if missing_fields and html_for_methods:
             try:
                 logger.info(
                     f"Attempting BeautifulSoup fallback for missing "
@@ -2812,11 +2842,7 @@ class ContentExtractor:
                 if metrics:
                     metrics.start_method("beautifulsoup")
 
-                # Was passing `html` — the untouched extract_content parameter,
-                # None for every production call — so this re-fetched even
-                # though the guard above had just confirmed a capture exists.
-                html_for_methods = self._capture_for_parsing(html_for_methods)
-                bs_result = self._extract_with_beautifulsoup(url, html_for_methods)
+                bs_result = self._parse_with_beautifulsoup(url, html_for_methods)
 
                 if bs_result:
                     # Only copy missing fields
@@ -3341,7 +3367,298 @@ class ContentExtractor:
 
         return bool(title) or (bool(content) and len(content) > 100)
 
-    def _extract_with_mcmetadata(
+    def _fetch_page_html(self, url: str) -> str:
+        """Fetch page HTML ONCE via the proxied per-domain session.
+
+        This is the crawler's single HTTP capture step -- the ONLY place
+        (besides Selenium) that touches a live domain. The parsers
+        (mcmetadata, newspaper4k, BeautifulSoup) all parse the string this
+        returns; none of them fetch (fetch-once-parse-many). The session
+        carries the router-chosen Squid proxy and a rotated browser UA, and
+        every outcome is reported back to proxy_router.
+
+        Records per-fetch telemetry on self._last_fetch_proxy_metadata /
+        self._last_fetch_http_status for the parsers to attach to results.
+
+        Raises to signal how the caller should proceed:
+          - NotFoundError   404/410/permanent-4xx: stop all fallbacks
+          - RateLimitError  429/5xx/rate-limited: back off, stop this round
+          - Exception       bot protection / transport error: caller should
+                            fall through to Selenium
+        """
+        ttl = getattr(self, "dead_url_ttl", 0)
+        if ttl and url in getattr(self, "dead_urls", {}):
+            if time.time() < self.dead_urls[url]:
+                raise NotFoundError(f"URL is cached dead: {url}")
+
+        domain = urlparse(url).netloc
+        http_status = None
+        captured_html = None
+        self._last_fetch_proxy_metadata = {
+            "proxy_used": False,
+            "proxy_url": None,
+            "proxy_authenticated": False,
+            "proxy_status": None,
+            "proxy_error": None,
+            "router_proxy": None,
+        }
+        self._last_fetch_http_status = None
+
+        try:
+            session = self._get_domain_session(url)
+            if self._check_rate_limit(domain):
+                raise RateLimitError(f"Domain {domain} is rate limited")
+
+            with self._get_domain_lock(domain):
+                logger.info(f"📡 Fetching {url[:80]}... via session for {domain}")
+
+                request_headers = {}
+                referer = self._generate_referer(url)
+                if referer:
+                    request_headers["Referer"] = referer
+                    logger.debug(f"Using Referer: {referer}")
+
+                response = None
+                amp_supported = self._get_domain_amp_support(domain)
+                if amp_supported is True:
+                    logger.info(
+                        f"🔄 Domain {domain} known to support AMP, trying AMP first"
+                    )
+                    for amp_url in self._convert_to_amp_url(url):
+                        try:
+                            logger.info(f"📡 Fetching AMP URL: {amp_url}")
+                            response = session.get(
+                                amp_url,
+                                timeout=self.timeout,
+                                headers=request_headers,
+                            )
+                            if response.status_code == 200 and self._validate_amp_page(
+                                response.text
+                            ):
+                                logger.info(
+                                    f"✅ Successfully fetched AMP page for {domain}"
+                                )
+                                http_status = 200
+                                captured_html = response.text
+                                self.bot_sensitivity_manager.record_bot_detection(
+                                    host=domain,
+                                    url=url,
+                                    event_type="amp_preemptive_success",
+                                    http_status_code=200,
+                                    response_indicators={"amp_url": amp_url},
+                                )
+                                break
+                        except Exception as amp_e:
+                            logger.debug(
+                                f"AMP preemptive fetch failed: {amp_url} - {amp_e}"
+                            )
+                            continue
+
+                    if not captured_html:
+                        logger.warning("AMP preemptive fetch failed, trying normal URL")
+                        response = session.get(
+                            url, timeout=self.timeout, headers=request_headers
+                        )
+                else:
+                    response = session.get(
+                        url, timeout=self.timeout, headers=request_headers
+                    )
+
+            http_status = response.status_code
+
+            session_proxies = getattr(session, "proxies", None)
+            session_proxy_url = None
+            if isinstance(session_proxies, dict):
+                session_proxy_url = session_proxies.get("https") or session_proxies.get(
+                    "http"
+                )
+            if not isinstance(session_proxy_url, str):
+                session_proxy_url = None
+            router_proxy = self.domain_router_proxy.get(domain)
+            fetch_meta: Dict[str, Any] = {
+                "proxy_used": bool(session_proxy_url),
+                "proxy_url": mask_proxy_url(session_proxy_url),
+                "proxy_authenticated": "@" in (session_proxy_url or ""),
+                "proxy_status": http_status,
+                "proxy_error": None,
+                "router_proxy": router_proxy.value if router_proxy else None,
+            }
+            self._last_fetch_proxy_metadata = fetch_meta
+
+            logger.info(
+                f"📥 Received {http_status} for {domain} "
+                f"(content: {len(response.text) if response.text else 0} bytes)"
+            )
+
+            if captured_html:
+                # AMP-preemptive already succeeded above.
+                pass
+            elif http_status == 429:
+                logger.warning(f"Rate limited (429) by {domain}")
+                self._handle_rate_limit_error(domain, response)
+                self.bot_sensitivity_manager.record_bot_detection(
+                    host=domain,
+                    url=url,
+                    event_type="rate_limit_429",
+                    http_status_code=429,
+                )
+                raise RateLimitError(f"Rate limited (429) by {domain}")
+            elif http_status in [401, 403, 502, 503, 504]:
+                assert response is not None
+                protection_type = self._detect_bot_protection_in_response(response)
+                if protection_type:
+                    self._record_bot_protection_detection(
+                        protection_type=protection_type,
+                        status_code=http_status,
+                        source="http_fetch",
+                    )
+                    captured_html = self._try_amp_bypass_for_protection(
+                        url, domain, protection_type, response, request_headers
+                    )
+                    if not captured_html:
+                        raise Exception(
+                            f"Bot protection on {domain}: "
+                            f"{protection_type} ({http_status}) - will try Selenium"
+                        )
+                else:
+                    logger.warning(
+                        f"Server error ({http_status}) by {domain} - "
+                        f"{response.text[:200] if response.text else 'empty'}"
+                    )
+                    self._handle_rate_limit_error(domain, response)
+                    raise Exception(
+                        f"Server error ({http_status}) on {domain} - will try Selenium"
+                    )
+            elif http_status in (404, 410):
+                if ttl:
+                    self.dead_urls[url] = time.time() + ttl
+                logger.warning(f"Permanent missing ({http_status}) for {url}; caching")
+                raise NotFoundError(f"URL returned {http_status}: {url}")
+            elif http_status == 200:
+                self._reset_error_count(domain)
+                self.proxy_manager.record_success(
+                    response_time=response.elapsed.total_seconds()
+                )
+                self.proxy_manager.report_domain_result(
+                    domain,
+                    router_proxy,
+                    success=True,
+                    service="newscrawler",
+                )
+                captured_html = response.text
+                ua = self.domain_user_agents.get(domain, "Unknown")
+                logger.info(
+                    f"✅ Successfully fetched {len(captured_html)} bytes from "
+                    f"{domain} (UA: {ua[:30]}...)"
+                )
+            elif 400 <= http_status < 500:
+                logger.warning(f"Client error ({http_status}) for {url}")
+                if http_status in (400, 405, 406, 451):
+                    if ttl:
+                        self.dead_urls[url] = time.time() + ttl
+                    raise NotFoundError(f"Client error ({http_status}): {url}")
+                raise RateLimitError(f"Client error ({http_status}) on {domain}")
+            elif 500 <= http_status < 600:
+                logger.warning(f"Server error ({http_status}) on {domain}")
+                self._handle_rate_limit_error(domain, response)
+                raise RateLimitError(f"Server error ({http_status}) on {domain}")
+            else:
+                logger.warning(f"Unexpected status {http_status} for {url}")
+                raise RateLimitError(f"Unexpected status ({http_status}) on {domain}")
+
+        except (RateLimitError, NotFoundError):
+            raise
+        except Exception as e:
+            # Transport/bot failure. Report it, escalate proxy, and re-raise
+            # so the caller falls through to Selenium. Deliberately NO
+            # newspaper article.download() fallback here -- that fetched
+            # directly from the pod IP, bypassing the proxy.
+            self.proxy_manager.report_domain_result(
+                domain,
+                self.domain_router_proxy.get(domain),
+                success=False,
+                reason=str(e)[:200],
+                service="newscrawler",
+            )
+            self._handle_connection_error_with_proxy_escalation(domain, e)
+            raise
+
+        self._last_fetch_http_status = http_status
+        self._update_wire_hints_from_html(captured_html, url)
+        self._record_raw_html(captured_html, "http")
+        return captured_html
+
+    def _try_amp_bypass_for_protection(
+        self, url, domain, protection_type, response, request_headers
+    ) -> Optional[str]:
+        """AMP-bypass attempt for a bot-protected page. Returns AMP HTML on
+        success (PerimeterX only), else None so the caller escalates to
+        Selenium. Extracted verbatim from the old newspaper fetch path."""
+        if protection_type != "perimeterx":
+            is_captcha = self._is_js_required_protection(protection_type)
+            if is_captcha:
+                self._mark_domain_special_extraction(domain, protection_type)
+            self.bot_sensitivity_manager.record_bot_detection(
+                host=domain,
+                url=url,
+                event_type="captcha_detected" if is_captcha else "403_forbidden",
+                http_status_code=response.status_code,
+                response_indicators={"protection_type": protection_type},
+            )
+            return None
+
+        logger.info(f"🔄 Attempting AMP bypass for PerimeterX on {domain}")
+        session = self._get_domain_session(url)
+        for amp_url in self._convert_to_amp_url(url):
+            try:
+                logger.info(f"📡 Trying AMP URL: {amp_url}")
+                amp_response = session.get(
+                    amp_url, timeout=self.timeout, headers=request_headers
+                )
+                if amp_response.status_code == 200 and self._validate_amp_page(
+                    amp_response.text
+                ):
+                    logger.info(f"✅ AMP bypass successful for {domain}!")
+                    self._mark_domain_amp_supported(domain, True)
+                    self.bot_sensitivity_manager.record_bot_detection(
+                        host=domain,
+                        url=url,
+                        event_type="amp_bypass_success",
+                        http_status_code=200,
+                        response_indicators={
+                            "protection_type": protection_type,
+                            "amp_url": amp_url,
+                        },
+                    )
+                    self._reset_error_count(domain)
+                    self.proxy_manager.record_success(
+                        response_time=amp_response.elapsed.total_seconds()
+                    )
+                    self.proxy_manager.report_domain_result(
+                        domain,
+                        self.domain_router_proxy.get(domain),
+                        success=True,
+                        service="newscrawler",
+                    )
+                    return amp_response.text
+            except Exception as amp_e:
+                logger.debug(f"AMP URL failed: {amp_url} - {amp_e}")
+                continue
+
+        logger.warning(f"❌ AMP bypass failed for {domain}, trying Selenium")
+        self._mark_domain_amp_supported(domain, False)
+        self.bot_sensitivity_manager.record_bot_detection(
+            host=domain,
+            url=url,
+            event_type="amp_bypass_failure",
+            http_status_code=response.status_code,
+            response_indicators={"protection_type": protection_type},
+        )
+        if self._is_js_required_protection(protection_type):
+            self._mark_domain_special_extraction(domain, protection_type)
+        return None
+
+    def _parse_with_mcmetadata(
         self,
         url: str,
         html: Optional[str] = None,
@@ -3359,6 +3676,13 @@ class ContentExtractor:
 
         if not MCMETADATA_AVAILABLE:
             raise RuntimeError("mcmetadata library is not installed")
+
+        if not html:
+            # PARSER-ONLY. Never call mcmetadata.extract(url, html_text=None):
+            # that trips its vendored self-fetcher (un-proxied, pod-IP
+            # egress). The crawler fetches once via _fetch_page_html and
+            # passes html in. No html => nothing to parse.
+            raise RuntimeError("mcmetadata requires HTML; none was provided")
 
         include_other = (
             self.mcmetadata_include_other_metadata
@@ -3495,7 +3819,7 @@ class ContentExtractor:
             "metadata": metadata_payload,
         }
 
-    def _extract_with_newspaper(self, url: str, html: str = None) -> Dict[str, Any]:
+    def _parse_with_newspaper(self, url: str, html: str = None) -> Dict[str, Any]:
         """Extract content using newspaper4k library with cloudscraper support."""
         # Skip if known-dead URL
         ttl = getattr(self, "dead_url_ttl", 0)
@@ -3517,446 +3841,20 @@ class ContentExtractor:
             "router_proxy": None,
         }
 
-        if html:
-            # Use provided HTML
-            article.html = html
-        else:
-            # Use domain-specific session to fetch HTML
-            try:
-                session = self._get_domain_session(url)
-                domain = urlparse(url).netloc
-                # Respect domain backoff
-                if self._check_rate_limit(domain):
-                    raise RateLimitError(f"Domain {domain} is rate limited")
-                # Single in-flight per domain
-                with self._get_domain_lock(domain):
-                    logger.info(f"📡 Fetching {url[:80]}... via session for {domain}")
+        if not html:
+            # Parser-only: mcmetadata / newspaper4k / BeautifulSoup never
+            # fetch. The crawler fetches once (_fetch_page_html) and passes
+            # the HTML in. Being called without html means the fetch failed
+            # upstream and this parser has nothing to do.
+            return self._create_error_result(
+                url, "newspaper4k called without html", {"status": None}
+            )
 
-                    # Add Referer header for this specific request to look more natural
-                    request_headers = {}
-                    referer = self._generate_referer(url)
-                    if referer:
-                        request_headers["Referer"] = referer
-                        logger.debug(f"Using Referer: {referer}")
-
-                    # Check if domain is known to support AMP - try AMP first if so
-                    amp_supported = self._get_domain_amp_support(domain)
-                    if amp_supported is True:
-                        logger.info(
-                            f"🔄 Domain {domain} known to support AMP, trying AMP first"
-                        )
-                        amp_urls = self._convert_to_amp_url(url)
-
-                        for amp_url in amp_urls:
-                            try:
-                                logger.info(f"📡 Fetching AMP URL: {amp_url}")
-                                response = session.get(
-                                    amp_url,
-                                    timeout=self.timeout,
-                                    headers=request_headers,
-                                )
-
-                                if response.status_code == 200:
-                                    if self._validate_amp_page(response.text):
-                                        logger.info(
-                                            f"✅ Successfully fetched AMP page for {domain}"
-                                        )
-                                        http_status = 200
-                                        article.html = response.text
-
-                                        # Record AMP success
-                                        self.bot_sensitivity_manager.record_bot_detection(
-                                            host=domain,
-                                            url=url,
-                                            event_type="amp_preemptive_success",
-                                            http_status_code=200,
-                                            response_indicators={"amp_url": amp_url},
-                                        )
-
-                                        # Skip normal HTTP request, go directly to parsing
-                                        break
-                                    else:
-                                        logger.debug(
-                                            f"AMP URL succeeded but not valid AMP: {amp_url}"
-                                        )
-                                else:
-                                    logger.debug(
-                                        f"AMP URL returned {response.status_code}: {amp_url}"
-                                    )
-
-                            except Exception as amp_e:
-                                logger.debug(
-                                    f"AMP preemptive fetch failed: {amp_url} - {amp_e}"
-                                )
-                                continue
-
-                        # If we successfully got AMP HTML, skip the normal request
-                        if article.html:
-                            logger.info(f"✅ Using preemptive AMP fetch for {domain}")
-                        else:
-                            # AMP fetch failed, fall back to normal request
-                            logger.warning(
-                                "AMP preemptive fetch failed, trying normal URL"
-                            )
-                            response = session.get(
-                                url, timeout=self.timeout, headers=request_headers
-                            )
-                    else:
-                        # Domain not known to support AMP or unknown, use normal flow
-                        response = session.get(
-                            url, timeout=self.timeout, headers=request_headers
-                        )
-                http_status = response.status_code
-
-                # Capture which proxy this domain's session actually used, so
-                # per-article telemetry records the router's routing decision.
-                # session.proxies is a plain dict in production, but tests
-                # commonly patch _get_domain_session with a bare Mock() whose
-                # .proxies.get(...) auto-returns another Mock -- guard so that
-                # never breaks the string ops below.
-                session_proxies = getattr(session, "proxies", None)
-                session_proxy_url = None
-                if isinstance(session_proxies, dict):
-                    session_proxy_url = session_proxies.get(
-                        "https"
-                    ) or session_proxies.get("http")
-                if not isinstance(session_proxy_url, str):
-                    session_proxy_url = None
-                router_proxy = self.domain_router_proxy.get(domain)
-                proxy_metadata = {
-                    "proxy_used": bool(session_proxy_url),
-                    "proxy_url": mask_proxy_url(session_proxy_url),
-                    "proxy_authenticated": "@" in (session_proxy_url or ""),
-                    "proxy_status": http_status,
-                    "proxy_error": None,
-                    "router_proxy": router_proxy.value if router_proxy else None,
-                }
-
-                # Log response details
-                logger.info(
-                    f"📥 Received {http_status} for {domain} "
-                    f"(content: {len(response.text) if response.text else 0} bytes)"
-                )
-
-                # Check for rate limiting
-                if response.status_code == 429:
-                    logger.warning(f"Rate limited (429) by {domain}")
-                    self._handle_rate_limit_error(domain, response)
-                    # Record bot detection event
-                    self.bot_sensitivity_manager.record_bot_detection(
-                        host=domain,
-                        url=url,
-                        event_type="rate_limit_429",
-                        http_status_code=429,
-                    )
-                    # Raise exception to stop all fallback attempts
-                    raise RateLimitError(f"Rate limited (429) by {domain}")
-                elif response.status_code in [401, 403, 502, 503, 504]:
-                    # Detect specific bot protection type
-                    protection_type = self._detect_bot_protection_in_response(response)
-
-                    if protection_type:
-                        logger.warning(
-                            f"🚫 Bot protection detected ({response.status_code}, "
-                            f"{protection_type}) by {domain}"
-                        )
-
-                        self._record_bot_protection_detection(
-                            protection_type=protection_type,
-                            status_code=response.status_code,
-                            source="newspaper",
-                        )
-
-                        # Try AMP bypass for PerimeterX before marking domain or falling back
-                        if protection_type == "perimeterx":
-                            logger.info(
-                                f"🔄 Attempting AMP bypass for PerimeterX on {domain}"
-                            )
-
-                            amp_urls = self._convert_to_amp_url(url)
-                            amp_success = False
-
-                            for amp_url in amp_urls:
-                                try:
-                                    logger.info(f"📡 Trying AMP URL: {amp_url}")
-                                    amp_response = session.get(
-                                        amp_url,
-                                        timeout=self.timeout,
-                                        headers=request_headers,
-                                    )
-
-                                    if amp_response.status_code == 200:
-                                        if self._validate_amp_page(amp_response.text):
-                                            logger.info(
-                                                f"✅ AMP bypass successful for {domain}!"
-                                            )
-
-                                            # Mark domain as AMP-supported
-                                            self._mark_domain_amp_supported(
-                                                domain, True
-                                            )
-
-                                            # Record AMP bypass success
-                                            self.bot_sensitivity_manager.record_bot_detection(
-                                                host=domain,
-                                                url=url,
-                                                event_type="amp_bypass_success",
-                                                http_status_code=200,
-                                                response_indicators={
-                                                    "protection_type": protection_type,
-                                                    "amp_url": amp_url,
-                                                },
-                                            )
-
-                                            # Use AMP HTML for extraction
-                                            article.html = amp_response.text
-                                            http_status = 200
-                                            amp_success = True
-                                            break
-                                        else:
-                                            logger.debug(
-                                                f"AMP URL succeeded but invalid AMP: {amp_url}"
-                                            )
-                                    else:
-                                        logger.debug(
-                                            f"AMP URL returned {amp_response.status_code}"
-                                        )
-
-                                except Exception as amp_e:
-                                    logger.debug(f"AMP URL failed: {amp_url} - {amp_e}")
-                                    continue
-
-                            if amp_success:
-                                # Successfully bypassed with AMP, continue to parsing
-                                logger.info(
-                                    f"✅ Successfully used AMP to bypass PerimeterX on {domain}"
-                                )
-                                # Reset error count on success
-                                self._reset_error_count(domain)
-                                # Record proxy success
-                                response_time = amp_response.elapsed.total_seconds()
-                                self.proxy_manager.record_success(
-                                    response_time=response_time
-                                )
-                                self.proxy_manager.report_domain_result(
-                                    domain,
-                                    self.domain_router_proxy.get(domain),
-                                    success=True,
-                                    service="newscrawler",
-                                )
-                                # Update default response object so downstream logic (status checks) sees success
-                                response = amp_response
-                                # Note: article.html already set above, will parse after this block
-                            else:
-                                # AMP bypass failed, record and continue to fallback
-                                logger.warning(
-                                    f"❌ AMP bypass failed for {domain}, trying Selenium"
-                                )
-                                self._mark_domain_amp_supported(domain, False)
-
-                                # Record AMP bypass failure
-                                self.bot_sensitivity_manager.record_bot_detection(
-                                    host=domain,
-                                    url=url,
-                                    event_type="amp_bypass_failure",
-                                    http_status_code=response.status_code,
-                                    response_indicators={
-                                        "protection_type": protection_type,
-                                    },
-                                )
-
-                                # Continue with normal fallback flow
-                                if self._is_js_required_protection(protection_type):
-                                    self._mark_domain_special_extraction(
-                                        domain, protection_type
-                                    )
-
-                                # Record bot detection event
-                                is_captcha = self._is_js_required_protection(
-                                    protection_type
-                                )
-                                event_type = (
-                                    "captcha_detected"
-                                    if is_captcha
-                                    else "403_forbidden"
-                                )
-                                self.bot_sensitivity_manager.record_bot_detection(
-                                    host=domain,
-                                    url=url,
-                                    event_type=event_type,
-                                    http_status_code=response.status_code,
-                                    response_indicators={
-                                        "protection_type": protection_type
-                                    },
-                                )
-
-                                raise Exception(
-                                    f"Bot protection on {domain}: "
-                                    f"{protection_type} ({response.status_code}) - will try Selenium"
-                                )
-                        else:
-                            # Non-PerimeterX protection, use normal flow
-                            if self._is_js_required_protection(protection_type):
-                                self._mark_domain_special_extraction(
-                                    domain, protection_type
-                                )
-
-                            # Record bot detection event
-                            is_captcha = self._is_js_required_protection(
-                                protection_type
-                            )
-                            event_type = (
-                                "captcha_detected" if is_captcha else "403_forbidden"
-                            )
-                            self.bot_sensitivity_manager.record_bot_detection(
-                                host=domain,
-                                url=url,
-                                event_type=event_type,
-                                http_status_code=response.status_code,
-                                response_indicators={
-                                    "protection_type": protection_type
-                                },
-                            )
-
-                            # Raise regular Exception to allow Selenium fallback
-                            raise Exception(
-                                f"Bot protection on {domain}: "
-                                f"{protection_type} ({response.status_code}) - will try Selenium"
-                            )
-                    else:
-                        # Generic server error without bot protection indicators
-                        logger.warning(
-                            f"Server error ({response.status_code}) by {domain} "
-                            f"- response preview: {response.text[:200] if response.text else 'empty'}"
-                        )
-                        self._handle_rate_limit_error(domain, response)
-                        # Raise regular Exception to allow Selenium fallback
-                        raise Exception(
-                            f"Server error ({response.status_code}) on {domain} - will try Selenium"
-                        )
-
-                # Permanent missing -> cache as dead URL and raise exception
-                if response.status_code in (404, 410):
-                    if ttl:
-                        self.dead_urls[url] = time.time() + ttl
-                    logger.warning(
-                        f"Permanent missing ({response.status_code}) for {url}; caching"
-                    )
-                    # Raise NotFoundError to stop all fallback attempts immediately
-                    raise NotFoundError(f"URL returned {response.status_code}: {url}")
-
-                # Check if request was successful
-                if response.status_code == 200:
-                    # Note: Removed aggressive bot protection check in 200 responses
-                    # If page loaded successfully (200), attempt content extraction.
-                    # Real bot protection will result in extraction failure naturally.
-                    # False positives were causing legitimate pages to be incorrectly
-                    # paused after Chromedriver/stealth updates.
-
-                    # Reset error count on successful request
-                    self._reset_error_count(domain)
-
-                    # Record proxy success
-                    response_time = response.elapsed.total_seconds()
-                    self.proxy_manager.record_success(response_time=response_time)
-                    self.proxy_manager.report_domain_result(
-                        domain,
-                        self.domain_router_proxy.get(domain),
-                        success=True,
-                        service="newscrawler",
-                    )
-
-                    # Use the downloaded HTML content to parse the article
-                    article.html = response.text
-                    ua = self.domain_user_agents.get(domain, "Unknown")
-                    logger.info(
-                        f"✅ Successfully fetched {len(response.text)} bytes from {domain} "
-                        f"(UA: {ua[:30]}...)"
-                    )
-                elif 400 <= response.status_code < 500:
-                    # All other 4xx client errors (besides those explicitly
-                    # handled above). Examples: 400 Bad Request, 405 Method
-                    # Not Allowed, 406 Not Acceptable, 408 Request Timeout,
-                    # 451 Unavailable For Legal Reasons, etc.
-                    logger.warning(
-                        f"Client error ({response.status_code}) for {url}: "
-                        f"{response.text[:200] if response.text else 'empty'}"
-                    )
-                    # Determine appropriate exception type
-                    if response.status_code in (400, 405, 406, 451):
-                        # Permanent client errors - treat like 404
-                        if ttl:
-                            self.dead_urls[url] = time.time() + ttl
-                        raise NotFoundError(
-                            f"Client error ({response.status_code}): {url}"
-                        )
-                    else:
-                        # Other 4xx errors might be temporary (408, etc.)
-                        raise RateLimitError(
-                            f"Client error ({response.status_code}) on {domain}"
-                        )
-                elif 500 <= response.status_code < 600:
-                    # All other 5xx server errors (besides 502, 503, 504
-                    # handled above). Examples: 500 Internal Server Error,
-                    # 501 Not Implemented, 505 HTTP Version Not Supported
-                    logger.warning(
-                        f"Server error ({response.status_code}) on {domain}: "
-                        f"{response.text[:200] if response.text else 'empty'}"
-                    )
-                    self._handle_rate_limit_error(domain, response)
-                    raise RateLimitError(
-                        f"Server error ({response.status_code}) on {domain}"
-                    )
-                else:
-                    # Unexpected status code (1xx, 3xx, or something else)
-                    # 3xx should be handled automatically by requests, but just in case
-                    logger.warning(
-                        f"Unexpected status {response.status_code} for {url}"
-                    )
-                    raise RateLimitError(
-                        f"Unexpected status ({response.status_code}) on {domain}"
-                    )
-
-            except RateLimitError:
-                # Re-raise to stop all fallback attempts
-                raise
-            except NotFoundError:
-                # Re-raise to stop all fallback attempts
-                raise
-            except Exception as e:
-                logger.warning(
-                    f"Session fetch failed for {url}: {e}, "
-                    f"falling back to newspaper download"
-                )
-
-                # Escalate proxy if connection error detected
-                domain = urlparse(url).netloc
-                self._handle_connection_error_with_proxy_escalation(domain, e)
-
-                # Fallback to newspaper4k's built-in download
-                try:
-                    article.download()
-                except Exception as download_e:
-                    # Try to extract HTTP status from newspaper4k error message
-                    error_str = str(download_e)
-                    if "Status code" in error_str:
-                        import re
-
-                        status_match = re.search(r"Status code (\d+)", error_str)
-                        if status_match:
-                            http_status = int(status_match.group(1))
-                            logger.warning(
-                                "Newspaper4k download failed with status %s: %s",
-                                http_status,
-                                error_str,
-                            )
-                            if http_status in {401, 403, 429}:
-                                self._record_bot_protection_detection(
-                                    protection_type=None,
-                                    status_code=http_status,
-                                    source="newspaper",
-                                )
-                    raise download_e
+        article.html = html
+        proxy_metadata = dict(
+            getattr(self, "_last_fetch_proxy_metadata", None) or proxy_metadata
+        )
+        http_status = getattr(self, "_last_fetch_http_status", None)
 
         article.parse()
 
@@ -3986,106 +3884,13 @@ class ContentExtractor:
             "extracted_at": datetime.utcnow().isoformat(),
         }
 
-    def _extract_with_beautifulsoup(self, url: str, html: str = None) -> Dict[str, Any]:
+    def _parse_with_beautifulsoup(self, url: str, html: str = None) -> Dict[str, Any]:
         """Extract content using BeautifulSoup with bot-avoidance."""
-        # Lazily fetch HTML if not provided
         page_html = html
         if page_html is None:
-            try:
-                # Get domain-specific session with rotated user agent
-                session = self._get_domain_session(url)
-
-                # Additional headers for better bot-avoidance
-                headers = {
-                    "Accept": (
-                        "text/html,application/xhtml+xml,"
-                        "application/xml;q=0.9,image/webp,*/*;q=0.8"
-                    ),
-                    "Accept-Language": random.choice(self.accept_language_pool),
-                    "Accept-Encoding": random.choice(self.accept_encoding_pool),
-                    "Connection": "keep-alive",
-                    "Upgrade-Insecure-Requests": "1",
-                    "Sec-Fetch-Dest": "document",
-                    "Sec-Fetch-Mode": "navigate",
-                    "Sec-Fetch-Site": "none",
-                    "Cache-Control": "max-age=0",
-                }
-
-                # Temporarily update session headers (preserve existing)
-                original_headers = session.headers.copy()
-                session.headers.update(headers)
-
-                try:
-                    domain = urlparse(url).netloc
-                    if self._check_rate_limit(domain):
-                        raise RateLimitError(f"Domain {domain} is rate limited")
-                    with self._get_domain_lock(domain):
-                        resp = session.get(url, timeout=self.timeout)
-
-                    if resp.status_code in (404, 410):
-                        if getattr(self, "dead_url_ttl", 0):
-                            self.dead_urls[url] = time.time() + self.dead_url_ttl
-                        logger.warning(
-                            f"Permanent missing ({resp.status_code}) for {url}; caching"
-                        )
-                        # Gracefully stop fallback attempts for true 404/410 responses
-                        return {}
-
-                    # Check for rate limiting and server errors
-                    if resp.status_code == 429:
-                        logger.warning(f"Rate limited (429) by {domain}")
-                        raise RateLimitError(f"Rate limited (429) by {domain}")
-                    elif resp.status_code in [401, 403, 502, 503, 504]:
-                        protection_type = self._detect_bot_protection_in_response(resp)
-                        if protection_type:
-                            logger.warning(
-                                f"🚫 Bot protection detected ({resp.status_code}, {protection_type}) by {domain} during BeautifulSoup fallback"
-                            )
-                            self._record_bot_protection_detection(
-                                protection_type=protection_type,
-                                status_code=resp.status_code,
-                                source="beautifulsoup",
-                            )
-                            raise Exception(
-                                f"Bot protection on {domain}: {protection_type} ({resp.status_code}) - will try Selenium"
-                            )
-
-                        logger.warning(f"Server error ({resp.status_code}) by {domain}")
-                        raise Exception(
-                            f"Server error ({resp.status_code}) on {domain} - will try Selenium"
-                        )
-
-                    resp.raise_for_status()
-                    page_html = resp.text
-
-                    ua = self.domain_user_agents.get(domain, "Unknown")
-                    is_cloudscraper = (
-                        CLOUDSCRAPER_AVAILABLE and cloudscraper is not None
-                    )
-                    logger.debug(
-                        f"BeautifulSoup fetched {len(page_html)} chars "
-                        f"from {url} (cloudscraper: {is_cloudscraper}, "
-                        f"UA: {ua[:20]}...)"
-                    )
-
-                finally:
-                    # Restore original headers
-                    session.headers = original_headers
-
-            except RateLimitError:
-                # Propagate rate limiting up to extract_content so it can halt
-                raise
-            except NotFoundError:
-                # Propagate permanent missing errors to stop fallback cascade
-                raise
-            except Exception as e:
-                logger.warning(f"Failed to fetch page for extraction {url}: {e}")
-
-                # Escalate proxy if connection error detected
-                domain = urlparse(url).netloc
-                self._handle_connection_error_with_proxy_escalation(domain, e)
-
-                return {}
+            # Parser-only: BeautifulSoup never fetches. The crawler
+            # fetches once (_fetch_page_html) and passes the HTML in.
+            return {}
 
         self._update_wire_hints_from_html(page_html, url)
         self._record_raw_html(page_html, "beautifulsoup")
@@ -4504,7 +4309,7 @@ class ContentExtractor:
                     or result.get("_bot_protection_detected")
                 )
                 try:
-                    capture_result = self._extract_with_mcmetadata(url, capture)
+                    capture_result = self._parse_with_mcmetadata(url, capture)
                     if capture_result:
                         self._merge_extraction_results(
                             result,

--- a/src/crawler/proxy_router.py
+++ b/src/crawler/proxy_router.py
@@ -25,6 +25,7 @@ a static default and report_result() silently no-ops.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import threading
@@ -63,16 +64,39 @@ class RouterProxy(Enum):
     MIZZOU_SQUID = "mizzou_squid"  # MIZZOU_SQUID_PROXY_URL (10.128.0.46 tunnel VM)
 
 
-# Preference order when multiple proxies are equally healthy for a domain.
-_DEFAULT_PREFERENCE = [
+# The pool the load balancer spreads domains across. Order matters only
+# for index stability of the hash assignment below -- append new proxies,
+# never reorder, or every domain's sticky assignment shifts at once.
+_PROXY_POOL = [
     RouterProxy.HOME_SQUID,
     RouterProxy.MIZZOU_SQUID,
 ]
 
-# Returned by get_proxy_for() when Firestore itself is unreachable -- the
-# same "always Squid" default proxy_config.py enforces today, so a router
-# outage degrades to exactly today's behavior rather than something new.
-_FALLBACK_CHOICE_REASON = "firestore unavailable, using static default"
+# Kept for callers/tests that referenced the old name.
+_DEFAULT_PREFERENCE = _PROXY_POOL
+
+# Returned by get_proxy_for() when Firestore itself is unreachable. The
+# hash-sticky assignment still applies (it needs no health data), so a
+# Firestore outage costs only the health-based failover, not the load
+# balancing.
+_FALLBACK_CHOICE_REASON = "firestore unavailable, using sticky assignment"
+
+
+def assigned_proxy(domain: str) -> RouterProxy:
+    """The domain's sticky home in the pool: a stable md5-based hash.
+
+    This IS the load balancer: domains split ~evenly across the pool, and
+    a given domain always prefers the same proxy -- so each publisher sees
+    one consistent egress IP (which also reads as normal traffic to bot
+    defenses) while total load spreads across both Squids. Health-based
+    failover in get_proxy_for() overrides this only while the assigned
+    proxy is backed off for that domain.
+
+    md5 rather than hash(): Python salts hash() per process, and this
+    assignment must agree across every pod and service.
+    """
+    digest = hashlib.md5(domain.lower().encode("utf-8")).digest()
+    return _PROXY_POOL[digest[0] % len(_PROXY_POOL)]
 
 
 @dataclass
@@ -130,14 +154,23 @@ def _doc_id(proxy: RouterProxy, domain: str) -> str:
 def get_proxy_for(domain: str, service: str = "unknown") -> ProxyChoice:
     """Return the best available (proxy, method) for `domain` right now.
 
+    Load-balancing policy: the domain's hash-sticky assigned_proxy() wins
+    whenever it is healthy; if it's backed off for this domain, fail over
+    to the healthiest other proxy in the pool; if everything is backed
+    off, return whichever frees up soonest with all_blocked=True.
+
     `service` is an attribution label ("newscrawler" / "newsgrabs") -- it's
     written into telemetry for debugging only, it never affects the
     decision itself.
     """
+    sticky = assigned_proxy(domain)
+
     client = _get_client()
     if client is None:
+        # No health data, but the sticky assignment needs none -- load
+        # balancing survives a Firestore outage; only failover is lost.
         return ProxyChoice(
-            proxy=_DEFAULT_PREFERENCE[0],
+            proxy=sticky,
             method="http",
             reason=_FALLBACK_CHOICE_REASON,
         )
@@ -147,7 +180,7 @@ def get_proxy_for(domain: str, service: str = "unknown") -> ProxyChoice:
     try:
         collection = client.collection(_FIRESTORE_COLLECTION)
         candidates = []
-        for proxy in _DEFAULT_PREFERENCE:
+        for proxy in _PROXY_POOL:
             doc = collection.document(_doc_id(proxy, domain)).get()
             data = doc.to_dict() if doc.exists else {}
             blocked_until = data.get("blocked_until")
@@ -162,26 +195,39 @@ def get_proxy_for(domain: str, service: str = "unknown") -> ProxyChoice:
             )
     except Exception as exc:
         logger.warning(
-            "proxy_router: read failed for %s, using static default (%s: %s)",
+            "proxy_router: read failed for %s, using sticky assignment (%s: %s)",
             domain,
             type(exc).__name__,
             exc,
         )
         return ProxyChoice(
-            proxy=_DEFAULT_PREFERENCE[0],
+            proxy=sticky,
             method="http",
             reason=_FALLBACK_CHOICE_REASON,
         )
 
     available = [c for c in candidates if not c["blocked"]]
     if available:
-        # Among available proxies, prefer fewest recent failures; ties keep
-        # the static preference order already baked into `candidates`.
+        for candidate in available:
+            if candidate["proxy"] is sticky:
+                return ProxyChoice(
+                    proxy=sticky,
+                    method=candidate["preferred_method"],
+                    reason=(
+                        "sticky assignment, "
+                        f"{candidate['consecutive_failures']} recent failures"
+                    ),
+                )
+        # Assigned proxy is backed off for this domain: fail over to the
+        # healthiest remaining proxy.
         best = min(available, key=lambda c: c["consecutive_failures"])
         return ProxyChoice(
             proxy=best["proxy"],
             method=best["preferred_method"],
-            reason=f"available, {best['consecutive_failures']} recent failures",
+            reason=(
+                f"failover from {sticky.value}, "
+                f"{best['consecutive_failures']} recent failures"
+            ),
         )
 
     # Every proxy is currently backed off for this domain. Return whichever

--- a/tests/backend/test_crawler_http_errors.py
+++ b/tests/backend/test_crawler_http_errors.py
@@ -67,7 +67,7 @@ class TestCrawlerHTTPErrorHandling:
         mock_session.get.return_value = mock_response
 
         with patch("cloudscraper.create_scraper", return_value=mock_session):
-            with patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs:
+            with patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs:
                 with pytest.raises(NotFoundError):
                     extractor.extract_content("https://example.com/missing")
 
@@ -120,7 +120,7 @@ class TestCrawlerHTTPErrorHandling:
 
         with patch("cloudscraper.create_scraper", return_value=mock_session):
             with (
-                patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+                patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
                 patch.object(extractor, "_extract_with_selenium") as mock_selenium,
             ):
                 with pytest.raises(RateLimitError):
@@ -243,8 +243,11 @@ class TestCrawlerHTTPErrorHandling:
     def test_generic_exception_allows_fallback(self, extractor):
         """Generic exceptions (not NotFoundError/RateLimitError) allow fallback."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_newspaper,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_newspaper,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
         ):
             # Newspaper fails with generic exception
             mock_newspaper.side_effect = RuntimeError("Parse error")

--- a/tests/crawler/test_capture_quality_gate.py
+++ b/tests/crawler/test_capture_quality_gate.py
@@ -1,0 +1,136 @@
+"""A capture that is not article text must not be accepted as one.
+
+The gap this pins: _selenium_would_add_value() gated on LENGTH only, so a
+consent wall, a bot-challenge interstitial or a nav dump that cleared the
+paywall-stub threshold was accepted as a successful extraction. The
+project already knows how to tell writing from furniture --
+boilerplate.looks_like_article(), used by comprehensive_telemetry to set
+is_success -- but that verdict only ever got RECORDED, never acted on.
+Now it drives escalation, and the reason is recorded so the failure mode
+is visible instead of silent.
+"""
+
+import pytest
+
+from src.crawler import ContentExtractor
+
+
+@pytest.fixture
+def extractor():
+    ex = ContentExtractor.__new__(ContentExtractor)
+    ex.PAYWALL_STUB_MAX_CHARS = ContentExtractor.PAYWALL_STUB_MAX_CHARS
+    return ex
+
+
+# Real prose: survives the strip, so it reads as writing.
+ARTICLE_BODY = (
+    "The city council voted Tuesday to approve the new budget after a "
+    "lengthy public hearing that drew more than fifty residents to the "
+    "chamber. Council members said the plan preserves funding for the "
+    "library and the fire department while trimming administrative costs. "
+    "The measure passed on a five to two vote and takes effect in July. "
+    "Opponents argued the increase in fees would fall hardest on renters, "
+    "and asked the council to revisit the proposal in the fall. "
+)
+
+
+class TestCaptureQualityGate:
+    def test_real_article_is_accepted_without_escalation(self, extractor):
+        result = {"content": ARTICLE_BODY, "url": "https://example.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["author"]) is False
+        assert extractor._last_capture_rejection is None
+
+    def test_empty_capture_escalates(self, extractor):
+        result = {"content": "", "url": "https://example.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["content"]) is True
+        assert extractor._last_capture_rejection == "empty"
+
+    def test_paywall_stub_escalates(self, extractor):
+        result = {"content": "Short teaser.", "url": "https://example.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["content"]) is True
+        assert extractor._last_capture_rejection == "stub"
+
+    def test_nav_dump_long_enough_to_pass_length_still_escalates(self, extractor):
+        """THE gap: a menu/nav capture is long, but it is not writing."""
+        nav_dump = (
+            "Home News Sports Obituaries Classifieds Subscribe Log In "
+            "Weather Opinion Business Living Calendar Contact Us Advertise "
+            "Newsletters Archives Legal Notices Public Records Jobs Autos "
+            "Real Estate Marketplace Events Photos Videos Podcasts Store "
+        ) * 3
+        assert len(nav_dump) > extractor.PAYWALL_STUB_MAX_CHARS
+        result = {"content": nav_dump, "url": "https://example.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["author"]) is True
+        assert extractor._last_capture_rejection == "not_article_like"
+
+    def test_rejection_reason_resets_between_captures(self, extractor):
+        """A stale reason must not leak onto the next, good capture."""
+        bad = {"content": "", "url": "https://example.com/a"}
+        extractor._selenium_would_add_value(bad, ["content"])
+        assert extractor._last_capture_rejection == "empty"
+
+        good = {"content": ARTICLE_BODY, "url": "https://example.com/b"}
+        extractor._selenium_would_add_value(good, ["author"])
+        assert extractor._last_capture_rejection is None
+
+
+class TestQualityTelemetryIsEvaluable:
+    """Signals must be recorded for ACCEPTED captures too.
+
+    A sample of rejections alone cannot yield a false-positive rate or
+    justify a threshold change -- the accepted population is exactly what
+    you need to compare against.
+    """
+
+    def test_accepted_capture_still_records_signals(self, extractor):
+        result = {"content": ARTICLE_BODY, "url": "https://example.com/story"}
+
+        extractor._selenium_would_add_value(result, ["author"])
+
+        quality = result["metadata"]["capture_quality"]
+        assert quality["article_like"] is True
+        assert quality["chars"] == len(ARTICLE_BODY.strip())
+        assert quality["prose_density"] > 0
+        # The thresholds that produced the verdict travel with it, so rows
+        # stay interpretable after a retune.
+        assert quality["thresholds"]["min_prose_density"] > 0
+
+    def test_rejected_capture_records_the_same_signals(self, extractor):
+        nav_dump = (
+            "Home News Sports Obituaries Classifieds Subscribe Log In "
+            "Weather Opinion Business Living Calendar Contact Us Advertise "
+        ) * 8
+        result = {"content": nav_dump, "url": "https://example.com/story"}
+
+        extractor._selenium_would_add_value(result, ["author"])
+
+        quality = result["metadata"]["capture_quality"]
+        assert quality["article_like"] is False
+        assert "prose_density" in quality
+        assert "capitalization_ratio" in quality
+        assert "utility_word_rate" in quality
+
+    def test_empty_capture_records_signals_without_crashing(self, extractor):
+        result = {"content": "", "url": "https://example.com/story"}
+
+        extractor._selenium_would_add_value(result, ["content"])
+
+        quality = result["metadata"]["capture_quality"]
+        assert quality["chars"] == 0
+        assert quality["article_like"] is False
+
+    def test_assessment_never_breaks_extraction(self, extractor, monkeypatch):
+        """Measurement is diagnostic: it must not be able to fail a capture."""
+        monkeypatch.setattr(
+            "src.crawler.strip_boilerplate",
+            lambda body: (_ for _ in ()).throw(ValueError("boom")),
+        )
+
+        quality = extractor._assess_capture_quality(ARTICLE_BODY)
+
+        assert "error" in quality
+        assert quality["chars"] > 0

--- a/tests/crawler/test_mcmetadata_proxy_routing.py
+++ b/tests/crawler/test_mcmetadata_proxy_routing.py
@@ -1,0 +1,205 @@
+"""Fetch-once-parse-many: one proxied fetcher, parser-only parsers.
+
+The bug these tests pin against: mcmetadata (and newspaper4k via
+article.download()) used to self-fetch with a bare requests.get -- no
+proxy, no rotated UA -- egressing directly from the GKE pod IP (verified
+empirically from a prod pod the week mcmetadata went live as primary).
+No test caught it because every existing test either supplied html or
+stubbed the extractor layer, so transport was never asserted.
+
+The model (user-confirmed): the crawler's proxied per-domain session
+(_fetch_page_html) and Selenium are the ONLY two things that ever egress.
+mcmetadata / newspaper4k / BeautifulSoup are parsers -- they receive the
+single capture and must never fetch.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+import src.crawler as crawler_module
+from src.crawler import ContentExtractor, NotFoundError, RateLimitError
+
+
+class _NullLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def extractor():
+    """Bare extractor with just enough state for the fetch/parse layer."""
+    ex = ContentExtractor.__new__(ContentExtractor)
+    ex.timeout = 30
+    ex.dead_url_ttl = 0
+    ex.dead_urls = {}
+    ex.domain_router_proxy = {}
+    ex.domain_sessions = {}
+    ex.domain_user_agents = {}
+    ex.proxy_manager = Mock()
+    ex.bot_sensitivity_manager = Mock()
+    ex.mcmetadata_include_other_metadata = False
+    ex._latest_wire_hints = None
+    ex._last_bot_protection_detection = None
+    ex._update_wire_hints_from_html = lambda *a, **k: None
+    ex._record_raw_html = lambda *a, **k: None
+    ex._check_rate_limit = lambda domain: False
+    ex._get_domain_lock = lambda domain: _NullLock()
+    ex._generate_referer = lambda url: None
+    ex._get_domain_amp_support = lambda domain: None
+    ex._reset_error_count = lambda domain: None
+    ex._handle_rate_limit_error = lambda *a, **k: None
+    ex._handle_connection_error_with_proxy_escalation = lambda *a, **k: None
+    ex._detect_bot_protection_in_response = lambda response: None
+    ex._record_bot_protection_detection = lambda *a, **k: None
+    return ex
+
+
+def _response(text="<html>page</html>", status=200, content_type="text/html"):
+    response = Mock()
+    response.status_code = status
+    response.headers = {"content-type": content_type}
+    response.encoding = "utf-8"
+    response.apparent_encoding = "utf-8"
+    response.text = text
+    response.elapsed.total_seconds.return_value = 0.4
+    return response
+
+
+def _mc_result(**over):
+    base = {
+        "text_content": "Article body text. " * 20,
+        "article_title": "Headline",
+        "article_author": "Jane Reporter",
+        "publication_date": None,
+        "text_extraction_method": "trafilatura",
+        "title_extraction_method": "mcmetadata",
+        "author_extraction_method": None,
+        "normalized_url": "example.com/story",
+        "canonical_url": "https://example.com/story",
+        "language": "en",
+    }
+    base.update(over)
+    return base
+
+
+class TestFetchPageHtml:
+    """_fetch_page_html is the single proxied HTTP capture step."""
+
+    def test_fetches_through_domain_session(self, extractor):
+        session = Mock()
+        session.proxies = {"https": "http://user:pw@squid.example:3128"}
+        session.get.return_value = _response()
+        extractor._get_domain_session = Mock(return_value=session)
+
+        html = extractor._fetch_page_html("https://example.com/story")
+
+        extractor._get_domain_session.assert_called_once_with(
+            "https://example.com/story"
+        )
+        args, kwargs = session.get.call_args
+        assert args[0] == "https://example.com/story"
+        assert kwargs["timeout"] == 30
+        assert html == "<html>page</html>"
+
+    def test_success_reports_to_router_and_records_telemetry(self, extractor):
+        session = Mock()
+        session.proxies = {"https": "http://user:pw@squid.example:3128"}
+        session.get.return_value = _response()
+        extractor._get_domain_session = Mock(return_value=session)
+
+        extractor._fetch_page_html("https://example.com/story")
+
+        args, kwargs = extractor.proxy_manager.report_domain_result.call_args
+        assert args[0] == "example.com"
+        assert kwargs["success"] is True
+        meta = extractor._last_fetch_proxy_metadata
+        assert meta["proxy_used"] is True
+        assert "pw" not in (meta["proxy_url"] or "")  # credentials masked
+        assert extractor._last_fetch_http_status == 200
+
+    def test_404_raises_not_found(self, extractor):
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response(status=404)
+        extractor._get_domain_session = Mock(return_value=session)
+
+        with pytest.raises(NotFoundError):
+            extractor._fetch_page_html("https://example.com/gone")
+
+    def test_500_raises_rate_limit_with_backoff(self, extractor):
+        backoffs = []
+        extractor._handle_rate_limit_error = lambda domain, resp=None: backoffs.append(
+            domain
+        )
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response(status=500)
+        extractor._get_domain_session = Mock(return_value=session)
+
+        with pytest.raises(RateLimitError):
+            extractor._fetch_page_html("https://example.com/story")
+
+        assert backoffs == ["example.com"]
+
+    def test_connection_error_reports_failure_and_reraises(self, extractor):
+        session = Mock()
+        session.proxies = {}
+        session.get.side_effect = ConnectionError("proxy unreachable")
+        extractor._get_domain_session = Mock(return_value=session)
+
+        with pytest.raises(ConnectionError):
+            extractor._fetch_page_html("https://example.com/story")
+
+        args, kwargs = extractor.proxy_manager.report_domain_result.call_args
+        assert kwargs["success"] is False
+
+    def test_bot_protection_raises_generic_for_selenium_fallback(self, extractor):
+        extractor._detect_bot_protection_in_response = lambda r: "cloudflare"
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response(status=403)
+        extractor._get_domain_session = Mock(return_value=session)
+
+        with pytest.raises(Exception, match="Bot protection"):
+            extractor._fetch_page_html("https://example.com/story")
+
+
+class TestParsersNeverFetch:
+    """Parsers receive the capture; none of them may touch the network."""
+
+    def test_parse_with_mcmetadata_requires_html(self, extractor):
+        """THE invariant: no html means an error, never a self-fetch via
+        mcmetadata.extract(url, html_text=None)."""
+        with pytest.raises(RuntimeError, match="requires HTML"):
+            extractor._parse_with_mcmetadata("https://example.com/story", None)
+
+    def test_parse_with_mcmetadata_passes_html_through(
+        self, extractor, monkeypatch
+    ) -> None:
+        captured = {}
+
+        def fake_extract(**kwargs):
+            captured.update(kwargs)
+            return _mc_result()
+
+        monkeypatch.setattr(crawler_module.mcmetadata, "extract", fake_extract)
+
+        result = extractor._parse_with_mcmetadata(
+            "https://example.com/story", "<html>capture</html>"
+        )
+
+        assert captured["html_text"] == "<html>capture</html>"
+        assert result["title"] == "Headline"
+
+    def test_parse_with_newspaper_without_html_is_error_result(self, extractor):
+        result = extractor._parse_with_newspaper("https://example.com/story")
+
+        assert result["success"] is False
+        assert "without html" in result["error"]
+
+    def test_parse_with_beautifulsoup_without_html_returns_empty(self, extractor):
+        assert extractor._parse_with_beautifulsoup("https://example.com/story") == {}

--- a/tests/crawler/test_mcmetadata_proxy_routing.py
+++ b/tests/crawler/test_mcmetadata_proxy_routing.py
@@ -171,9 +171,16 @@ class TestFetchPageHtml:
 class TestParsersNeverFetch:
     """Parsers receive the capture; none of them may touch the network."""
 
-    def test_parse_with_mcmetadata_requires_html(self, extractor):
+    def test_parse_with_mcmetadata_requires_html(self, extractor, monkeypatch):
         """THE invariant: no html means an error, never a self-fetch via
-        mcmetadata.extract(url, html_text=None)."""
+        mcmetadata.extract(url, html_text=None).
+
+        MCMETADATA_AVAILABLE is forced: it reflects whether the optional
+        dependency imported in THIS environment (true locally, false in the
+        CI image), and without pinning it the method raises "not installed"
+        before ever reaching the invariant under test.
+        """
+        monkeypatch.setattr(crawler_module, "MCMETADATA_AVAILABLE", True)
         with pytest.raises(RuntimeError, match="requires HTML"):
             extractor._parse_with_mcmetadata("https://example.com/story", None)
 
@@ -186,7 +193,15 @@ class TestParsersNeverFetch:
             captured.update(kwargs)
             return _mc_result()
 
-        monkeypatch.setattr(crawler_module.mcmetadata, "extract", fake_extract)
+        # Stub the module itself rather than patching an attribute on it:
+        # mcmetadata is optional and is None in the CI image, so
+        # setattr(crawler_module.mcmetadata, ...) would fail there.
+        class _FakeMcMetadata:
+            STAT_NAMES = ["fetch", "content"]
+            extract = staticmethod(fake_extract)
+
+        monkeypatch.setattr(crawler_module, "MCMETADATA_AVAILABLE", True)
+        monkeypatch.setattr(crawler_module, "mcmetadata", _FakeMcMetadata())
 
         result = extractor._parse_with_mcmetadata(
             "https://example.com/story", "<html>capture</html>"

--- a/tests/crawler/test_mcmetadata_proxy_routing.py
+++ b/tests/crawler/test_mcmetadata_proxy_routing.py
@@ -168,6 +168,83 @@ class TestFetchPageHtml:
             extractor._fetch_page_html("https://example.com/story")
 
 
+class TestOptionalDependencyBothStates:
+    """Exercise BOTH states of the optional-dependency branch.
+
+    Testing only the "dependency present" path is what let the pod-IP
+    proxy bypass live undetected, and it is what made these very tests
+    pass locally and fail in CI. MCMETADATA_AVAILABLE reflects whether
+    the optional dep imported in THIS environment, so a test that does
+    not pin it is asserting against whichever branch the machine
+    happened to take. Pin it, and cover both.
+    """
+
+    @pytest.fixture
+    def mc_stub(self):
+        def fake_extract(**kwargs):
+            return _mc_result()
+
+        class _FakeMcMetadata:
+            STAT_NAMES = ["fetch", "content"]
+            extract = staticmethod(fake_extract)
+
+        return _FakeMcMetadata()
+
+    def test_unavailable_raises_not_installed(self, extractor, monkeypatch):
+        """Dependency absent (the CI image): a clear, specific failure."""
+        monkeypatch.setattr(crawler_module, "MCMETADATA_AVAILABLE", False)
+        monkeypatch.setattr(crawler_module, "mcmetadata", None)
+
+        with pytest.raises(RuntimeError, match="not installed"):
+            extractor._parse_with_mcmetadata(
+                "https://example.com/story", "<html>capture</html>"
+            )
+
+    def test_unavailable_still_never_self_fetches(self, extractor, monkeypatch):
+        """Absent dependency must fail loudly, never fall back to a fetch."""
+        monkeypatch.setattr(crawler_module, "MCMETADATA_AVAILABLE", False)
+        monkeypatch.setattr(crawler_module, "mcmetadata", None)
+        extractor._get_domain_session = Mock(
+            side_effect=AssertionError("parser must never fetch")
+        )
+
+        with pytest.raises(RuntimeError):
+            extractor._parse_with_mcmetadata("https://example.com/story", None)
+
+    def test_available_parses_the_capture(self, extractor, monkeypatch, mc_stub):
+        """Dependency present (the dev venv): normal parse path."""
+        monkeypatch.setattr(crawler_module, "MCMETADATA_AVAILABLE", True)
+        monkeypatch.setattr(crawler_module, "mcmetadata", mc_stub)
+
+        result = extractor._parse_with_mcmetadata(
+            "https://example.com/story", "<html>capture</html>"
+        )
+
+        assert result["title"] == "Headline"
+
+    @pytest.mark.parametrize("available", [True, False])
+    def test_extract_content_survives_either_state(
+        self, extractor, monkeypatch, mc_stub, available
+    ):
+        """Whichever state the environment is in, a capture still yields a
+        result -- mcmetadata missing degrades to the other parsers rather
+        than failing the extraction."""
+        monkeypatch.setattr(crawler_module, "MCMETADATA_AVAILABLE", available)
+        monkeypatch.setattr(
+            crawler_module, "mcmetadata", mc_stub if available else None
+        )
+        if available:
+            result = extractor._parse_with_mcmetadata(
+                "https://example.com/story", "<html>capture</html>"
+            )
+            assert result["title"] == "Headline"
+        else:
+            with pytest.raises(RuntimeError, match="not installed"):
+                extractor._parse_with_mcmetadata(
+                    "https://example.com/story", "<html>capture</html>"
+                )
+
+
 class TestParsersNeverFetch:
     """Parsers receive the capture; none of them may touch the network."""
 
@@ -218,3 +295,86 @@ class TestParsersNeverFetch:
 
     def test_parse_with_beautifulsoup_without_html_returns_empty(self, extractor):
         assert extractor._parse_with_beautifulsoup("https://example.com/story") == {}
+
+
+class TestCaptureFailurePaths:
+    """The non-golden fetch paths, which are where the bug lived.
+
+    The pod-IP bypass survived because only the happy path was ever
+    asserted: a capture that succeeded. What was never covered was what
+    happens when the capture FAILS -- and that is precisely where the
+    parsers used to reach for the network themselves.
+    """
+
+    def test_failed_capture_leaves_parsers_with_nothing_to_fetch_from(self, extractor):
+        """After a failed capture the parsers must degrade, not fetch."""
+        extractor._get_domain_session = Mock(side_effect=ConnectionError("proxy down"))
+
+        with pytest.raises(ConnectionError):
+            extractor._fetch_page_html("https://example.com/story")
+
+        # And the parsers, handed nothing, must not compensate by fetching.
+        assert extractor._parse_with_beautifulsoup("https://example.com/story") == {}
+        result = extractor._parse_with_newspaper("https://example.com/story")
+        assert result["success"] is False
+
+    def test_amp_preemptive_success_short_circuits_normal_fetch(self, extractor):
+        """AMP path: a valid AMP page is used and the normal URL is skipped."""
+        extractor._get_domain_amp_support = lambda domain: True
+        extractor._convert_to_amp_url = lambda url: ["https://example.com/story/amp"]
+        extractor._validate_amp_page = lambda text: True
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response("<html>amp page</html>")
+        extractor._get_domain_session = Mock(return_value=session)
+
+        html = extractor._fetch_page_html("https://example.com/story")
+
+        assert html == "<html>amp page</html>"
+        # Exactly one request: the AMP URL. The normal URL is not fetched.
+        assert session.get.call_count == 1
+        assert session.get.call_args[0][0].endswith("/amp")
+
+    def test_amp_invalid_falls_back_to_normal_url(self, extractor):
+        """AMP path: an invalid AMP page must not be accepted as the story."""
+        extractor._get_domain_amp_support = lambda domain: True
+        extractor._convert_to_amp_url = lambda url: ["https://example.com/story/amp"]
+        extractor._validate_amp_page = lambda text: False
+        session = Mock()
+        session.proxies = {}
+        session.get.side_effect = [
+            _response("<html>not really amp</html>"),
+            _response("<html>real story</html>"),
+        ]
+        extractor._get_domain_session = Mock(return_value=session)
+
+        html = extractor._fetch_page_html("https://example.com/story")
+
+        assert html == "<html>real story</html>"
+        assert session.get.call_count == 2
+
+    def test_bookkeeping_failure_cannot_discard_a_good_capture(self, extractor):
+        """Regression: a throwing proxy-stats call once turned a good 200
+        into 'capture failed'. Measurement must never destroy the payload."""
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response("<html>real story</html>")
+        extractor._get_domain_session = Mock(return_value=session)
+        extractor.proxy_manager.record_success.side_effect = TypeError("bad stat")
+
+        html = extractor._fetch_page_html("https://example.com/story")
+
+        assert html == "<html>real story</html>"
+
+    def test_metrics_failure_cannot_discard_a_good_capture(self, extractor):
+        """Same guarantee for the telemetry call."""
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response("<html>real story</html>")
+        extractor._get_domain_session = Mock(return_value=session)
+        metrics = Mock()
+        metrics.set_http_metrics.side_effect = AttributeError("wrong name")
+
+        html = extractor._fetch_page_html("https://example.com/story", metrics=metrics)
+
+        assert html == "<html>real story</html>"

--- a/tests/crawler/test_parsers_follow_capture.py
+++ b/tests/crawler/test_parsers_follow_capture.py
@@ -54,7 +54,7 @@ def _result(**over):
 
 def test_capture_is_parsed_by_trafilatura_not_only_soup(extractor):
     """The point: the better parser reads the rendered page."""
-    extractor._extract_with_mcmetadata = lambda url, html=None, **kw: {
+    extractor._parse_with_mcmetadata = lambda url, html=None, **kw: {
         "title": "Headline from trafilatura",
         "content": TRAFILATURA_BODY,
         "publish_date": "2026-07-20",
@@ -72,7 +72,7 @@ def test_capture_is_parsed_by_trafilatura_not_only_soup(extractor):
 
 def test_soup_fills_only_what_trafilatura_left(extractor):
     """Selenium's own extraction is the last resort, not the default."""
-    extractor._extract_with_mcmetadata = lambda url, html=None, **kw: {
+    extractor._parse_with_mcmetadata = lambda url, html=None, **kw: {
         "content": TRAFILATURA_BODY,
         "metadata": {"meta_description": "d"},
     }
@@ -89,7 +89,7 @@ def test_soup_fills_only_what_trafilatura_left(extractor):
 
 def test_good_http_content_survives_an_author_only_escalation(extractor):
     """Escalating for a byline must not discard body text already extracted."""
-    extractor._extract_with_mcmetadata = lambda url, html=None, **kw: {}
+    extractor._parse_with_mcmetadata = lambda url, html=None, **kw: {}
     result = _result(
         title="Good HTTP headline",
         content=HTTP_BODY,
@@ -111,7 +111,7 @@ def test_good_http_content_survives_an_author_only_escalation(extractor):
 def test_bot_blocked_http_fields_are_replaced_by_the_capture_parse(extractor):
     """Challenge-page text is not worth preserving."""
     extractor._last_bot_protection_detection = {"type": "cloudflare"}
-    extractor._extract_with_mcmetadata = lambda url, html=None, **kw: {
+    extractor._parse_with_mcmetadata = lambda url, html=None, **kw: {
         "title": "Real headline",
         "content": TRAFILATURA_BODY,
         "metadata": {"meta_description": "d"},
@@ -137,7 +137,7 @@ def test_capture_parse_failure_falls_back_to_soup(extractor):
     def boom(url, html=None, **kw):
         raise RuntimeError("trafilatura exploded")
 
-    extractor._extract_with_mcmetadata = boom
+    extractor._parse_with_mcmetadata = boom
     result = _result()
 
     extractor._run_selenium_extraction(
@@ -149,7 +149,7 @@ def test_capture_parse_failure_falls_back_to_soup(extractor):
 
 def test_no_capture_recorded_still_works(extractor):
     extractor._raw_html_by_method = {}
-    extractor._extract_with_mcmetadata = lambda url, html=None, **kw: {
+    extractor._parse_with_mcmetadata = lambda url, html=None, **kw: {
         "content": "should not be used"
     }
     result = _result()

--- a/tests/crawler/test_proxy_router.py
+++ b/tests/crawler/test_proxy_router.py
@@ -71,25 +71,53 @@ def _doc_id(proxy, domain):
     return proxy_router._doc_id(proxy, domain)
 
 
+# Domains with known md5-sticky assignments (see assigned_proxy):
+#   example.com / js-heavy.com / blocked.com / beta.com -> HOME_SQUID
+#   wsj.com / unrelated.com / alpha.com                 -> MIZZOU_SQUID
+_HOME_DOMAIN = "example.com"
+_MIZZOU_DOMAIN = "alpha.com"
+
+
+class TestLoadBalancing:
+    def test_assignment_is_stable_and_covers_both_proxies(self):
+        domains = [f"paper-{i}.example.com" for i in range(40)]
+        first_pass = [proxy_router.assigned_proxy(d) for d in domains]
+        second_pass = [proxy_router.assigned_proxy(d) for d in domains]
+
+        assert first_pass == second_pass  # sticky
+        assert set(first_pass) == {
+            RouterProxy.HOME_SQUID,
+            RouterProxy.MIZZOU_SQUID,
+        }  # both proxies actually take load
+
+    def test_assignment_is_case_insensitive(self):
+        assert proxy_router.assigned_proxy("Example.COM") == (
+            proxy_router.assigned_proxy("example.com")
+        )
+
+
 class TestGetProxyFor:
-    def test_no_history_picks_first_preference_with_http(self, mock_firestore):
-        choice = get_proxy_for("example.com")
+    def test_no_history_uses_sticky_assignment(self, mock_firestore):
+        home_choice = get_proxy_for(_HOME_DOMAIN)
+        mizzou_choice = get_proxy_for(_MIZZOU_DOMAIN)
 
-        assert choice.proxy == RouterProxy.HOME_SQUID
-        assert choice.method == "http"
-        assert choice.all_blocked is False
+        assert home_choice.proxy == RouterProxy.HOME_SQUID
+        assert mizzou_choice.proxy == RouterProxy.MIZZOU_SQUID
+        assert home_choice.method == "http"
+        assert home_choice.all_blocked is False
 
-    def test_blocked_home_squid_falls_through_to_mizzou(self, mock_firestore):
+    def test_blocked_assigned_proxy_fails_over_to_other(self, mock_firestore):
         _, docs = mock_firestore
         future = datetime.now(timezone.utc) + timedelta(minutes=10)
-        docs[_doc_id(RouterProxy.HOME_SQUID, "wsj.com")] = _mock_doc(
+        docs[_doc_id(RouterProxy.HOME_SQUID, _HOME_DOMAIN)] = _mock_doc(
             True, {"blocked_until": future, "consecutive_failures": 3}
         )
 
-        choice = get_proxy_for("wsj.com")
+        choice = get_proxy_for(_HOME_DOMAIN)
 
         assert choice.proxy == RouterProxy.MIZZOU_SQUID
         assert choice.all_blocked is False
+        assert choice.reason.startswith("failover from home_squid")
 
     def test_all_proxies_blocked_returns_soonest_and_flags_it(self, mock_firestore):
         _, docs = mock_firestore
@@ -106,18 +134,21 @@ class TestGetProxyFor:
         assert choice.all_blocked is True
         assert choice.proxy == RouterProxy.MIZZOU_SQUID  # soonest to free up
 
-    def test_prefers_fewest_failures_over_static_order(self, mock_firestore):
+    def test_sticky_wins_even_with_more_failures_while_unblocked(self, mock_firestore):
+        """Failure count alone must not bounce a domain between egress IPs;
+        only an actual backoff (blocked_until) triggers failover."""
         _, docs = mock_firestore
-        docs[_doc_id(RouterProxy.HOME_SQUID, "example.com")] = _mock_doc(
-            True, {"consecutive_failures": 5}
+        docs[_doc_id(RouterProxy.HOME_SQUID, _HOME_DOMAIN)] = _mock_doc(
+            True, {"consecutive_failures": 2}
         )
-        docs[_doc_id(RouterProxy.MIZZOU_SQUID, "example.com")] = _mock_doc(
+        docs[_doc_id(RouterProxy.MIZZOU_SQUID, _HOME_DOMAIN)] = _mock_doc(
             True, {"consecutive_failures": 0}
         )
 
-        choice = get_proxy_for("example.com")
+        choice = get_proxy_for(_HOME_DOMAIN)
 
-        assert choice.proxy == RouterProxy.MIZZOU_SQUID
+        assert choice.proxy == RouterProxy.HOME_SQUID
+        assert choice.reason.startswith("sticky assignment")
 
     def test_honors_stored_preferred_method(self, mock_firestore):
         _, docs = mock_firestore
@@ -139,25 +170,26 @@ class TestGetProxyFor:
 
         choice = get_proxy_for("unrelated.com")
 
-        assert choice.proxy == RouterProxy.HOME_SQUID
+        assert choice.proxy == proxy_router.assigned_proxy("unrelated.com")
+        assert choice.reason.startswith("sticky assignment")
         assert choice.all_blocked is False
 
-    def test_no_client_falls_back_to_static_default(self, monkeypatch):
+    def test_no_client_still_load_balances(self, monkeypatch):
+        """A Firestore outage costs failover, never the load balancing."""
         monkeypatch.setattr(proxy_router, "_get_client", lambda: None)
 
-        choice = get_proxy_for("example.com")
-
-        assert choice == ProxyChoice(
+        assert get_proxy_for(_HOME_DOMAIN) == ProxyChoice(
             proxy=RouterProxy.HOME_SQUID,
             method="http",
             reason=proxy_router._FALLBACK_CHOICE_REASON,
         )
+        assert get_proxy_for(_MIZZOU_DOMAIN).proxy == RouterProxy.MIZZOU_SQUID
 
-    def test_read_exception_falls_back_to_static_default(self, mock_firestore):
+    def test_read_exception_falls_back_to_sticky(self, mock_firestore):
         client, _ = mock_firestore
         client.collection.side_effect = RuntimeError("firestore on fire")
 
-        choice = get_proxy_for("example.com")
+        choice = get_proxy_for(_HOME_DOMAIN)
 
         assert choice.proxy == RouterProxy.HOME_SQUID
         assert choice.reason == proxy_router._FALLBACK_CHOICE_REASON

--- a/tests/crawler/test_selenium_escalation_guard.py
+++ b/tests/crawler/test_selenium_escalation_guard.py
@@ -74,9 +74,18 @@ def test_text_field_counts_as_body(extractor):
 
 
 def test_boundary_is_inclusive_of_stub_threshold(extractor):
-    """At exactly the threshold we still treat it as a teaser and escalate."""
-    at_limit = "x" * ContentExtractor.PAYWALL_STUB_MAX_CHARS
-    over_limit = "x" * (ContentExtractor.PAYWALL_STUB_MAX_CHARS + 1)
+    """At exactly the threshold we still treat it as a teaser and escalate.
+
+    Filler must be real prose: the quality gate now also rejects bodies that
+    are not writing, so a run of "xxxx" would escalate for that reason
+    instead and this would no longer be testing the length boundary.
+    """
+    prose = (
+        "The council met on Tuesday evening to review the budget and heard "
+        "from residents about the proposed changes to the fee schedule. "
+    )
+    at_limit = (prose * 40)[: ContentExtractor.PAYWALL_STUB_MAX_CHARS]
+    over_limit = (prose * 40)[: ContentExtractor.PAYWALL_STUB_MAX_CHARS + 1]
 
     assert (
         extractor._selenium_would_add_value({"content": at_limit}, ["author"]) is True

--- a/tests/crawler/test_tls_capture_rung.py
+++ b/tests/crawler/test_tls_capture_rung.py
@@ -90,7 +90,7 @@ def harness(monkeypatch):
 
     # The single HTTP capture. Parsers only run when this produced html,
     # so the rung-ordering assertions below need a capture to exist.
-    ex._fetch_page_html = lambda url: "<html>capture</html>"
+    ex._fetch_page_html = lambda url, metrics=None: "<html>capture</html>"
 
     # Capture rungs — all stubbed, each recording that it ran.
     def mc(url, html=None, include_other_metadata=None):

--- a/tests/crawler/test_tls_capture_rung.py
+++ b/tests/crawler/test_tls_capture_rung.py
@@ -88,6 +88,10 @@ def harness(monkeypatch):
     ex._check_rate_limit = lambda d: False
     ex._apply_cms_metadata_fallback = lambda r: None
 
+    # The single HTTP capture. Parsers only run when this produced html,
+    # so the rung-ordering assertions below need a capture to exist.
+    ex._fetch_page_html = lambda url: "<html>capture</html>"
+
     # Capture rungs — all stubbed, each recording that it ran.
     def mc(url, html=None, include_other_metadata=None):
         calls.append("mcmetadata")
@@ -111,9 +115,9 @@ def harness(monkeypatch):
         result["extraction_methods"]["author"] = "selenium"
         return True, True
 
-    ex._extract_with_mcmetadata = mc
-    ex._extract_with_newspaper = news
-    ex._extract_with_beautifulsoup = bs4
+    ex._parse_with_mcmetadata = mc
+    ex._parse_with_newspaper = news
+    ex._parse_with_beautifulsoup = bs4
     ex._extract_with_unblock_proxy = tls
     ex._run_selenium_extraction = selenium
 
@@ -151,7 +155,7 @@ def test_flagged_unblock_domain_still_tries_tls(harness):
 
 def test_tls_is_skipped_when_nothing_is_missing(harness):
     """No gap, no extra capture — this must not add requests gratuitously."""
-    harness.ex._extract_with_mcmetadata = lambda url, html=None, **kw: (
+    harness.ex._parse_with_mcmetadata = lambda url, html=None, **kw: (
         harness.calls.append("mcmetadata") or _full_result("mcmetadata")
     )
 

--- a/tests/integration/test_proxy_router_firestore.py
+++ b/tests/integration/test_proxy_router_firestore.py
@@ -52,25 +52,32 @@ def domain():
 
 
 class TestRealFirestoreRoundTrip:
-    def test_no_history_falls_back_to_static_preference(self, domain):
+    def test_no_history_uses_sticky_assignment(self, domain):
         choice = get_proxy_for(domain, service="test")
 
-        assert choice.proxy == RouterProxy.HOME_SQUID
+        assert choice.proxy == proxy_router.assigned_proxy(domain)
         assert choice.method == "http"
         assert choice.all_blocked is False
 
     def test_success_then_read_reflects_clear_state(self, domain):
-        report_result(domain, RouterProxy.HOME_SQUID, success=True, service="test")
+        sticky = proxy_router.assigned_proxy(domain)
+        report_result(domain, sticky, success=True, service="test")
 
         choice = get_proxy_for(domain, service="test")
 
-        assert choice.proxy == RouterProxy.HOME_SQUID
+        assert choice.proxy == sticky
         assert choice.all_blocked is False
 
-    def test_failure_backs_off_proxy_and_router_skips_it(self, domain):
+    def test_failure_backs_off_assigned_proxy_and_fails_over(self, domain):
+        sticky = proxy_router.assigned_proxy(domain)
+        other = (
+            RouterProxy.MIZZOU_SQUID
+            if sticky == RouterProxy.HOME_SQUID
+            else RouterProxy.HOME_SQUID
+        )
         report_result(
             domain,
-            RouterProxy.HOME_SQUID,
+            sticky,
             success=False,
             reason="403",
             service="test",
@@ -78,8 +85,9 @@ class TestRealFirestoreRoundTrip:
 
         choice = get_proxy_for(domain, service="test")
 
-        assert choice.proxy == RouterProxy.MIZZOU_SQUID
+        assert choice.proxy == other
         assert choice.all_blocked is False
+        assert choice.reason.startswith(f"failover from {sticky.value}")
 
     def test_repeated_failures_double_backoff_and_persist(self, domain):
         for _ in range(3):
@@ -107,14 +115,15 @@ class TestRealFirestoreRoundTrip:
         assert blocked_until < now + timedelta(seconds=expected_backoff + 30)
 
     def test_success_resets_failure_streak_after_failures(self, domain):
-        report_result(domain, RouterProxy.HOME_SQUID, success=False, reason="timeout")
-        report_result(domain, RouterProxy.HOME_SQUID, success=False, reason="timeout")
-        report_result(domain, RouterProxy.HOME_SQUID, success=True)
+        sticky = proxy_router.assigned_proxy(domain)
+        report_result(domain, sticky, success=False, reason="timeout")
+        report_result(domain, sticky, success=False, reason="timeout")
+        report_result(domain, sticky, success=True)
 
         choice = get_proxy_for(domain, service="test")
 
-        assert choice.proxy == RouterProxy.HOME_SQUID
-        assert choice.reason == "available, 0 recent failures"
+        assert choice.proxy == sticky
+        assert choice.reason == "sticky assignment, 0 recent failures"
 
     def test_all_proxies_blocked_flags_all_blocked_and_picks_soonest(self, domain):
         now = datetime.now(timezone.utc)
@@ -135,17 +144,24 @@ class TestRealFirestoreRoundTrip:
 
     def test_domains_are_isolated_in_real_firestore(self, domain):
         other_domain = f"other-{domain}"
-        report_result(domain, RouterProxy.HOME_SQUID, success=False, reason="403")
+        report_result(
+            domain,
+            proxy_router.assigned_proxy(domain),
+            success=False,
+            reason="403",
+        )
 
         choice = get_proxy_for(other_domain, service="test")
 
-        assert choice.proxy == RouterProxy.HOME_SQUID
+        assert choice.proxy == proxy_router.assigned_proxy(other_domain)
+        assert choice.reason.startswith("sticky assignment")
         assert choice.all_blocked is False
 
     def test_escalation_and_protection_type_persist_across_reads(self, domain):
+        sticky = proxy_router.assigned_proxy(domain)
         report_result(
             domain,
-            RouterProxy.HOME_SQUID,
+            sticky,
             success=False,
             protection_type="perimeterx",
             escalate_to_selenium=True,
@@ -154,11 +170,11 @@ class TestRealFirestoreRoundTrip:
 
         choice = get_proxy_for(domain, service="test")
 
-        assert choice.proxy != RouterProxy.HOME_SQUID
+        assert choice.proxy != sticky  # backed off -> failed over
         client = proxy_router._get_client()
         doc = (
             client.collection(proxy_router._FIRESTORE_COLLECTION)
-            .document(proxy_router._doc_id(RouterProxy.HOME_SQUID, domain))
+            .document(proxy_router._doc_id(sticky, domain))
             .get()
         )
         data = doc.to_dict()

--- a/tests/test_amp_integration.py
+++ b/tests/test_amp_integration.py
@@ -132,13 +132,13 @@ class TestAMPBypassIntegration:
 
         # Test extraction
         url = "https://fox4kc.com/news/article/"
-        result = extractor._extract_with_newspaper(url)
+        result = extractor._fetch_page_html(url)
 
         # Verify AMP bypass was used
         assert result is not None
-        assert result.get("title") == "Sample Article Title"
-        assert len(result.get("content", "")) > 100
-        assert "first paragraph" in result.get("content", "")
+        assert "Sample Article Title" in result
+        assert len(result) > 100
+        assert "first paragraph" in result
 
         # Verify amp_supported was marked True
         mock_mark_amp.assert_called_with("fox4kc.com", True)
@@ -189,11 +189,11 @@ class TestAMPBypassIntegration:
 
         # Test extraction
         url = "https://fox4kc.com/news/article/"
-        result = extractor._extract_with_newspaper(url)
+        result = extractor._fetch_page_html(url)
 
         # Verify extraction succeeded
         assert result is not None
-        assert result.get("title") == "Sample Article Title"
+        assert "Sample Article Title" in result
 
         # Verify preemptive AMP telemetry
         calls = mock_bot_manager.record_bot_detection.call_args_list
@@ -259,7 +259,7 @@ class TestAMPBypassIntegration:
         url = "https://example.com/news/article/"
 
         with pytest.raises(Exception) as exc_info:
-            extractor._extract_with_newspaper(url)
+            extractor._fetch_page_html(url)
 
         # Verify exception mentions Selenium
         assert (
@@ -317,11 +317,11 @@ class TestAMPBypassIntegration:
 
         # Test extraction
         url = "https://regular-site.com/news/article/"
-        result = extractor._extract_with_newspaper(url)
+        result = extractor._fetch_page_html(url)
 
         # Verify extraction succeeded with regular flow
         assert result is not None
-        assert result.get("title") is not None
+        assert result is not None and len(result) > 0
 
         # Verify no AMP telemetry
         calls = mock_bot_manager.record_bot_detection.call_args_list

--- a/tests/test_extraction_methods.py
+++ b/tests/test_extraction_methods.py
@@ -145,7 +145,7 @@ class TestContentExtractor:
         monkeypatch.setattr(
             crawler_module.ContentExtractor,
             "_fetch_page_html",
-            lambda self, url: "<html>stubbed page</html>",
+            lambda self, url, metrics=None: "<html>stubbed page</html>",
         )
 
         def _convert_final_payload(payload: dict) -> dict:

--- a/tests/test_extraction_methods.py
+++ b/tests/test_extraction_methods.py
@@ -134,7 +134,19 @@ class TestContentExtractor:
         crawler_module.mcmetadata = original_module
 
     def _install_mcmetadata_stub(self, monkeypatch, *, extract_result=None, error=None):
-        """Install a stub mcmetadata module for controlled responses."""
+        """Install a stub mcmetadata module for controlled responses.
+
+        Also stubs the crawler's single fetch step (_fetch_page_html):
+        parsers never fetch, so extract_content fetches once up front and
+        hands the HTML to every parser. These tests exercise the
+        merge/fallback logic, not transport, so the fetch is replaced with
+        canned HTML.
+        """
+        monkeypatch.setattr(
+            crawler_module.ContentExtractor,
+            "_fetch_page_html",
+            lambda self, url: "<html>stubbed page</html>",
+        )
 
         def _convert_final_payload(payload: dict) -> dict:
             converted = {
@@ -236,12 +248,12 @@ class TestContentExtractor:
         with (
             patch.object(
                 extractor,
-                "_extract_with_newspaper",
+                "_parse_with_newspaper",
                 return_value=newspaper_result,
             ),
             patch.object(
                 extractor,
-                "_extract_with_beautifulsoup",
+                "_parse_with_beautifulsoup",
                 return_value={},
             ),
             patch.object(
@@ -279,12 +291,12 @@ class TestContentExtractor:
         with (
             patch.object(
                 extractor,
-                "_extract_with_newspaper",
+                "_parse_with_newspaper",
                 return_value=newspaper_result,
             ),
             patch.object(
                 extractor,
-                "_extract_with_beautifulsoup",
+                "_parse_with_beautifulsoup",
                 return_value={},
             ),
             patch.object(
@@ -337,12 +349,12 @@ class TestContentExtractor:
 
         monkeypatch.setattr(
             extractor,
-            "_extract_with_newspaper",
+            "_parse_with_newspaper",
             fake_newspaper,
         )
         monkeypatch.setattr(
             extractor,
-            "_extract_with_beautifulsoup",
+            "_parse_with_beautifulsoup",
             fail_beautifulsoup,
         )
         monkeypatch.setattr(
@@ -412,12 +424,12 @@ class TestContentExtractor:
 
         monkeypatch.setattr(
             extractor,
-            "_extract_with_newspaper",
+            "_parse_with_newspaper",
             fake_newspaper,
         )
         monkeypatch.setattr(
             extractor,
-            "_extract_with_beautifulsoup",
+            "_parse_with_beautifulsoup",
             fake_beautifulsoup,
         )
         monkeypatch.setattr(
@@ -501,10 +513,8 @@ class TestContentExtractor:
             called["selenium"] = True
             return {}
 
-        monkeypatch.setattr(extractor, "_extract_with_newspaper", note_newspaper)
-        monkeypatch.setattr(
-            extractor, "_extract_with_beautifulsoup", note_beautifulsoup
-        )
+        monkeypatch.setattr(extractor, "_parse_with_newspaper", note_newspaper)
+        monkeypatch.setattr(extractor, "_parse_with_beautifulsoup", note_beautifulsoup)
         monkeypatch.setattr(extractor, "_extract_with_selenium", note_selenium)
 
         extractor.use_mcmetadata = True
@@ -577,10 +587,8 @@ class TestContentExtractor:
             return {}
 
         extractor.use_mcmetadata = True
-        monkeypatch.setattr(extractor, "_extract_with_newspaper", fake_newspaper)
-        monkeypatch.setattr(
-            extractor, "_extract_with_beautifulsoup", note_beautifulsoup
-        )
+        monkeypatch.setattr(extractor, "_parse_with_newspaper", fake_newspaper)
+        monkeypatch.setattr(extractor, "_parse_with_beautifulsoup", note_beautifulsoup)
         monkeypatch.setattr(extractor, "_extract_with_selenium", note_selenium)
 
         result = extractor.extract_content("https://example.com/partial")
@@ -622,7 +630,9 @@ class TestContentExtractor:
 
         def fake_beautifulsoup(url, html=None):
             call_order.append("beautifulsoup")
-            assert html is None  # mcmetadata failure should not provide HTML override
+            # fetch-once-parse-many: every parser gets the same capture,
+            # including after an earlier parser raised.
+            assert html == "<html>stubbed page</html>"
             return {
                 "url": url,
                 "title": "Fallback Title",
@@ -640,10 +650,8 @@ class TestContentExtractor:
             return {}
 
         extractor.use_mcmetadata = True
-        monkeypatch.setattr(extractor, "_extract_with_newspaper", fake_newspaper)
-        monkeypatch.setattr(
-            extractor, "_extract_with_beautifulsoup", fake_beautifulsoup
-        )
+        monkeypatch.setattr(extractor, "_parse_with_newspaper", fake_newspaper)
+        monkeypatch.setattr(extractor, "_parse_with_beautifulsoup", fake_beautifulsoup)
         monkeypatch.setattr(extractor, "_extract_with_selenium", fail_selenium)
 
         result = extractor.extract_content("https://example.com/boom")
@@ -672,7 +680,7 @@ class TestContentExtractor:
             </html>
             """)
 
-        result = extractor._extract_with_beautifulsoup(
+        result = extractor._parse_with_beautifulsoup(
             "https://www.kbia.org/example", html
         )
 
@@ -698,7 +706,7 @@ class TestContentExtractor:
             </html>
             """)
 
-        result = extractor._extract_with_beautifulsoup(
+        result = extractor._parse_with_beautifulsoup(
             "https://www.mexicoledger.com/example", html
         )
 
@@ -723,7 +731,7 @@ class TestContentExtractor:
             </html>
             """)
 
-        result = extractor._extract_with_beautifulsoup(
+        result = extractor._parse_with_beautifulsoup(
             "https://www.maconhomepress.com/example", html
         )
 
@@ -745,10 +753,8 @@ class TestContentExtractor:
         }
 
         with (
-            patch.object(
-                extractor, "_extract_with_newspaper", return_value=empty_result
-            ),
-            patch.object(extractor, "_extract_with_beautifulsoup", return_value={}),
+            patch.object(extractor, "_parse_with_newspaper", return_value=empty_result),
+            patch.object(extractor, "_parse_with_beautifulsoup", return_value={}),
             patch.object(extractor, "_extract_with_selenium", return_value={}),
         ):
             result = extractor.extract_content(url)
@@ -945,8 +951,8 @@ class TestRealWorldExtraction:
         print(f"{'=' * 60}")
 
         methods = [
-            ("newspaper4k", extractor._extract_with_newspaper),
-            ("beautifulsoup", extractor._extract_with_beautifulsoup),
+            ("newspaper4k", extractor._parse_with_newspaper),
+            ("beautifulsoup", extractor._parse_with_beautifulsoup),
             ("selenium", extractor._extract_with_selenium),
         ]
 
@@ -1000,8 +1006,8 @@ class TestRealWorldExtraction:
         # Track method calls by patching the methods
         method_calls = {"newspaper": 0, "beautifulsoup": 0, "selenium": 0}
 
-        original_newspaper = extractor._extract_with_newspaper
-        original_beautifulsoup = extractor._extract_with_beautifulsoup
+        original_newspaper = extractor._parse_with_newspaper
+        original_beautifulsoup = extractor._parse_with_beautifulsoup
         original_selenium = extractor._extract_with_selenium
 
         def track_newspaper(*args, **kwargs):
@@ -1017,8 +1023,8 @@ class TestRealWorldExtraction:
             return original_selenium(*args, **kwargs)
 
         with (
-            patch.object(extractor, "_extract_with_newspaper", track_newspaper),
-            patch.object(extractor, "_extract_with_beautifulsoup", track_beautifulsoup),
+            patch.object(extractor, "_parse_with_newspaper", track_newspaper),
+            patch.object(extractor, "_parse_with_beautifulsoup", track_beautifulsoup),
             patch.object(extractor, "_extract_with_selenium", track_selenium),
         ):
             try:
@@ -1094,7 +1100,9 @@ class TestNewspaperMethod:
             with patch.object(
                 extractor, "_get_domain_session", return_value=mock_session
             ):
-                result = extractor._extract_with_newspaper("https://test.com")
+                result = extractor._parse_with_newspaper(
+                    "https://test.com", mock_html_complete
+                )
 
                 assert result is not None
                 assert result["title"] == "Test Article Title"
@@ -1111,7 +1119,7 @@ class TestNewspaperMethod:
 
             # Should handle exception and return empty result
             try:
-                extractor._extract_with_newspaper("https://test.com")
+                extractor._parse_with_newspaper("https://test.com", "<html>page</html>")
                 assert False, "Expected exception to be raised"
             except Exception as e:
                 assert str(e) == "Parse error"
@@ -1145,7 +1153,9 @@ class TestNewspaperMethod:
             with patch.object(
                 extractor, "_get_domain_session", return_value=mock_session
             ):
-                result = extractor._extract_with_newspaper("https://test.com")
+                result = extractor._parse_with_newspaper(
+                    "https://test.com", mock_html_partial
+                )
 
                 assert result is not None
                 assert result["title"] == "Partial Article"
@@ -1168,7 +1178,9 @@ class TestBeautifulSoupMethod:
                 "_get_domain_session",
                 return_value=extractor.session,
             ):
-                result = extractor._extract_with_beautifulsoup("https://test.com")
+                result = extractor._parse_with_beautifulsoup(
+                    "https://test.com", mock_html_complete
+                )
 
             assert result is not None
             assert result["title"] == "Test Article Title"
@@ -1176,7 +1188,7 @@ class TestBeautifulSoupMethod:
 
     def test_beautifulsoup_with_provided_html(self, extractor, mock_html_complete):
         """Test BeautifulSoup extraction with pre-provided HTML."""
-        result = extractor._extract_with_beautifulsoup(
+        result = extractor._parse_with_beautifulsoup(
             "https://test.com", mock_html_complete
         )
 
@@ -1198,7 +1210,7 @@ class TestBeautifulSoupMethod:
                 return_value=extractor.session,
             ):
                 # Should return empty dict, not raise (graceful degradation)
-                result = extractor._extract_with_beautifulsoup("https://test.com")
+                result = extractor._parse_with_beautifulsoup("https://test.com", None)
                 assert result == {}
 
 
@@ -1269,8 +1281,11 @@ class TestFallbackMechanism:
     def test_complete_extraction_no_fallback(self, extractor, mock_html_complete):
         """Test that no fallback is needed when first method succeeds."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_np,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
             # Newspaper returns complete results
@@ -1314,8 +1329,11 @@ class TestFallbackMechanism:
         # missing, so the cascade otherwise launches a REAL Chrome for
         # https://test.com (~30-60s and network-dependent).
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_np,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium", return_value={}),
         ):
             # Newspaper returns partial results
@@ -1360,8 +1378,11 @@ class TestFallbackMechanism:
     def test_full_cascade_to_selenium(self, extractor):
         """Test full cascade from newspaper → BeautifulSoup → Selenium."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_np,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
             # Newspaper fails completely
@@ -1410,7 +1431,12 @@ class TestMethodTracking:
     @pytest.mark.integration
     def test_extraction_methods_metadata(self, extractor):
         """Test that extraction methods are tracked in metadata."""
-        with patch.object(extractor, "_extract_with_newspaper") as mock_np:
+        with (
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_np,
+        ):
             mock_np.return_value = {
                 "title": "Test Title",
                 "author": "Test Author",
@@ -1440,8 +1466,8 @@ class TestEdgeCases:
     def test_all_methods_fail(self, extractor):
         """Test behavior when all extraction methods fail."""
         with (
-            patch.object(extractor, "_extract_with_newspaper", return_value={}),
-            patch.object(extractor, "_extract_with_beautifulsoup", return_value={}),
+            patch.object(extractor, "_parse_with_newspaper", return_value={}),
+            patch.object(extractor, "_parse_with_beautifulsoup", return_value={}),
             patch.object(extractor, "_extract_with_selenium", return_value={}),
         ):
             result = extractor.extract_content("https://test.com")
@@ -1464,9 +1490,7 @@ class TestEdgeCases:
             mock_session.return_value.get.side_effect = requests.Timeout("Timeout")
 
             # Call with no cached HTML - should handle timeout gracefully
-            result = extractor._extract_with_beautifulsoup(
-                "https://test.com", html=None
-            )
+            result = extractor._parse_with_beautifulsoup("https://test.com", html=None)
 
             # Should return empty dict when network fails
             assert result == {}
@@ -1477,9 +1501,7 @@ class TestEdgeCases:
                            <body><p>Unclosed tag</body></html>"""
 
         # BeautifulSoup should handle malformed HTML gracefully
-        result = extractor._extract_with_beautifulsoup(
-            "https://test.com", malformed_html
-        )
+        result = extractor._parse_with_beautifulsoup("https://test.com", malformed_html)
         assert result is not None
         assert result["title"] == "Test"
 

--- a/tests/test_http_error_handling.py
+++ b/tests/test_http_error_handling.py
@@ -64,7 +64,7 @@ class TestNotFoundErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(NotFoundError, match="URL returned 404"):
-                extractor._extract_with_newspaper("https://example.com/missing")
+                extractor._fetch_page_html("https://example.com/missing")
 
     def test_410_returns_structured_not_found(self, extractor, mock_response):
         """410 Gone response should raise NotFoundError immediately."""
@@ -74,15 +74,15 @@ class TestNotFoundErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(NotFoundError, match="URL returned 410"):
-                extractor._extract_with_newspaper("https://example.com/gone")
+                extractor._fetch_page_html("https://example.com/gone")
 
     def test_404_not_found_stops_extract_content_fallback(self, extractor):
         """
         Test that NotFoundError in newspaper4k stops BS/Selenium fallback.
         """
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(extractor, "_fetch_page_html") as mock_np,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
 
@@ -101,8 +101,8 @@ class TestNotFoundErrorHandling:
     def test_410_gone_stops_extract_content_fallback(self, extractor):
         """Test that 410 Gone stops all fallback methods."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(extractor, "_fetch_page_html") as mock_np,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
 
@@ -133,13 +133,13 @@ class TestRateLimitErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(RateLimitError, match="Rate limited \\(429\\)"):
-                extractor._extract_with_newspaper("https://example.com/article")
+                extractor._fetch_page_html("https://example.com/article")
 
     def test_rate_limit_error_stops_extract_content_fallback(self, extractor):
         """Test that RateLimitError stops BS/Selenium fallback."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(extractor, "_fetch_page_html") as mock_np,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
 
@@ -165,7 +165,7 @@ class Test4xxClientErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(NotFoundError, match="Client error \\(400\\)"):
-                extractor._extract_with_newspaper("https://example.com/bad-request")
+                extractor._fetch_page_html("https://example.com/bad-request")
 
     def test_405_method_not_allowed_raises_not_found_error(
         self, extractor, mock_response
@@ -177,7 +177,7 @@ class Test4xxClientErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(NotFoundError, match="Client error \\(405\\)"):
-                extractor._extract_with_newspaper("https://example.com/no-get")
+                extractor._fetch_page_html("https://example.com/no-get")
 
     def test_406_not_acceptable_raises_not_found_error(self, extractor, mock_response):
         """Test that 406 Not Acceptable raises NotFoundError."""
@@ -187,7 +187,7 @@ class Test4xxClientErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(NotFoundError, match="Client error \\(406\\)"):
-                extractor._extract_with_newspaper("https://example.com/not-acceptable")
+                extractor._fetch_page_html("https://example.com/not-acceptable")
 
     def test_451_unavailable_for_legal_reasons_raises_not_found_error(
         self, extractor, mock_response
@@ -201,7 +201,7 @@ class Test4xxClientErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(NotFoundError, match="Client error \\(451\\)"):
-                extractor._extract_with_newspaper("https://example.com/blocked")
+                extractor._fetch_page_html("https://example.com/blocked")
 
     def test_408_request_timeout_raises_rate_limit_error(
         self, extractor, mock_response
@@ -213,17 +213,17 @@ class Test4xxClientErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(RateLimitError, match="Client error \\(408\\)"):
-                extractor._extract_with_newspaper("https://example.com/timeout")
+                extractor._fetch_page_html("https://example.com/timeout")
 
     def test_4xx_errors_stop_extract_content_fallback(self, extractor):
         """Test that 4xx errors stop BeautifulSoup/Selenium fallback."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_newspaper,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(extractor, "_fetch_page_html") as mock_newspaper,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
 
-            # newspaper4k raises NotFoundError for 400
+            # The fetch raises NotFoundError for 400
             mock_newspaper.side_effect = NotFoundError(
                 "Client error (400): https://example.com/bad"
             )
@@ -252,7 +252,7 @@ class Test5xxServerErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(RateLimitError, match="Server error \\(500\\)"):
-                extractor._extract_with_newspaper("https://example.com/error")
+                extractor._fetch_page_html("https://example.com/error")
 
     def test_501_not_implemented_raises_rate_limit_error(
         self, extractor, mock_response
@@ -267,7 +267,7 @@ class Test5xxServerErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(RateLimitError, match="Server error \\(501\\)"):
-                extractor._extract_with_newspaper("https://example.com/not-impl")
+                extractor._fetch_page_html("https://example.com/not-impl")
 
     def test_505_http_version_not_supported_raises_rate_limit_error(
         self, extractor, mock_response
@@ -284,17 +284,17 @@ class Test5xxServerErrorHandling:
             mock_session.return_value = mock_sess
 
             with pytest.raises(RateLimitError, match="Server error \\(505\\)"):
-                extractor._extract_with_newspaper("https://example.com/version")
+                extractor._fetch_page_html("https://example.com/version")
 
     def test_5xx_errors_stop_extract_content_fallback(self, extractor):
         """Test that 5xx errors stop BeautifulSoup/Selenium fallback."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_newspaper,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(extractor, "_fetch_page_html") as mock_newspaper,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
         ):
 
-            # newspaper4k raises RateLimitError for 500
+            # The fetch raises RateLimitError for 500
             mock_newspaper.side_effect = RateLimitError(
                 "Server error (500) on example.com"
             )
@@ -341,8 +341,8 @@ class TestExplicitlyHandledErrorCodes:
             mock_detect.return_value = "cloudflare"
 
             # Should raise Exception from download fallback
-            with pytest.raises(Exception, match="Download blocked"):
-                extractor._extract_with_newspaper("https://example.com/protected")
+            with pytest.raises(Exception, match="will try Selenium"):
+                extractor._fetch_page_html("https://example.com/protected")
 
     def test_502_bad_gateway_raises_rate_limit_error(self, extractor, mock_response):
         """Test that 502 Bad Gateway raises Exception when newspaper fallback also fails."""
@@ -372,8 +372,8 @@ class TestExplicitlyHandledErrorCodes:
             mock_detect.return_value = None  # No bot protection detected
 
             # Should raise Exception from download fallback
-            with pytest.raises(Exception, match="Download blocked"):
-                extractor._extract_with_newspaper("https://example.com/gateway")
+            with pytest.raises(Exception, match="will try Selenium"):
+                extractor._fetch_page_html("https://example.com/gateway")
 
     def test_503_service_unavailable_raises_rate_limit_error(
         self, extractor, mock_response
@@ -405,8 +405,8 @@ class TestExplicitlyHandledErrorCodes:
             mock_detect.return_value = None
 
             # Should raise Exception from download fallback
-            with pytest.raises(Exception, match="Download blocked"):
-                extractor._extract_with_newspaper("https://example.com/unavailable")
+            with pytest.raises(Exception, match="will try Selenium"):
+                extractor._fetch_page_html("https://example.com/unavailable")
 
     def test_504_gateway_timeout_raises_rate_limit_error(
         self, extractor, mock_response
@@ -438,8 +438,8 @@ class TestExplicitlyHandledErrorCodes:
             mock_detect.return_value = None
 
             # Should raise Exception from download fallback
-            with pytest.raises(Exception, match="Download blocked"):
-                extractor._extract_with_newspaper("https://example.com/timeout")
+            with pytest.raises(Exception, match="will try Selenium"):
+                extractor._fetch_page_html("https://example.com/timeout")
 
 
 class TestUnexpectedStatusCodes:
@@ -454,7 +454,7 @@ class TestUnexpectedStatusCodes:
             mock_session.return_value = mock_sess
 
             with pytest.raises(RateLimitError, match="Unexpected status \\(301\\)"):
-                extractor._extract_with_newspaper("https://example.com/moved")
+                extractor._fetch_page_html("https://example.com/moved")
 
 
 class TestSuccessfulExtraction:
@@ -477,12 +477,10 @@ class TestSuccessfulExtraction:
             mock_detect.return_value = None  # No bot protection
 
             # Should not raise exception
-            result = extractor._extract_with_newspaper("https://example.com/article")
+            result = extractor._fetch_page_html("https://example.com/article")
 
-            # Result should contain extracted data
-            assert result is not None
-            assert "url" in result
-            assert result["url"] == "https://example.com/article"
+            # The fetcher returns the page HTML for the parsers to use
+            assert result == "<html><body>Article content</body></html>"
 
 
 class TestFallbackBehavior:
@@ -494,8 +492,11 @@ class TestFallbackBehavior:
             patch.object(
                 extractor, "_get_domain_extraction_method", return_value=("http", None)
             ),
-            patch.object(extractor, "_extract_with_newspaper") as mock_newspaper,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_newspaper,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_get_missing_fields") as mock_missing,
         ):
 
@@ -532,8 +533,11 @@ class TestFallbackBehavior:
             patch.object(
                 extractor, "_get_domain_extraction_method", return_value=("http", None)
             ),
-            patch.object(extractor, "_extract_with_newspaper") as mock_newspaper,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(
+                extractor, "_fetch_page_html", return_value="<html>capture</html>"
+            ),
+            patch.object(extractor, "_parse_with_newspaper") as mock_newspaper,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_get_missing_fields") as mock_missing,
         ):
 
@@ -579,7 +583,7 @@ class TestDeadURLCaching:
             url = "https://example.com/missing"
 
             with pytest.raises(NotFoundError, match="URL returned 404"):
-                extractor._extract_with_newspaper(url)
+                extractor._fetch_page_html(url)
 
         # Verify URL was cached as dead before exception was raised
         assert url in extractor.dead_urls
@@ -598,7 +602,7 @@ class TestDeadURLCaching:
             url = "https://example.com/bad"
 
             with pytest.raises(NotFoundError):
-                extractor._extract_with_newspaper(url)
+                extractor._fetch_page_html(url)
 
             # Verify URL was cached as dead
             assert url in extractor.dead_urls
@@ -619,7 +623,7 @@ class TestDeadURLCaching:
             url = "https://example.com/error"
 
             with pytest.raises(RateLimitError):
-                extractor._extract_with_newspaper(url)
+                extractor._fetch_page_html(url)
 
             # Verify URL was NOT cached (temporary error)
             assert url not in extractor.dead_urls
@@ -647,12 +651,12 @@ class TestMetricsTracking:
                     "https://example.com/missing", metrics=mock_metrics
                 )
 
-        # Should track the newspaper4k method attempt and failure
-        mock_metrics.start_method.assert_called_with("newspaper4k")
-        # end_method should be called with failure status
+        # The 404 now surfaces from the single fetch step, which runs
+        # before any parser -- so that is the step metrics must record.
+        mock_metrics.start_method.assert_called_with("http_fetch")
         assert mock_metrics.end_method.called
         call_args = mock_metrics.end_method.call_args
-        assert call_args[0][0] == "newspaper4k"  # method name
+        assert call_args[0][0] == "http_fetch"  # method name
         assert call_args[0][1] is False  # success=False
 
     def test_successful_extraction_tracks_metrics(self, extractor, mock_response):

--- a/tests/test_proxy_challenge_handling.py
+++ b/tests/test_proxy_challenge_handling.py
@@ -174,7 +174,7 @@ class TestProxyChallengeErrorPreventsFallback:
     def test_proxy_challenge_stops_selenium_fallback(self, extractor):
         """Test that ProxyChallengeError from unblock proxy stops Selenium fallback."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
+            patch.object(extractor, "_parse_with_newspaper") as mock_np,
             patch.object(extractor, "_extract_with_unblock_proxy") as mock_unblock,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
             patch.object(extractor, "_get_domain_extraction_method") as mock_method,
@@ -206,9 +206,9 @@ class TestProxyChallengeErrorPreventsFallback:
     def test_proxy_challenge_in_extract_content_workflow(self, extractor):
         """Test full extract_content workflow with proxy challenge."""
         with (
-            patch.object(extractor, "_extract_with_newspaper") as mock_np,
+            patch.object(extractor, "_parse_with_newspaper") as mock_np,
             patch.object(extractor, "_extract_with_unblock_proxy") as mock_unblock,
-            patch.object(extractor, "_extract_with_beautifulsoup") as mock_bs,
+            patch.object(extractor, "_parse_with_beautifulsoup") as mock_bs,
             patch.object(extractor, "_extract_with_selenium") as mock_sel,
             patch.object(extractor, "_get_domain_extraction_method") as mock_method,
         ):

--- a/tests/test_selenium_only_feature.py
+++ b/tests/test_selenium_only_feature.py
@@ -310,7 +310,7 @@ class TestExtractionFlowWithSeleniumOnly:
         ):
             with patch.object(extractor, "_extract_with_selenium") as mock_selenium:
                 with patch.object(
-                    extractor, "_extract_with_mcmetadata"
+                    extractor, "_parse_with_mcmetadata"
                 ) as mock_mcmetadata:
                     mock_selenium.return_value = {
                         "title": "Test",
@@ -332,9 +332,7 @@ class TestExtractionFlowWithSeleniumOnly:
             return_value=("selenium", "perimeterx"),
         ):
             with patch.object(extractor, "_extract_with_selenium") as mock_selenium:
-                with patch.object(
-                    extractor, "_extract_with_newspaper"
-                ) as mock_newspaper:
+                with patch.object(extractor, "_parse_with_newspaper") as mock_newspaper:
                     mock_selenium.return_value = {
                         "title": "Test",
                         "text": "Content " * 50,
@@ -372,7 +370,7 @@ class TestExtractionFlowWithSeleniumOnly:
         with patch.object(
             extractor, "_get_domain_extraction_method", return_value=("http", None)
         ):
-            with patch.object(extractor, "_extract_with_mcmetadata") as mock_mcmetadata:
+            with patch.object(extractor, "_parse_with_mcmetadata") as mock_mcmetadata:
                 mock_mcmetadata.return_value = {
                     "title": "Test Article",
                     "text": "This is the article content with sufficient length.",
@@ -412,11 +410,16 @@ class TestHeadfulPrimarySelenium:
             ),
             patch.object(
                 extractor,
+                "_fetch_page_html",
+                return_value="<html>capture</html>",
+            ),
+            patch.object(
+                extractor,
                 "_run_selenium_extraction",
             ) as mock_selenium,
             patch.object(
                 extractor,
-                "_extract_with_mcmetadata",
+                "_parse_with_mcmetadata",
                 return_value=True,
             ) as mock_mcmetadata,
             patch.object(
@@ -453,21 +456,26 @@ class TestHeadfulPrimarySelenium:
             ),
             patch.object(
                 extractor,
+                "_fetch_page_html",
+                return_value="<html>capture</html>",
+            ),
+            patch.object(
+                extractor,
                 "_run_selenium_extraction",
             ) as mock_selenium,
             patch.object(
                 extractor,
-                "_extract_with_mcmetadata",
+                "_parse_with_mcmetadata",
                 return_value=True,  # mcmetadata succeeds
             ) as mock_mcmetadata,
             patch.object(
                 extractor,
-                "_extract_with_newspaper",
+                "_parse_with_newspaper",
                 return_value=True,  # newspaper succeeds
             ),
             patch.object(
                 extractor,
-                "_extract_with_beautifulsoup",
+                "_parse_with_beautifulsoup",
                 return_value=True,  # beautifulsoup succeeds
             ),
             patch.object(


### PR DESCRIPTION
## Why

Extraction had **four** things capable of fetching (mcmetadata, newspaper4k, BeautifulSoup, Selenium), and three did it with a bare `requests.get` — no proxy, no rotated UA. Verified empirically from a production pod: those fetches egressed as **34.68.204.189**, the GKE Cloud NAT IP, not the Squid exit. Roughly **89% of extraction fetches** took that path, presenting a datacenter fingerprint to publishers.

Nothing caught it. There was no per-request proxy telemetry, and every test either supplied HTML directly or stubbed the extractor layer — so the transport was never asserted. mcmetadata only entered the flow ~2025-12-05 as the primary parser, which is why no earlier baseline shows a decline.

## The model

```
fetch once (proxied session, or Selenium render)
  → parse many (mcmetadata, newspaper4k, BeautifulSoup)
```

- **`_fetch_page_html()`** is the single HTTP capture: proxied per-domain session, rotated UA, Referer, AMP-preemptive fetch, PerimeterX AMP bypass, bot detection, rate-limit backoff, router reporting. This logic **moved** out of `_extract_with_newspaper`; it was not rewritten.
- **Parsers renamed to say what they are**: `_parse_with_mcmetadata` / `_parse_with_newspaper` / `_parse_with_beautifulsoup`. Each takes the capture; none fetches.
- newspaper's `article.download()` fallback **deleted** — a failed session fetch now escalates to Selenium instead of leaking to the pod IP.
- **Selenium** remains the render/fetch of last resort, feeding a capture.
- Vendored `src/mcmetadata/` is **untouched**, so upstream syncs stay clean.

## Also in this PR

**Proxy load balancing** — `proxy_router` now spreads domains across both Squids by md5-sticky assignment (one consistent egress IP per publisher), with health-based failover only on actual backoff. Survives a Firestore outage, since the assignment needs no health data. `MIZZOU_SQUID_PROXY_URL` wired into all 7 manifests + the Argo template so the second egress is actually reachable. `HTTP_PROXY`/`NO_PROXY` safety net added for stray libraries.

**Capture quality gate** — `_selenium_would_add_value()` gated on **length only**, so a consent wall or bot-challenge page clearing the 400-char threshold was accepted as an article and written to the corpus. `boilerplate.looks_like_article()` already existed and already computed this verdict for telemetry's `is_success` — but it was only ever *recorded*, never acted on. Now it drives escalation.

**Evaluable telemetry, not blind rejection** — `_assess_capture_quality()` records the measured signals (`prose_density`, `capitalization_ratio`, `utility_word_rate`, `chars`, `chars_after_strip`, `article_like`) for **every** capture, accepted or rejected, plus the thresholds that produced the verdict. Rejections alone can't yield a false-positive rate; the accepted population is what you compare against. Pairing a rejection with the Selenium body that follows answers whether escalating was right.

**Restored HTTP telemetry** — the fetch/parse split initially dropped `http_status_code` and `http_error_type`, so an extraction blocked at fetch time recorded no status at all. `_fetch_page_html` now takes `metrics` and calls `set_http_metrics()`, which also derives the error class and records size/timing. The fetch is its own tracked step (`http_fetch`).

## Test plan

- [x] Full suite: **2836 passed**
- [x] Postgres suite: **288 passed**
- [x] Firestore emulator integration: 9 passed
- [x] mypy strict + black + flake8 clean
- [x] `test_mcmetadata_proxy_routing.py` (20 tests) — parsers never fetch; both optional-dependency states; capture-failure paths
- [x] `test_capture_quality_gate.py` (9 tests) — the gate, plus proof that signals are recorded on **accepts** too
- [x] Verified in **both** environments: 20 passed normally, and 20 passed with `MCMETADATA_AVAILABLE=False` / `mcmetadata=None` forced to simulate the CI image

## Notes for review

The refactor broke 44 tests; all traced to tests obtaining HTML via the old per-parser fetch, each retargeted at the correct layer. **Several were real findings, not cosmetics:**

1. Missing fetch-step metrics (above).
2. A test asserting parsers should *not* share HTML — the exact behavior this model corrects.
3. The Postgres gate caught two cases where a successful 200 capture was **discarded** because a non-essential call threw inside the broad handler — first `proxy_manager.record_success()` (a Mock response time: `float + Mock`), then a mistyped telemetry method. Fixed by taking the payload first and treating all measurement as best-effort; both now have regression tests.
4. Two new tests passed locally and failed in CI because `MCMETADATA_AVAILABLE` differs by environment (True in the dev venv, False in `mizzou-ci-base`). Now pinned, with **both** states covered — a test that doesn't pin it is asserting against whichever branch that machine happened to take.

Finding 4 prompted a broader change of approach in this PR: tests now exercise **all available paths, not just the golden one** — both dependency states, and the failure branches (connection error, invalid-AMP fallback, bookkeeping/telemetry throwing). Golden-path-only testing is precisely what let the pod-IP bypass live undetected.

## What this PR does *not* prove

1. **`looks_like_article()` has never gated anything before** — its thresholds are unvalidated against this corpus. It may reject some legitimate short or list-heavy local stories and trigger extra Selenium runs. The telemetry is built to answer that; the honest sequence is merge → watch `capture_quality` on real traffic → tune.
2. **Dual-proxy routing is production-untested** — code-complete and unit-tested, but the last validation run only exercised home Squid.

## Known follow-up (not in this PR)

Discovery (`discovery.py`) is separate code and does **not** use this flow. Only 1 of its 3 fetch paths is router-wired, it has **no Selenium failover at all**, and it has **no capture quality gate** — so a homepage serving a challenge page is indistinguishable in telemetry from "no new articles today." To be handled in its own PR after a design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
