### PR TITLE
Apply the Argo template from the repo, not by editing the cluster's copy

### DIFF
--- a/gcp/cloudbuild/update-workflow-template.sh
+++ b/gcp/cloudbuild/update-workflow-template.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
-# Shared script for updating Argo WorkflowTemplate after service deployments
-# Usage: ./shared-post-deploy.sh <service-type> <sha> <registry>
-# Example: ./shared-post-deploy.sh crawler 05f0c40 us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler
+# Apply the Argo WorkflowTemplate FROM THE REPO, with image tags substituted.
+#
+# Usage: ./update-workflow-template.sh <service-type> <sha> [registry]
+# Example: ./update-workflow-template.sh crawler 05f0c40
+#
+# This script used to read the LIVE template out of the cluster, rewrite only
+# its image tags, and push it back -- so nothing else in
+# k8s/argo/base-pipeline-workflow.yaml could ever reach production. The cluster
+# copy was seeded once by hand and drifted from the repo indefinitely: on
+# 2026-07-26 it still carried an extraction-worker cap of 10 (superseded months
+# earlier by 702cd559) and lacked the MIZZOU_SQUID_PROXY_URL env from #416, so
+# the second proxy was unreachable and a validation run spawned 10 workers
+# instead of 2. Both changes were correct in the repo and had never been
+# applied.
+#
+# The rendering logic lives in scripts/render_workflow_template.py so it can be
+# unit tested -- it decides what production runs.
 
 set -euo pipefail
 
 SERVICE_TYPE="${1:-}"
 NEW_SHA="${2:-}"
-REGISTRY="${3:-us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler}"
+# Registry is accepted for backwards compatibility with existing callers; the
+# template carries fully-qualified image references, so only the tag changes.
+REGISTRY="${3:-}"
+TEMPLATE_PATH="${TEMPLATE_PATH:-k8s/argo/base-pipeline-workflow.yaml}"
 
 if [ -z "$SERVICE_TYPE" ] || [ -z "$NEW_SHA" ]; then
   echo "❌ Usage: $0 <service-type> <sha> [registry]"
@@ -16,81 +33,10 @@ fi
 
 echo "📦 Service: $SERVICE_TYPE"
 echo "🏷️  SHA: $NEW_SHA"
-echo "🔄 Updating Argo WorkflowTemplate..."
+echo "📄 Source of truth: $TEMPLATE_PATH"
+echo "🔄 Applying Argo WorkflowTemplate from repo..."
 
-# Export variables for Python script
-export SERVICE_TYPE
-export NEW_SHA
-export REGISTRY
+python3 scripts/render_workflow_template.py \
+  "$SERVICE_TYPE" "$NEW_SHA" --template "$TEMPLATE_PATH"
 
-# Use Python to update the workflow template
-python3 - << 'PYTHON_EOF'
-import subprocess, json, sys, os
-
-# Prefer environment variables for robustness
-service_type = os.environ.get('SERVICE_TYPE', '')
-new_sha = os.environ.get('NEW_SHA', '')
-registry = os.environ.get('REGISTRY', 'us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler')
-
-if not service_type or not new_sha:
-    print("❌ Missing SERVICE_TYPE or NEW_SHA")
-    sys.exit(1)
-
-print(f"Updating {service_type} images to {new_sha}...")
-
-# Get the workflow template
-try:
-    result = subprocess.run(
-        ["kubectl", "get", "workflowtemplate", "news-pipeline-template", "-n", "production", "-o", "json"],
-        capture_output=True, text=True, check=True
-    )
-    wf = json.loads(result.stdout)
-except subprocess.CalledProcessError as e:
-    print(f"❌ Failed to get workflow template: {e.stderr}")
-    sys.exit(1)
-
-# Update images based on service type
-updated_count = 0
-for template in wf['spec']['templates']:
-    if 'container' in template and 'image' in template['container']:
-        img = template['container']['image']
-
-        # Update crawler images
-        if service_type == 'crawler' and f'{service_type}:' in img:
-            new_image = f"{registry}/crawler:{new_sha}"
-            template['container']['image'] = new_image
-            print(f"  ✓ Updated {template['name']}: {new_image}")
-            updated_count += 1
-
-        # Update processor images
-        elif service_type == 'processor' and f'{service_type}:' in img:
-            new_image = f"{registry}/processor:{new_sha}"
-            template['container']['image'] = new_image
-            print(f"  ✓ Updated {template['name']}: {new_image}")
-            updated_count += 1
-
-if updated_count == 0:
-    print(f"⚠️  No {service_type} images found in workflow template")
-    sys.exit(0)
-
-# Apply the updated workflow
-try:
-    proc = subprocess.Popen(
-        ["kubectl", "apply", "-f", "-"],
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-    )
-    stdout, stderr = proc.communicate(json.dumps(wf))
-
-    if proc.returncode != 0:
-        print(f"❌ Failed to apply workflow template: {stderr}")
-        sys.exit(1)
-
-    print(stdout)
-    print(f"✅ Updated {updated_count} workflow templates with {service_type}:{new_sha}")
-except Exception as e:
-    print(f"❌ Error applying workflow: {e}")
-    sys.exit(1)
-PYTHON_EOF
-
-echo "✅ Argo WorkflowTemplate updated successfully"
-echo "   Next workflow run will use ${SERVICE_TYPE}:${NEW_SHA}"
+echo "✅ Argo WorkflowTemplate now matches the repo, with ${SERVICE_TYPE}:${NEW_SHA}"

