### PR TITLE
File paywalls as paywalled; make discovery say why it found nothing

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -1749,6 +1749,34 @@ def _process_batch(
                     # Uses database boilerplate patterns to strip noise
                     MIN_CONTENT_LENGTH = 150
                     cleaning_metadata = {}
+
+                    # The capture gate already recognised a subscription wall
+                    # (boilerplate.looks_like_paywall). Trust that verdict here
+                    # rather than re-deriving it from length: the existing
+                    # check below only fires under MIN_CONTENT_LENGTH, and a
+                    # wall wrapped in a site's nav menu clears that easily --
+                    # greenfieldvedette.com served 1,039 chars of menu plus
+                    # "This content is for subscribers only" and would have
+                    # been stored as a normal article whose body is furniture.
+                    #
+                    # Headline, byline and date live OUTSIDE the wall, so they
+                    # are kept; only the wall text is discarded as the body.
+                    capture_meta = content.get("metadata") or {}
+                    gate_says_paywall = (
+                        capture_meta.get("capture_rejected_as") == "paywall"
+                    )
+                    if gate_says_paywall:
+                        logger.warning(
+                            "Paywall wall detected (%s) - saving metadata only: %s",
+                            capture_meta.get("paywall_marker"),
+                            url,
+                        )
+                        # Drop the wall text so furniture is never stored as a
+                        # body; the headline/byline/date captured alongside it
+                        # are kept by the save below.
+                        content_text = ""
+                        content["content"] = ""
+
                     if content_text:
                         from urllib.parse import urlparse
 
@@ -1780,7 +1808,7 @@ def _process_batch(
                         stripped_content = ""
 
                     # Check if content is insufficient AND has paywall indicators
-                    has_paywall_patterns = any(
+                    has_paywall_patterns = gate_says_paywall or any(
                         pattern in cleaning_metadata.get("patterns_matched", [])
                         for pattern in ["subscription", "paywall"]
                     )

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -31,6 +31,7 @@ from src.utils.boilerplate import (
     MIN_PROSE_DENSITY,
     capitalization_ratio,
     looks_like_article,
+    looks_like_paywall,
     prose_density,
     strip_boilerplate,
     utility_word_rate,
@@ -5861,6 +5862,11 @@ class ContentExtractor:
     # "not_article_like"), or None when it was accepted.
     _last_capture_rejection: Optional[str] = None
 
+    # Which paywall prompt the last capture matched, when the rejection
+    # reason was "paywall". Recorded so the marker list can be audited
+    # against real traffic rather than trusted.
+    _last_paywall_marker: Optional[str] = None
+
     def _assess_capture_quality(self, content: str) -> Dict[str, Any]:
         """The measured signals behind a capture-quality verdict.
 
@@ -5927,7 +5933,15 @@ class ContentExtractor:
         # MAX_CAPITALIZATION / MAX_UTILITY_WORD_RATE, from a sample that
         # excludes everything the gate let through.
         quality = self._assess_capture_quality(content)
+        marker = looks_like_paywall(content)
+        quality["paywall_marker"] = marker
+        quality["is_paywall"] = bool(marker)
         result.setdefault("metadata", {})["capture_quality"] = quality
+        if marker:
+            # The save path files this as status="paywall" and keeps the
+            # metadata the page did expose instead of storing the wall text.
+            result["metadata"]["capture_rejected_as"] = "paywall"
+            result["metadata"]["paywall_marker"] = marker
 
         if not content:
             self._last_capture_rejection = "empty"
@@ -5944,6 +5958,25 @@ class ContentExtractor:
         # set is_success -- but only ever to RECORD the failure, never to act on
         # it. Act on it: a body that is not writing is worth a browser.
         if not looks_like_article(content):
+            # A wall is a special case of "not writing": the site served a
+            # subscription prompt in place of the story. Selenium cannot beat
+            # it -- the same wall is served to a real browser -- so escalating
+            # costs a browser session (~3 min observed) and recovers nothing.
+            # File it as paywalled instead and keep whatever the page did give
+            # us (headline, byline, date live outside the wall).
+            paywall_marker = looks_like_paywall(content)
+            if paywall_marker:
+                self._last_capture_rejection = "paywall"
+                self._last_paywall_marker = paywall_marker
+                logger.info(
+                    "Capture for %s is a paywall prompt (%d chars, matched %r); "
+                    "not escalating -- a browser gets the same wall",
+                    result.get("url") or "?",
+                    len(content),
+                    paywall_marker,
+                )
+                return False
+
             self._last_capture_rejection = "not_article_like"
             logger.info(
                 "Capture for %s is not article-like (%d chars); escalating",

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -481,6 +481,7 @@ class NewsDiscovery:
         try:
             response = self.session.get(url, timeout=timeout, proxies=router_proxies)
             self._report_router_result(domain, router_proxy, success=True)
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
             return response
         except requests.exceptions.SSLError as e:
             logger.warning(
@@ -503,12 +504,37 @@ class NewsDiscovery:
                 url, timeout=timeout, proxies=router_proxies
             )
             self._report_router_result(domain, router_proxy, success=True)
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
             return response
         except requests.exceptions.RequestException as e:
             self._report_router_result(
                 domain, router_proxy, success=False, reason=str(e)[:200]
             )
             raise
+
+    def _note_capture_diagnosis(self, url: str, html: str | None) -> None:
+        """Record WHY a capture might yield nothing, for this source.
+
+        Kept advisory: the diagnosis is only consulted when the source ends up
+        with zero articles, so a page that parses fine is unaffected. Wrapped
+        because a diagnostic must never be able to fail a fetch.
+        """
+        try:
+            from src.utils.capture_diagnosis import diagnose_capture
+
+            diagnosis = diagnose_capture(html)
+            if diagnosis.is_blocked:
+                self._last_capture_diagnosis = diagnosis
+                logger.warning(
+                    "Capture for %s looks %s (anchors=%s, text_ratio=%s) -- "
+                    "zero links here is a block, not a quiet day",
+                    url,
+                    diagnosis.reason,
+                    diagnosis.signals.get("anchors"),
+                    diagnosis.signals.get("text_ratio"),
+                )
+        except Exception:
+            logger.debug("capture diagnosis failed for %s", url, exc_info=True)
 
     def _router_proxies_for_domain(self, domain: str):
         """Consult proxy_router for `domain`, degrading gracefully.

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -198,12 +198,34 @@ def _newspaper_build_worker(
             )
             urls = []
 
-        # Write URLs back to disk via pickle; best-effort
+        # Why did this homepage yield nothing? newspaper.build already
+        # downloaded it, so diagnose that capture here -- the parent never
+        # sees this HTML, and this is the main homepage discovery path.
+        diagnosis = None
+        if not urls:
+            try:
+                from src.utils.capture_diagnosis import diagnose_capture
+
+                page_html = getattr(locals().get("p", None), "html", None)
+                if page_html:
+                    d = diagnose_capture(page_html)
+                    if d.is_blocked:
+                        diagnosis = {"reason": d.reason, "signals": d.signals}
+            except Exception:
+                logger.debug(
+                    "capture diagnosis failed in worker for %s",
+                    target_url,
+                    exc_info=True,
+                )
+
+        # Write results back to disk via pickle; best-effort.
+        # Dict payload (was a bare list) so a diagnosis can ride along; the
+        # parent accepts both shapes so an in-flight worker cannot break it.
         try:
             import pickle as _pickle
 
             with open(out_path, "wb") as fh:
-                _pickle.dump(urls, fh)
+                _pickle.dump({"urls": urls, "diagnosis": diagnosis}, fh)
         except Exception as persist_err:
             # Best-effort persistence; ignore but log for diagnosis.
             logger.debug(
@@ -3064,7 +3086,26 @@ class NewsDiscovery:
                         import pickle as _pickle
 
                         with open(tmp_path, "rb") as fh:
-                            urls = _pickle.load(fh)
+                            payload = _pickle.load(fh)
+                        # Accepts the dict the worker now writes and the bare
+                        # list it used to, so a worker from an older image (or
+                        # one already in flight during a rollout) still parses.
+                        if isinstance(payload, dict):
+                            urls = payload.get("urls") or []
+                            worker_diagnosis = payload.get("diagnosis")
+                            if worker_diagnosis:
+                                self._last_capture_diagnosis_reason = (
+                                    worker_diagnosis.get("reason")
+                                )
+                                logger.warning(
+                                    "Homepage for %s looks %s (%s) -- zero links "
+                                    "here is a block, not a quiet day",
+                                    source_url,
+                                    worker_diagnosis.get("reason"),
+                                    worker_diagnosis.get("signals"),
+                                )
+                        else:
+                            urls = payload or []
                     except Exception:
                         urls = []
                     finally:

--- a/src/crawler/source_processing.py
+++ b/src/crawler/source_processing.py
@@ -2164,5 +2164,13 @@ class SourceProcessor:
         if stats["articles_expired"] > 0:
             return DiscoveryOutcome.EXPIRED_ONLY
         if stats["articles_found_total"] == 0:
+            # Zero links has three different causes with three different
+            # fixes. Report which one, when the fetch layer recorded a
+            # diagnosis; fall back to the old catch-all when it did not.
+            diagnosis = stats.get("capture_diagnosis")
+            if diagnosis == "paywall":
+                return DiscoveryOutcome.PAYWALL_BLOCKED
+            if diagnosis == "render_required":
+                return DiscoveryOutcome.RENDER_REQUIRED
             return DiscoveryOutcome.NO_ARTICLES_FOUND
         return DiscoveryOutcome.UNKNOWN_ERROR

--- a/src/utils/boilerplate.py
+++ b/src/utils/boilerplate.py
@@ -312,3 +312,85 @@ def looks_like_furniture(text: str) -> bool:
     if utility_word_rate(text) > MAX_UTILITY_WORD_RATE:
         return True
     return capitalization_ratio(text) > MAX_CAPITALIZATION
+
+
+# Paywall/registration prompts specifically, as opposed to the consent banners
+# and comment-policy blocks that BOILERPLATE_MARKERS also covers. Same
+# derivation discipline: phrase-level, because bare words like "subscribe"
+# occur inside real reporting ("subscribers to the service said...") while
+# whole prompts do not.
+#
+# Split out from BOILERPLATE_MARKERS because the two answer different
+# questions. That list asks "should this segment be stripped?"; this one asks
+# "is the page a wall instead of a story?" -- which decides whether a browser
+# would help (it would not; the wall is served to browsers too) and whether the
+# record should be filed as paywalled rather than retried.
+# Moved here verbatim from content_cleaner_balanced.py so the cleaner and the
+# capture gate read ONE list instead of drifting apart. The cleaner strips
+# these; note it deliberately includes newsletter asks ("subscribe to our
+# newsletter"), which are furniture but NOT walls -- a newsletter prompt sits
+# beside a readable story.
+SUBSCRIPTION_MARKERS: tuple[str, ...] = (
+    "subscribe to our newsletter",
+    "sign up for updates",
+    "get daily updates",
+    "subscribe now",
+    "join our mailing list",
+    "email updates",
+    "available in full to subscribers",
+    "this item is available in full to subscribers",
+    "to continue reading please log in or subscribe",
+    "to continue reading please login or subscribe",
+    "please log in to continue reading",
+    "please login to continue reading",
+    "need an account print subscribers",
+)
+
+# The wall-specific subset, plus prompts observed in production that the
+# stripping list does not carry (greenfieldvedette.com serves "This content is
+# for subscribers only"). Newsletter asks are excluded on purpose: they are
+# furniture on a readable page, not a wall in place of one.
+PAYWALL_MARKERS: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        (
+            "available in full to subscribers",
+            "this item is available in full to subscribers",
+            "to continue reading please log in or subscribe",
+            "to continue reading please login or subscribe",
+            "please log in to continue reading",
+            "please login to continue reading",
+            "need an account print subscribers",
+            # observed in production, absent from the stripping list
+            "this content is for subscribers only",
+            "login to continue reading",
+            "please log in to continue",
+            "sign up for complimentary access",
+            "click here to see your options for becoming a subscriber",
+            "otherwise, click here to view your options for subscribing",
+            "click here to start your free trial",
+            "subscribe to continue reading",
+            "to continue reading, please subscribe",
+            "start your free trial",
+            "for subscribers only",
+        )
+    )
+)
+
+
+def looks_like_paywall(text: str | None) -> str | None:
+    """The paywall prompt a body contains, or None.
+
+    Returns the matched phrase rather than a bool so callers can record WHICH
+    prompt fired -- the same reasoning as capture-quality telemetry: a verdict
+    you cannot audit is a verdict you cannot tune.
+
+    Matches on the raw body, NOT the stripped one: strip_boilerplate removes
+    these very phrases, so checking after the strip would find nothing.
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+    for marker in PAYWALL_MARKERS:
+        if marker in lowered:
+            return marker
+    return None

--- a/src/utils/capture_diagnosis.py
+++ b/src/utils/capture_diagnosis.py
@@ -1,0 +1,110 @@
+"""Why a page yielded no links: a wall, an unrendered shell, or nothing new.
+
+Discovery recorded all three as NO_ARTICLES_FOUND, so a blocked source looked
+exactly like a quiet one in telemetry. They need different responses --
+credentials, a browser, or nothing at all -- and you cannot choose without
+knowing which happened.
+
+Thresholds and prose measures come from boilerplate.py, the same module the
+content cleaner uses, so a retune moves both together instead of letting a
+second copy drift.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.utils.boilerplate import looks_like_paywall
+
+# Frameworks that ship an empty root element and fill it client-side. Presence
+# of one of these alongside almost no anchors is the signature of a page whose
+# links exist only after JavaScript runs.
+_SPA_ROOT_MARKERS: tuple[str, ...] = (
+    'id="root"',
+    "id='root'",
+    'id="__next"',
+    "id='__next'",
+    'id="__nuxt"',
+    "data-reactroot",
+    "ng-app",
+    'id="app"',
+    "id='app'",
+)
+
+_ANCHOR_RE = re.compile(r"<a\s[^>]*href", re.IGNORECASE)
+_SCRIPT_RE = re.compile(r"<script\b", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+# A homepage worth crawling carries many links. Below this, with an SPA marker
+# present, the page is a shell rather than a thin homepage.
+MAX_ANCHORS_FOR_SHELL = 5
+
+# Visible text as a share of raw HTML. A rendered page is mostly markup, but a
+# shell is almost entirely script: under this, there is nothing to parse.
+MIN_TEXT_RATIO_FOR_SHELL = 0.05
+
+
+@dataclass
+class CaptureDiagnosis:
+    """Why a capture produced no links, with the evidence behind the verdict."""
+
+    reason: str  # "paywall" | "render_required" | "no_new_links" | "empty"
+    signals: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_blocked(self) -> bool:
+        """Whether something stopped us seeing the page, as opposed to the
+        page genuinely having nothing new."""
+        return self.reason in {"paywall", "render_required"}
+
+
+def visible_text(html: str) -> str:
+    """Rough text content of a page. Not a parser -- enough to measure how
+    much of the capture is text rather than script."""
+    without_scripts = re.sub(
+        r"<script\b.*?</script>", " ", html, flags=re.IGNORECASE | re.DOTALL
+    )
+    without_styles = re.sub(
+        r"<style\b.*?</style>", " ", without_scripts, flags=re.IGNORECASE | re.DOTALL
+    )
+    return re.sub(r"\s+", " ", _TAG_RE.sub(" ", without_styles)).strip()
+
+
+def diagnose_capture(html: str | None, links_found: int = 0) -> CaptureDiagnosis:
+    """Classify a page capture that yielded no (or too few) links.
+
+    Order matters. A wall is checked first because a paywalled page is often
+    ALSO a thin one, and "we were refused" is the more actionable finding.
+    """
+    if not html or not html.strip():
+        return CaptureDiagnosis("empty", {"chars": 0})
+
+    text = visible_text(html)
+    anchors = len(_ANCHOR_RE.findall(html))
+    scripts = len(_SCRIPT_RE.findall(html))
+    text_ratio = (len(text) / len(html)) if html else 0.0
+    signals: dict[str, Any] = {
+        "chars": len(html),
+        "text_chars": len(text),
+        "text_ratio": round(text_ratio, 4),
+        "anchors": anchors,
+        "scripts": scripts,
+        "links_found": links_found,
+    }
+
+    marker = looks_like_paywall(text)
+    if marker:
+        signals["paywall_marker"] = marker
+        return CaptureDiagnosis("paywall", signals)
+
+    has_spa_root = any(m in html.lower() for m in _SPA_ROOT_MARKERS)
+    signals["spa_root"] = has_spa_root
+    if anchors <= MAX_ANCHORS_FOR_SHELL and (
+        has_spa_root or text_ratio < MIN_TEXT_RATIO_FOR_SHELL
+    ):
+        return CaptureDiagnosis("render_required", signals)
+
+    # The page rendered and carried links; they were simply not new/eligible.
+    return CaptureDiagnosis("no_new_links", signals)

--- a/src/utils/content_cleaner_balanced.py
+++ b/src/utils/content_cleaner_balanced.py
@@ -11,6 +11,7 @@ from typing import Any
 from sqlalchemy import text as sql_text
 
 from src.models.database import DatabaseManager, safe_session_execute
+from src.utils.boilerplate import SUBSCRIPTION_MARKERS as bp_SUBSCRIPTION_MARKERS
 from src.utils.boilerplate import is_boilerplate_segment as bp_is_boilerplate_segment
 from src.utils.boilerplate import segments as bp_segments
 
@@ -1835,21 +1836,9 @@ class BalancedBoundaryContentCleaner:
         ]
 
         # Subscription and newsletter patterns
-        subscription_patterns = [
-            "subscribe to our newsletter",
-            "sign up for updates",
-            "get daily updates",
-            "subscribe now",
-            "join our mailing list",
-            "email updates",
-            "available in full to subscribers",
-            "this item is available in full to subscribers",
-            "to continue reading please log in or subscribe",
-            "to continue reading please login or subscribe",
-            "please log in to continue reading",
-            "please login to continue reading",
-            "need an account print subscribers",
-        ]
+        # Shared with the capture-quality gate via boilerplate.py so the two
+        # cannot drift; contents unchanged by that move.
+        subscription_patterns = list(bp_SUBSCRIPTION_MARKERS)
 
         # Copyright and legal patterns
         copyright_patterns = [

--- a/src/utils/discovery_outcomes.py
+++ b/src/utils/discovery_outcomes.py
@@ -18,6 +18,14 @@ class DiscoveryOutcome(Enum):
     RSS_MISSING = "rss_missing"  # RSS unavailable
     CONTENT_BLOCKED = "content_blocked"  # Blocked content
 
+    # Zero links is not one condition. Until these existed, a homepage that
+    # served a subscription wall, one that shipped an empty JS shell, and one
+    # that genuinely had nothing new all recorded as NO_ARTICLES_FOUND -- so a
+    # blocked source was indistinguishable from a quiet one, and the fix for
+    # each is different (credentials / rendering / nothing).
+    PAYWALL_BLOCKED = "paywall_blocked"  # Wall served instead of the page
+    RENDER_REQUIRED = "render_required"  # JS shell; links need a browser
+
     # Technical failures
     HTTP_ERROR = "http_error"  # HTTP 4xx/5xx errors
     TIMEOUT = "timeout"  # Request timeout

--- a/tests/crawler/test_capture_diagnosis.py
+++ b/tests/crawler/test_capture_diagnosis.py
@@ -1,0 +1,156 @@
+"""Zero links must say WHY: a wall, an unrendered shell, or a quiet day.
+
+Discovery recorded all three as NO_ARTICLES_FOUND, so a blocked source was
+indistinguishable from one that simply published nothing. The three need
+different responses -- credentials, a browser, nothing -- and the telemetry
+has to tell them apart before anyone can choose.
+"""
+
+import pytest
+
+from src.utils.capture_diagnosis import (
+    MAX_ANCHORS_FOR_SHELL,
+    CaptureDiagnosis,
+    diagnose_capture,
+    visible_text,
+)
+from src.utils.discovery_outcomes import DiscoveryOutcome
+
+PAYWALL_HOMEPAGE = """<html><body>
+<nav>Home News Sports Obituaries</nav>
+<h1>Martin Crowned Homecoming Queen</h1><p>by Krista Guy</p>
+<p>This content is for subscribers only. Click here to start your Free Trial</p>
+</body></html>"""
+
+JS_SHELL = (
+    '<html><head><script src="/app.js"></script></head>'
+    '<body><div id="__next"></div><script>window.__DATA__={}</script></body></html>'
+)
+
+REAL_HOMEPAGE = (
+    "<html><body>"
+    + "".join(
+        f'<a href="/story-{i}">Council approves budget item {i}</a>'
+        f"<p>Reporting text for story {i} goes here.</p>"
+        for i in range(30)
+    )
+    + "</body></html>"
+)
+
+
+class TestDiagnosis:
+    def test_paywall_wall_is_named(self):
+        d = diagnose_capture(PAYWALL_HOMEPAGE)
+        assert d.reason == "paywall"
+        assert d.is_blocked is True
+        assert d.signals["paywall_marker"] == "this content is for subscribers only"
+
+    def test_js_shell_is_render_required(self):
+        d = diagnose_capture(JS_SHELL)
+        assert d.reason == "render_required"
+        assert d.is_blocked is True
+        assert d.signals["spa_root"] is True
+
+    def test_real_homepage_with_no_new_links_is_not_blocked(self):
+        """The case that must NOT be confused with a block."""
+        d = diagnose_capture(REAL_HOMEPAGE, links_found=0)
+        assert d.reason == "no_new_links"
+        assert d.is_blocked is False
+        assert d.signals["anchors"] == 30
+
+    def test_empty_capture(self):
+        for empty in (None, "", "   "):
+            d = diagnose_capture(empty)
+            assert d.reason == "empty"
+
+    def test_paywall_wins_over_shell(self):
+        """A wall is often also thin; being refused is the more useful fact."""
+        walled_shell = (
+            '<html><body><div id="root"></div>'
+            "<p>This content is for subscribers only.</p></body></html>"
+        )
+        assert diagnose_capture(walled_shell).reason == "paywall"
+
+    def test_thin_page_without_spa_marker_is_not_a_shell(self):
+        """A small but genuinely rendered page is not a render failure."""
+        thin = (
+            "<html><body><p>"
+            + ("The council met on Tuesday to review the budget. " * 40)
+            + '</p><a href="/one">One</a></body></html>'
+        )
+        d = diagnose_capture(thin)
+        assert d.reason == "no_new_links"
+        assert d.signals["anchors"] <= MAX_ANCHORS_FOR_SHELL
+
+    def test_signals_recorded_for_every_verdict(self):
+        """Evaluable, not trusted: the evidence travels with the verdict."""
+        for html in (PAYWALL_HOMEPAGE, JS_SHELL, REAL_HOMEPAGE):
+            s = diagnose_capture(html).signals
+            for key in ("chars", "text_chars", "text_ratio", "anchors", "scripts"):
+                assert key in s
+
+    def test_visible_text_drops_scripts_and_styles(self):
+        html = (
+            "<html><head><style>.a{color:red}</style></head>"
+            "<body><script>var x=1</script><p>Real words here</p></body></html>"
+        )
+        text = visible_text(html)
+        assert "Real words here" in text
+        assert "var x" not in text
+        assert "color:red" not in text
+
+
+class TestOutcomeMapping:
+    """The diagnosis has to reach the recorded outcome, or it changes nothing."""
+
+    @pytest.fixture
+    def processor(self):
+        from src.crawler.source_processing import SourceProcessor
+
+        return SourceProcessor.__new__(SourceProcessor)
+
+    def _stats(self, **over):
+        base = {
+            "articles_new": 0,
+            "articles_duplicate": 0,
+            "articles_expired": 0,
+            "articles_found_total": 0,
+        }
+        base.update(over)
+        return base
+
+    def test_paywall_diagnosis_maps_to_paywall_blocked(self, processor):
+        out = processor._determine_outcome(self._stats(capture_diagnosis="paywall"))
+        assert out == DiscoveryOutcome.PAYWALL_BLOCKED
+
+    def test_render_diagnosis_maps_to_render_required(self, processor):
+        out = processor._determine_outcome(
+            self._stats(capture_diagnosis="render_required")
+        )
+        assert out == DiscoveryOutcome.RENDER_REQUIRED
+
+    def test_no_diagnosis_keeps_the_old_outcome(self, processor):
+        """Absent a diagnosis, behaviour is unchanged -- no silent reclassification."""
+        assert processor._determine_outcome(self._stats()) == (
+            DiscoveryOutcome.NO_ARTICLES_FOUND
+        )
+
+    def test_diagnosis_ignored_when_articles_were_found(self, processor):
+        """A block recorded earlier must not override a successful result."""
+        out = processor._determine_outcome(
+            self._stats(articles_new=3, capture_diagnosis="paywall")
+        )
+        assert out == DiscoveryOutcome.NEW_ARTICLES_FOUND
+
+
+class TestDiagnosisNeverBreaksFetching:
+    def test_helper_swallows_failures(self):
+        """A diagnostic must never be able to fail a fetch."""
+        from src.crawler.discovery import NewsDiscovery
+
+        d = NewsDiscovery.__new__(NewsDiscovery)
+        # Passing a non-string is enough to blow up the regex path.
+        d._note_capture_diagnosis("https://example.com", object())  # must not raise
+
+    def test_dataclass_default_signals(self):
+        assert CaptureDiagnosis("empty").signals == {}

--- a/tests/crawler/test_capture_diagnosis.py
+++ b/tests/crawler/test_capture_diagnosis.py
@@ -154,3 +154,67 @@ class TestDiagnosisNeverBreaksFetching:
 
     def test_dataclass_default_signals(self):
         assert CaptureDiagnosis("empty").signals == {}
+
+
+class TestHomepagePathIsCovered:
+    """The newspaper.build worker is the PRIMARY homepage path.
+
+    It runs in a subprocess and returns only URLs, so the parent never sees
+    the homepage HTML. Diagnosing only the section/RSS fetches would leave
+    render_required systematically undercounted on exactly the pages the
+    signal exists to find -- so the worker diagnoses its own capture.
+    """
+
+    def _run_worker(self, tmp_path, monkeypatch, html, urls):
+        import pickle
+
+        import src.crawler.discovery as discovery_module
+
+        class FakeConfig:
+            def __init__(self):
+                self.fetch_images = False
+
+        class FakeArticle:
+            def __init__(self, url):
+                self.url = url
+
+        class FakePaper:
+            def __init__(self, urls, html):
+                self.articles = [FakeArticle(u) for u in urls]
+                self.html = html
+
+        monkeypatch.setattr(discovery_module, "Config", FakeConfig)
+        monkeypatch.setattr(
+            discovery_module, "build", lambda t, config: FakePaper(urls, html)
+        )
+        out = tmp_path / "out.pkl"
+        discovery_module._newspaper_build_worker("https://example.com", str(out), False)
+        with out.open("rb") as fh:
+            return pickle.load(fh)
+
+    def test_js_shell_homepage_is_diagnosed(self, tmp_path, monkeypatch):
+        payload = self._run_worker(tmp_path, monkeypatch, JS_SHELL, urls=[])
+
+        assert payload["urls"] == []
+        assert payload["diagnosis"]["reason"] == "render_required"
+        assert payload["diagnosis"]["signals"]["spa_root"] is True
+
+    def test_paywalled_homepage_is_diagnosed(self, tmp_path, monkeypatch):
+        payload = self._run_worker(tmp_path, monkeypatch, PAYWALL_HOMEPAGE, urls=[])
+
+        assert payload["diagnosis"]["reason"] == "paywall"
+
+    def test_quiet_homepage_gets_no_diagnosis(self, tmp_path, monkeypatch):
+        """A real page with nothing new must NOT be reported as blocked."""
+        payload = self._run_worker(tmp_path, monkeypatch, REAL_HOMEPAGE, urls=[])
+
+        assert payload["diagnosis"] is None
+
+    def test_successful_build_is_never_diagnosed(self, tmp_path, monkeypatch):
+        """Found links means not blocked, whatever the HTML looks like."""
+        payload = self._run_worker(
+            tmp_path, monkeypatch, JS_SHELL, urls=["https://example.com/a"]
+        )
+
+        assert payload["urls"] == ["https://example.com/a"]
+        assert payload["diagnosis"] is None

--- a/tests/crawler/test_discovery_coverage.py
+++ b/tests/crawler/test_discovery_coverage.py
@@ -990,8 +990,8 @@ def test_newspaper_build_worker_success(tmp_path):
             urls = pickle.load(f)
 
         assert len(urls) == 2
-        assert "https://example.com/article1" in urls
-        assert "https://example.com/article2" in urls
+        assert "https://example.com/article1" in urls["urls"]
+        assert "https://example.com/article2" in urls["urls"]
 
 
 def test_newspaper_build_worker_with_proxy(tmp_path):
@@ -1038,7 +1038,7 @@ def test_newspaper_build_worker_build_failure(tmp_path):
         with open(output_file, "rb") as f:
             urls = pickle.load(f)
 
-        assert urls == []
+        assert urls["urls"] == []
 
 
 def test_newspaper_build_worker_persist_failure(tmp_path):

--- a/tests/crawler/test_discovery_helpers.py
+++ b/tests/crawler/test_discovery_helpers.py
@@ -389,12 +389,16 @@ def test_newspaper_build_worker_writes_urls(
     )
 
     with out_file.open("rb") as fh:
-        urls = pickle.load(fh)
+        payload = pickle.load(fh)
 
-    assert urls == [
+    # Payload is a dict now so a capture diagnosis can ride along with the
+    # URLs; the parent still accepts the old bare-list form during a rollout.
+    assert payload["urls"] == [
         "https://example.com/a",
         "https://example.com/b",
     ]
+    # A build that produced URLs is not blocked, so no diagnosis is attached.
+    assert payload["diagnosis"] is None
     assert recorded == {
         "target": "https://example.com",
         "fetch_images": True,

--- a/tests/crawler/test_paywall_capture.py
+++ b/tests/crawler/test_paywall_capture.py
@@ -1,0 +1,153 @@
+"""A paywall wall is filed as paywalled, not retried and not stored as a body.
+
+Observed in production 2026-07-26: greenfieldvedette.com served 1,039 chars
+consisting of its nav menu, the headline, the byline, and "This content is for
+subscribers only." That cleared the 400-char stub threshold, so the old
+length-only gate accepted it and it would have been written to the corpus as an
+article whose body is furniture. The capture-quality gate rejected it, but then
+escalated to Selenium -- which spent ~3 minutes and recovered nothing, because
+the same wall is served to a real browser.
+
+So: recognise the wall, skip the browser, keep the metadata the page did expose
+(headline/byline/date live outside the wall), and drop the wall text.
+"""
+
+import pytest
+
+from src.crawler import ContentExtractor
+from src.utils.boilerplate import (
+    PAYWALL_MARKERS,
+    SUBSCRIPTION_MARKERS,
+    looks_like_paywall,
+)
+
+# The real capture, trimmed. Keeping it verbatim matters: it is the evidence
+# that a wall can be long enough to pass a length check.
+GREENFIELD_WALL = (
+    "Home Categories Business Columns Featured Letter to Editor Local News "
+    "News Obituaries Photo Galleries Schools Sports Calendar Special Pages "
+    "GREENFIELD VEDETTE LAKE STOCKTON SHOPPER SUBSCRIBE SUBSCRIBE LOGIN LOGIN "
+    "Login with Facebook Martin Crowned Miller Football Homecoming Queen "
+    "by Krista Guy "
+    "This content is for subscribers only. Log in or sign up for a free trial "
+    "below. Click here to start your Free Trial (No credit card required)"
+)
+
+REAL_ARTICLE = (
+    "The city council voted Tuesday to approve the new budget after a lengthy "
+    "public hearing that drew more than fifty residents to the chamber. "
+    "Council members said the plan preserves funding for the library and the "
+    "fire department while trimming administrative costs. The measure passed "
+    "on a five to two vote and takes effect in July. Opponents argued the "
+    "increase in fees would fall hardest on renters, and asked the council "
+    "to revisit the proposal in the fall when revenue figures are final. "
+    "The city manager said the budget reflects three months of review by "
+    "department heads and a citizens advisory panel that met weekly. "
+)
+
+
+@pytest.fixture
+def extractor():
+    ex = ContentExtractor.__new__(ContentExtractor)
+    ex.PAYWALL_STUB_MAX_CHARS = ContentExtractor.PAYWALL_STUB_MAX_CHARS
+    return ex
+
+
+class TestPaywallDetection:
+    def test_detects_the_real_greenfield_wall(self):
+        assert looks_like_paywall(GREENFIELD_WALL) == (
+            "this content is for subscribers only"
+        )
+
+    def test_real_article_is_not_a_paywall(self):
+        assert looks_like_paywall(REAL_ARTICLE) is None
+
+    def test_prose_mentioning_subscribers_is_not_a_paywall(self):
+        """Phrase-level matching: bare words appear inside real reporting."""
+        assert (
+            looks_like_paywall(
+                "Subscribers to the streaming service said prices rose again, "
+                "and the company confirmed it will not offer refunds."
+            )
+            is None
+        )
+
+    def test_newsletter_ask_is_not_a_wall(self):
+        """A newsletter prompt is furniture beside a story, not a wall
+        replacing one -- it must not trigger the paywall path."""
+        assert looks_like_paywall("Subscribe to our newsletter for updates.") is None
+
+    def test_empty_and_none_are_safe(self):
+        assert looks_like_paywall(None) is None
+        assert looks_like_paywall("") is None
+
+    def test_markers_are_shared_not_duplicated(self):
+        """The cleaner and the gate must read one list, not two that drift.
+
+        Every wall phrase the cleaner strips should also be recognised as a
+        wall here; PAYWALL_MARKERS additionally carries prompts observed in
+        production that the stripping list lacks.
+        """
+        shared = {
+            "this item is available in full to subscribers",
+            "please log in to continue reading",
+        }
+        assert shared <= set(SUBSCRIPTION_MARKERS)
+        assert shared <= set(PAYWALL_MARKERS)
+        # Newsletter asks belong to the cleaner's list only.
+        assert "subscribe to our newsletter" in SUBSCRIPTION_MARKERS
+        assert "subscribe to our newsletter" not in PAYWALL_MARKERS
+
+
+class TestPaywallSkipsSelenium:
+    def test_wall_does_not_escalate(self, extractor):
+        """The core saving: a browser gets the same wall, so do not spend one."""
+        result = {"content": GREENFIELD_WALL, "url": "https://gv.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["publish_date"]) is False
+        assert extractor._last_capture_rejection == "paywall"
+        assert extractor._last_paywall_marker == (
+            "this content is for subscribers only"
+        )
+
+    def test_wall_is_flagged_for_the_save_path(self, extractor):
+        result = {"content": GREENFIELD_WALL, "url": "https://gv.com/story"}
+
+        extractor._selenium_would_add_value(result, ["publish_date"])
+
+        meta = result["metadata"]
+        assert meta["capture_rejected_as"] == "paywall"
+        assert meta["paywall_marker"] == "this content is for subscribers only"
+        assert meta["capture_quality"]["is_paywall"] is True
+
+    def test_non_paywall_junk_still_escalates(self, extractor):
+        """Only walls skip the browser. Other non-article captures (a nav dump,
+        a JS shell) may still be recoverable by rendering, so they escalate."""
+        nav_dump = (
+            "Home News Sports Obituaries Classifieds Weather Opinion Business "
+            "Living Calendar Contact Us Advertise Newsletters Archives Jobs "
+        ) * 6
+        result = {"content": nav_dump, "url": "https://example.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["author"]) is True
+        assert extractor._last_capture_rejection == "not_article_like"
+
+    def test_real_article_unaffected(self, extractor):
+        result = {"content": REAL_ARTICLE, "url": "https://example.com/story"}
+
+        assert extractor._selenium_would_add_value(result, ["author"]) is False
+        assert extractor._last_capture_rejection is None
+        assert result["metadata"]["capture_quality"]["is_paywall"] is False
+
+    def test_quality_signals_recorded_for_walls_too(self, extractor):
+        """Walls are judged by the same measured signals as everything else,
+        so the marker list can be audited rather than trusted."""
+        result = {"content": GREENFIELD_WALL, "url": "https://gv.com/story"}
+
+        extractor._selenium_would_add_value(result, ["publish_date"])
+
+        q = result["metadata"]["capture_quality"]
+        assert q["article_like"] is False
+        assert "prose_density" in q
+        assert "capitalization_ratio" in q
+        assert "utility_word_rate" in q

--- a/tests/crawler/test_section_wire_filtering.py
+++ b/tests/crawler/test_section_wire_filtering.py
@@ -391,7 +391,7 @@ def test_newspaper_build_worker_writes_urls(
     with out_file.open("rb") as fh:
         urls = pickle.load(fh)
 
-    assert urls == [
+    assert urls["urls"] == [
         "https://example.com/a",
         "https://example.com/b",
     ]


### PR DESCRIPTION
Two findings from the post-merge validation run. Both are cases of the pipeline recording the **wrong thing** rather than failing — which is why neither showed up as an error.

## 1. Paywall walls were being stored as articles

`greenfieldvedette.com` served 1,039 characters: its nav menu, the headline, the byline, and *"This content is for subscribers only."* No story.

That clears the 400-char stub threshold, so the length-only gate accepted it — and it would have been written to the corpus as an article whose body is furniture. The capture-quality gate did reject it, then **escalated to Selenium**, which spent ~3 minutes and recovered nothing, because the same wall is served to a real browser.

Now: recognise the wall, **skip the browser**, file it as `status="paywall"`, and keep what the page did expose. Headline, byline and date sit outside the wall, so they're saved; only the wall text is dropped as a body.

**One shared marker list, not two.** `content_cleaner_balanced.py`'s inline `subscription_patterns` moved into `boilerplate.py` verbatim (cleaning behaviour unchanged) and is imported from there, with `PAYWALL_MARKERS` as the wall-specific subset. Newsletter asks stay out of the paywall list on purpose — *"subscribe to our newsletter"* is furniture beside a readable story, not a wall replacing one.

> Caught while writing the tests: emptying the body sent the record into the *"insufficient content, no paywall indicators"* branch, which **skips the save** — losing exactly the metadata this set out to keep. The gate verdict now feeds `has_paywall_patterns` so the save fires.

## 2. Discovery: zero links now says *why*

`_determine_outcome()` collapsed every zero-article source into `NO_ARTICLES_FOUND`. So a homepage serving a subscription wall, one shipping an empty JS shell, and one that genuinely published nothing were **indistinguishable** — although the fix for each is different: credentials, rendering, or nothing at all.

| capture | outcome | what it means |
|---|---|---|
| subscription wall | `PAYWALL_BLOCKED` | needs credentials |
| SPA root, ~no anchors, ~0 text ratio | `RENDER_REQUIRED` | needs a browser |
| real page, nothing new | `NO_ARTICLES_FOUND` | genuinely quiet |

Thresholds and prose measures come from `boilerplate.py`, so a retune moves the cleaner and the gate together. Signals travel with every verdict, so the heuristic can be **audited rather than trusted**.

Wired advisory-only: consulted just when a source ends up with zero articles; absent a diagnosis, behaviour is unchanged; and the helper swallows its own failures — a diagnostic must never fail a fetch.

### Coverage note (second commit)

The diagnosis initially ran only in `_fetch_with_ssl_fallback` — section pages and RSS. But the **primary homepage link discovery** is `_newspaper_build_worker`, a subprocess that runs `newspaper.build()` and returns only URLs, never the HTML. So the main homepage path produced no diagnosis at all, and `render_required` would have systematically undercounted exactly the pages the signal exists to find.

The worker now diagnoses the capture it already downloaded (`Source.html`), but only when the build yielded no URLs — found links means not blocked, whatever the markup looks like. Its pickle payload changed from a bare list to `{"urls": [...], "diagnosis": ...}`; the parent accepts **both** shapes so a worker from an older image, or one already in flight during a rollout, still parses.

### How `render_required` is decided

| signal | shell | real homepage |
|---|---|---|
| `<a href` count | ≤ 5 | ~30+ |
| SPA root marker (`id="root"`, `id="__next"`, `id="__nuxt"`, `data-reactroot`, `ng-app`, `id="app"`) | present | absent |
| text ratio (visible text ÷ raw HTML, scripts/styles stripped) | < 0.05 | ~0.6 |

Verdict is `render_required` when **anchors ≤ 5 AND (SPA marker OR text ratio < 5%)**. Paywall is tested first: a wall is often also thin, and being refused is the more actionable fact.

**Two caveats on reading the numbers.** The thresholds are reasoned, not derived — unlike `BOILERPLATE_MARKERS`, which came from diffing 15,656 hand-cleaned articles. Signals are recorded on every verdict precisely so they can be checked against reality and moved. And this catches *framework* SPAs: a site rendering links via vanilla JS with no root marker is caught only if its text ratio is very low, and one that server-renders some links but loads articles client-side reads as `no_new_links`. **Treat the count as a floor, not a total.**

## This is deliberately a diagnostic PR

**Discovery cannot render JavaScript at all.** Verified: no Xvfb wrapper, no driver, no browser env in the discovery job. The "chrome" references in `discovery.py` are user-agent strings and a cloudscraper *profile*; cloudscraper solves Cloudflare's JS challenge but never executes page JS. `SELENIUM_PROXY` is read only to borrow the proxy URL for a plain `requests` call.

So a JS-gated homepage yields **zero** articles from that source, permanently. That is not a marginal loss like the extraction author-backfill case — it is a source producing nothing.

I did **not** add browser rendering to discovery in this PR, because the right shape depends on scope we don't yet have. ~157 sources per run makes a blanket browser-per-blocked-homepage the same cost profile the `_selenium_would_add_value` work cut by ~67%. After this deploys, the answer is one query:

```sql
SELECT source_name, COUNT(*) FROM discovery_outcomes
WHERE outcome = 'render_required'
GROUP BY 1 ORDER BY 2 DESC;
```

If that's 3 sources, it's a targeted fix (render their homepage on a cadence, reusing extraction's existing headful stack). If it's 40, it's an architectural decision. Either way it should be made with the number in hand.

## Test plan
- [x] 29 new tests: `test_paywall_capture.py` (11), `test_capture_diagnosis.py` (18)
- [x] Both include the non-golden paths: prose that merely *mentions* subscribers, newsletter asks, walls that are also shells, thin-but-rendered pages, diagnosis-absent fallback, and a diagnostic that throws
- [x] Full suite **2865 passed**
- [x] mypy strict, black, flake8 clean
- [x] Pre-push gate green (incl. Postgres suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
