### PR TITLE
Fix update-versions-env: it reported success while updating nothing

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -623,7 +623,22 @@ jobs:
 
   update-versions-env:
     name: Update versions.env
-    needs: [detect-changes, wait-for-builds]
+    # The build-* jobs must be listed here, not just reached transitively via
+    # wait-for-builds: the `needs` context contains ONLY direct dependencies,
+    # so `needs.build-crawler.outputs.build_id` resolved to empty and this job
+    # reported success while updating nothing. k8s/versions.env consequently
+    # went un-updated from 2026-04-03 until this fix, leaving the committed
+    # tags months behind what is actually deployed.
+    needs:
+      [
+        detect-changes,
+        wait-for-builds,
+        build-base,
+        build-ml-base,
+        build-processor,
+        build-api,
+        build-crawler,
+      ]
     if: >-
       github.ref == 'refs/heads/main' &&
       (
@@ -666,8 +681,15 @@ jobs:
           if [ -n "$CRAWLER_BUILD_ID" ]; then ARGS+=(--crawler "$SHORT"); fi
           if [ -n "$API_BUILD_ID" ]; then ARGS+=(--api "$SHORT"); fi
           if [ ${#ARGS[@]} -eq 0 ]; then
-            echo "No services requested a versions update"
-            exit 0
+            # This job's `if:` already established that at least one build ran,
+            # so reaching here means the build IDs did not resolve -- the exact
+            # silent no-op that left versions.env stale for ~4 months. Fail
+            # loudly rather than report success while doing nothing.
+            echo "::error::Build IDs did not resolve despite this job being" \
+                 "triggered by a build. Check that every build-* job is listed" \
+                 "in this job's needs: -- the needs context only exposes direct" \
+                 "dependencies, so transitive access via wait-for-builds is empty."
+            exit 1
           fi
           ./scripts/update-versions-env.sh "${ARGS[@]}"
           if git diff --quiet k8s/versions.env k8s/argo/base-pipeline-workflow.yaml; then

--- a/k8s/versions.env
+++ b/k8s/versions.env
@@ -1,5 +1,11 @@
 # Image versions for Kubernetes manifests
 # Source this file before running envsubst
-export PROCESSOR_TAG=dcc138e
-export CRAWLER_TAG=dcc138e
-export API_TAG=dcc138e
+#
+# Maintained by the update-versions-env job in build-and-deploy-services.yml.
+# That job silently no-opped from 2026-04-03 until 2026-07-26 (it read build
+# IDs from jobs it did not declare in `needs:`, so they were always empty),
+# which left these tags months behind what was actually deployed. Values below
+# were reconciled by hand against the live cluster at the time of that fix.
+export PROCESSOR_TAG=613a942
+export CRAWLER_TAG=2bba720
+export API_TAG=2bba720


### PR DESCRIPTION
## The bug

`update-versions-env` reads build IDs from jobs it does not declare in `needs:`:

```yaml
needs: [detect-changes, wait-for-builds]     # build-* jobs absent
env:
  CRAWLER_BUILD_ID: ${{ needs.build-crawler.outputs.build_id }}
```

The `needs` context exposes only **direct** dependencies. `wait-for-builds` depends on all five build jobs, but that does not propagate — so every build ID resolved to empty, the script hit its own guard, and the job exited 0 having done nothing:

```
SHORT_SHA: 2bba7202...
PROCESSOR_BUILD_ID:      ← empty
API_BUILD_ID:            ← empty
CRAWLER_BUILD_ID:        ← empty
No services requested a versions update
```

It reported **success** every time, which is why it went unnoticed.

## Impact — narrower than it looks, but real

`k8s/versions.env` was last updated **2026-04-03**, by a hand-written commit. Every automated build since left it stale.

- **Deploys were unaffected.** Cloud Build triggers apply the real tags directly; the live template correctly ran `crawler:2bba720`.
- **The repo lied about what is deployed.** `versions.env` and the committed Argo template both said `dcc138e` — four months behind. Anyone using `versions.env` for its stated purpose (sourcing it for `envsubst` on a manual apply) would have deployed a months-old image.

## Fixes

1. **Declare the `build-*` jobs in `needs:`.** Safe: they carry no `if:`, so they always run and emit an empty `build_id` when nothing was triggered — adding them cannot cause skip-propagation.
2. **Fail loudly if the IDs still do not resolve.** The job's `if:` has already established that a build ran, so an empty set now means the wiring broke again. Reporting success while doing nothing is the failure mode that hid this for four months.
3. **Reconcile `versions.env` by hand** against the live cluster (`crawler`/`api` `2bba720`, `processor` `613a942` — the latter was not rebuilt in the last run). Without this it would stay stale, because a workflow-only change rebuilds no service and so triggers no update.

## Audit

Checked every workflow for the same bug class — references to `needs.<job>` where `<job>` is not declared:

```
No undeclared `needs` references anywhere.
```

(One apparent hit was a false positive in my checker: `build-base` declares `needs` as a string, not a list.)

## Test plan

- [x] YAML validates; `update-versions-env` now declares all five build jobs
- [x] Confirmed build jobs have no `if:`, so `needs:` cannot skip-propagate
- [x] Repo-wide audit for undeclared `needs` references — clean
- [ ] Real proof is the next merge to `main` that rebuilds a service: `versions.env` should receive a `chore: update image tags (<sha>) [skip ci]` commit. If the wiring is still wrong, the job now fails instead of passing silently.

## Note

This does not change how images are deployed — only what the repo records about them. Related: the live Argo template was separately found stale (missing `MIZZOU_SQUID_PROXY_URL`, and carrying a superseded 10-worker cap instead of 2). That is the template *application* path rather than this file, and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)