--- a/scripts/render_workflow_template.py
+++ b/scripts/render_workflow_template.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Render the Argo WorkflowTemplate from the repo with image tags applied.
+
+Deploys used to read the LIVE template out of the cluster, rewrite only its
+image tags, and push it back -- so nothing else in
+k8s/argo/base-pipeline-workflow.yaml could ever reach production. The cluster
+copy was seeded once by hand and drifted from the repo indefinitely: on
+2026-07-26 it still carried an extraction-worker cap of 10 (superseded months
+earlier by 702cd559) and lacked the MIZZOU_SQUID_PROXY_URL env from #416, so
+the second proxy was unreachable and a run spawned 10 workers instead of 2.
+
+The rendering lives here, rather than in a shell heredoc, so it can be tested:
+this decides what production runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+KNOWN_SERVICES: tuple[str, ...] = ("crawler", "processor", "api")
+
+DEFAULT_TEMPLATE = "k8s/argo/base-pipeline-workflow.yaml"
+TEMPLATE_NAME = "news-pipeline-template"
+NAMESPACE = "production"
+
+
+def parse_live_tags(template_json: str) -> dict[str, str]:
+    """Image tags in a live WorkflowTemplate, keyed by service."""
+    tags: dict[str, str] = {}
+    try:
+        doc = json.loads(template_json)
+    except (ValueError, TypeError):
+        return tags
+    for tmpl in doc.get("spec", {}).get("templates", []):
+        image = (tmpl.get("container") or {}).get("image", "")
+        match = re.search(r"/([a-z-]+):([\w.-]+)$", image)
+        if match and match.group(1) in KNOWN_SERVICES:
+            tags[match.group(1)] = match.group(2)
+    return tags
+
+
+def apply_tags(
+    rendered: str, service_type: str, new_sha: str, live_tags: dict[str, str]
+) -> tuple[str, dict[str, tuple[str, int]]]:
+    """Substitute image tags into the repo template.
+
+    The service being deployed takes this build's SHA; every other service
+    keeps the tag it is currently running, so a crawler deploy cannot roll the
+    processor back to whatever tag the repo file happens to carry (those are
+    maintained by a separate job that lagged for months). A service that is
+    neither built here nor live keeps the repo's own value.
+    """
+    applied: dict[str, tuple[str, int]] = {}
+    for svc in KNOWN_SERVICES:
+        tag = new_sha if svc == service_type else live_tags.get(svc)
+        if not tag:
+            continue
+        pattern = re.compile(rf"(image:\s*\S*/{svc}):[\w.-]+")
+        rendered, count = pattern.subn(rf"\g<1>:{tag}", rendered)
+        if count:
+            applied[svc] = (tag, count)
+    return rendered, applied
+
+
+def fetch_live_tags() -> dict[str, str]:
+    try:
+        out = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "workflowtemplate",
+                TEMPLATE_NAME,
+                "-n",
+                NAMESPACE,
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        print(
+            f"ℹ️  No live template to read ({detail.strip()[:120]}); using repo tags."
+        )
+        return {}
+    return parse_live_tags(out)
+
+
+def kubectl_apply(rendered: str, dry_run: bool) -> tuple[int, str, str]:
+    cmd = ["kubectl", "apply", "-f", "-"]
+    if dry_run:
+        cmd.append("--dry-run=server")
+    proc = subprocess.run(cmd, input=rendered, capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("service_type", help="crawler | processor | api")
+    parser.add_argument("sha", help="image tag produced by this build")
+    parser.add_argument("--template", default=DEFAULT_TEMPLATE)
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="render and print without touching the cluster",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.template) as fh:
+            rendered = fh.read()
+    except OSError as exc:
+        print(f"❌ Cannot read {args.template}: {exc}")
+        print("   Run from the repository root (the Cloud Build workspace).")
+        return 1
+
+    live = {} if args.print_only else fetch_live_tags()
+    if live:
+        print(
+            "   Currently live: "
+            + ", ".join(f"{k}:{v}" for k, v in sorted(live.items()))
+        )
+
+    rendered, applied = apply_tags(rendered, args.service_type, args.sha, live)
+    if not applied:
+        print("⚠️  No image references substituted; applying repo file as-is.")
+    for svc, (tag, count) in sorted(applied.items()):
+        marker = " (this build)" if svc == args.service_type else " (preserved)"
+        print(f"  ✓ {svc}:{tag} x{count}{marker}")
+
+    if args.print_only:
+        print(rendered)
+        return 0
+
+    # Validate server-side first: a malformed template must fail the build
+    # rather than half-apply to production.
+    for dry_run in (True, False):
+        code, out, err = kubectl_apply(rendered, dry_run=dry_run)
+        if code != 0:
+            stage = "validation" if dry_run else "apply"
+            print(f"❌ Template {stage} failed:\n{err}")
+            return 1
+        print(out.strip())
+
+    print(f"✅ WorkflowTemplate applied from {args.template}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/deploy/test_render_workflow_template.py
+++ b/tests/deploy/test_render_workflow_template.py
@@ -1,0 +1,185 @@
+"""The deploy must apply the repo's template, not re-edit the cluster's copy.
+
+Deploys used to read the live WorkflowTemplate, change only its image tags,
+and write it back. Everything else in k8s/argo/base-pipeline-workflow.yaml was
+therefore unreachable: the cluster copy was seeded by hand and drifted
+indefinitely. On 2026-07-26 it still carried an extraction-worker cap of 10 --
+superseded months earlier -- and lacked MIZZOU_SQUID_PROXY_URL, so the second
+proxy was unreachable and a validation run spawned 10 workers instead of 2.
+
+These tests pin the two properties that matter: repo content reaches the
+cluster, and a deploy of one service never rolls another one back.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+from scripts.render_workflow_template import (
+    KNOWN_SERVICES,
+    apply_tags,
+    main,
+    parse_live_tags,
+)
+
+REPO_TEMPLATE = pathlib.Path("k8s/argo/base-pipeline-workflow.yaml")
+
+TEMPLATE_SNIPPET = """\
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+spec:
+  templates:
+    - name: discovery-step
+      container:
+        image: us-central1-docker.pkg.dev/proj/repo/crawler:OLD
+        env:
+          - name: MIZZOU_SQUID_PROXY_URL
+            value: keep-me
+    - name: extraction-step
+      container:
+        image: us-central1-docker.pkg.dev/proj/repo/crawler:OLD
+    - name: wait-for-candidates
+      container:
+        image: us-central1-docker.pkg.dev/proj/repo/processor:OLD
+"""
+
+LIVE_JSON = """{
+  "spec": {"templates": [
+    {"container": {"image": "us-central1-docker.pkg.dev/proj/repo/crawler:LIVECRAWL"}},
+    {"container": {"image": "us-central1-docker.pkg.dev/proj/repo/processor:LIVEPROC"}}
+  ]}
+}"""
+
+
+class TestParseLiveTags:
+    def test_reads_tags_per_service(self):
+        assert parse_live_tags(LIVE_JSON) == {
+            "crawler": "LIVECRAWL",
+            "processor": "LIVEPROC",
+        }
+
+    def test_malformed_json_is_not_fatal(self):
+        """A cluster read that returns junk must not break the deploy."""
+        assert parse_live_tags("not json") == {}
+        assert parse_live_tags("") == {}
+
+    def test_ignores_unknown_services(self):
+        other = '{"spec":{"templates":[{"container":{"image":"reg/redis:7"}}]}}'
+        assert parse_live_tags(other) == {}
+
+
+class TestApplyTags:
+    def test_deployed_service_gets_this_builds_sha(self):
+        out, applied = apply_tags(TEMPLATE_SNIPPET, "crawler", "NEWSHA", {})
+        assert "crawler:NEWSHA" in out
+        assert applied["crawler"] == ("NEWSHA", 2)
+
+    def test_other_services_keep_their_live_tag(self):
+        """A crawler deploy must not roll the processor back to the repo's
+        tag -- those lag, because a separate job maintains them."""
+        out, applied = apply_tags(
+            TEMPLATE_SNIPPET, "crawler", "NEWSHA", {"processor": "LIVEPROC"}
+        )
+        assert "processor:LIVEPROC" in out
+        assert "processor:OLD" not in out
+        assert applied["processor"] == ("LIVEPROC", 1)
+
+    def test_service_neither_built_nor_live_keeps_repo_value(self):
+        out, applied = apply_tags(TEMPLATE_SNIPPET, "crawler", "NEWSHA", {})
+        assert "processor:OLD" in out
+        assert "processor" not in applied
+
+    def test_repo_content_survives_substitution(self):
+        """THE regression: everything other than tags must reach the cluster."""
+        out, _ = apply_tags(TEMPLATE_SNIPPET, "crawler", "NEWSHA", {})
+        assert "MIZZOU_SQUID_PROXY_URL" in out
+        assert "keep-me" in out
+
+    def test_output_is_still_valid_yaml(self):
+        out, _ = apply_tags(TEMPLATE_SNIPPET, "crawler", "NEWSHA", {})
+        doc = yaml.safe_load(out)
+        assert doc["kind"] == "WorkflowTemplate"
+
+    def test_unknown_service_substitutes_nothing(self):
+        out, applied = apply_tags(TEMPLATE_SNIPPET, "nosuch", "NEWSHA", {})
+        assert applied == {}
+        assert out == TEMPLATE_SNIPPET
+
+
+@pytest.mark.skipif(not REPO_TEMPLATE.exists(), reason="repo template not present")
+class TestAgainstTheRealTemplate:
+    """Guard the specific content that was found missing in production."""
+
+    def test_real_template_renders_and_keeps_its_content(self):
+        rendered, applied = apply_tags(
+            REPO_TEMPLATE.read_text(),
+            "crawler",
+            "abc1234",
+            {"processor": "613a942"},
+        )
+
+        assert applied["crawler"][0] == "abc1234"
+        assert applied["processor"][0] == "613a942"
+        # The two settings that had silently failed to reach production.
+        assert rendered.count("MIZZOU_SQUID_PROXY_URL") >= 1
+        assert "min(2, max(2" in rendered
+        assert all(
+            isinstance(d, (dict, type(None))) for d in yaml.safe_load_all(rendered)
+        )
+
+    def test_every_known_service_reference_is_taggable(self):
+        text = REPO_TEMPLATE.read_text()
+        for svc in KNOWN_SERVICES:
+            if f"/{svc}:" not in text:
+                continue
+            rendered, applied = apply_tags(text, svc, "ZZZ", {})
+            assert applied[svc][1] >= 1, f"{svc} references were not substituted"
+
+
+class TestMainDoesNotTouchClusterOnFailure:
+    def test_missing_template_exits_nonzero(self, capsys):
+        rc = main(["crawler", "SHA", "--template", "does/not/exist.yaml"])
+        assert rc == 1
+        assert "Cannot read" in capsys.readouterr().out
+
+    def test_print_only_never_calls_kubectl(self, monkeypatch, tmp_path, capsys):
+        """--print-only is the safe way to inspect a render."""
+        import scripts.render_workflow_template as mod
+
+        monkeypatch.setattr(
+            mod,
+            "kubectl_apply",
+            lambda *a, **k: pytest.fail("must not touch the cluster"),
+        )
+        monkeypatch.setattr(
+            mod, "fetch_live_tags", lambda: pytest.fail("must not read cluster")
+        )
+        path = tmp_path / "tpl.yaml"
+        path.write_text(TEMPLATE_SNIPPET)
+
+        rc = main(["crawler", "NEWSHA", "--template", str(path), "--print-only"])
+
+        assert rc == 0
+        assert "crawler:NEWSHA" in capsys.readouterr().out
+
+    def test_validation_failure_aborts_before_real_apply(self, monkeypatch, tmp_path):
+        """The server-side dry run must gate the real apply, so a malformed
+        template fails the build instead of half-applying."""
+        import scripts.render_workflow_template as mod
+
+        calls = []
+
+        def fake_apply(rendered, dry_run):
+            calls.append(dry_run)
+            return (1, "", "invalid template") if dry_run else (0, "ok", "")
+
+        monkeypatch.setattr(mod, "fetch_live_tags", dict)
+        monkeypatch.setattr(mod, "kubectl_apply", fake_apply)
+        path = tmp_path / "tpl.yaml"
+        path.write_text(TEMPLATE_SNIPPET)
+
+        rc = main(["crawler", "NEWSHA", "--template", str(path)])
+
+        assert rc == 1
+        assert calls == [True], "real apply must not run after a failed dry run"


### PR DESCRIPTION
## The bug

`update-workflow-template.sh` read the **live** WorkflowTemplate out of the cluster, rewrote only its image tags, and pushed it back:

```python
kubectl get workflowtemplate ...   # read the CLUSTER's copy
... rewrite image tags only ...
kubectl apply -f -                 # write it back
```

`k8s/argo/base-pipeline-workflow.yaml` was **never read**. The cluster copy was seeded by hand once and has drifted from the repo ever since — nothing in that file except image tags could reach production.

## It had already cost us

On 2026-07-26 the live template still carried an extraction-worker cap of **10**, superseded months earlier by 702cd559 (*"cap extraction workers at 2"*), and was missing the `MIZZOU_SQUID_PROXY_URL` env added in #416.

Consequences: the second Squid was unreachable from extraction pods, so the load balancer silently used one proxy; and a validation run spawned 10 workers instead of 2. Both settings were correct in the repo and had simply never been applied. I had to `kubectl replace` by hand to run the validation at all — that was treating the symptom.

## The fix

Render the repo file, substitute tags, apply.

- The service being deployed takes this build's SHA.
- Every other service keeps the tag it is **currently running**, so a crawler deploy cannot roll the processor back to the repo's tag — those lag until a separate job updates them (#418).
- A service neither built here nor live keeps the repo's own value.
- A **server-side dry run gates the real apply**, so a malformed template fails the build instead of half-applying to production.

## Two judgment calls

**Logic moved out of the shell heredoc** into `scripts/render_workflow_template.py`. This decides what production runs; it should be testable.

**Tests live in `tests/deploy/`, not `tests/scripts/`.** Everything under `tests/scripts/` is auto-marked `local_scripts` by `tests/conftest.py` and excluded from CI and the pre-push gate. A test that never runs cannot protect a deploy — I put them there first and caught it when all 14 reported "deselected".

## Verified against the live cluster

```
live tags: {'crawler': '2bba720', 'processor': '613a942'}
would apply: {'crawler': '2bba720', 'processor': '613a942'}
dry-run rc: 0 | workflowtemplate.argoproj.io/news-pipeline-template configured
MIZZOU env in what we'd apply: 3
```

Reads live tags, preserves the processor rather than rolling it back, carries the env that had gone missing, and the server-side dry run passes.

## Test plan

- [x] 14 new tests in `tests/deploy/` — tag substitution, live-tag preservation, malformed cluster JSON, repo content surviving, YAML validity, `--print-only` never touching the cluster, and a failed dry run aborting before the real apply
- [x] Tests against the **real** repo template, asserting the two settings that had silently failed to reach production
- [x] Full suite **2850 passed**; flake8 and `bash -n` clean
- [x] Server-side dry run against production

## Note on when this takes effect

This PR touches only `scripts/`, `gcp/`, and `tests/`, none of which trigger a service rebuild — so merging it will not itself run a deploy. The new path first executes on the next service-code change. Given that, it is worth watching that build's template-apply step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)