### PR TITLE
Trigger Cloud Builds by SHA, not by branch

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -215,6 +215,13 @@ jobs:
           echo "Services to build: ${{ steps.services.outputs.list }}"
           echo "================================"
 
+  # Every build below is triggered by SHA, never by branch. `--branch` builds
+  # whatever main points at WHEN THE TRIGGER FIRES, which need not be the commit
+  # this run validated. On 2026-07-26 #417 merged at 13:49:36 and #418 at
+  # 13:50:03; #417's triggers fired at 13:50:18 and 13:50:44 and so built and
+  # tagged 797faa0 -- #418's tree -- while reporting against c6082b1f. The
+  # concurrency group above serialises Actions runs but cannot prevent this,
+  # because the SHA was never pinned.
   build-base:
     name: Build Base Image
     needs: detect-changes
@@ -246,7 +253,7 @@ jobs:
         run: |
           set +e
           BUILD_ID=$(gcloud builds triggers run build-base-manual \
-            --branch="${{ github.ref_name }}" \
+            --sha="${{ github.sha }}" \
             --format="value(metadata.build.id)" 2>&1)
           EXIT_CODE=$?
           set -e
@@ -310,7 +317,7 @@ jobs:
         run: |
           set +e
           BUILD_ID=$(gcloud builds triggers run build-ml-base-manual \
-            --branch="${{ github.ref_name }}" \
+            --sha="${{ github.sha }}" \
             --format="value(metadata.build.id)" 2>&1)
           EXIT_CODE=$?
           set -e
@@ -372,7 +379,7 @@ jobs:
         run: |
           set +e
           BUILD_ID=$(gcloud builds triggers run build-processor-manual \
-            --branch="${{ github.ref_name }}" \
+            --sha="${{ github.sha }}" \
             --format="value(metadata.build.id)" 2>&1)
           EXIT_CODE=$?
           set -e
@@ -415,7 +422,7 @@ jobs:
         run: |
           set +e
           BUILD_ID=$(gcloud builds triggers run build-api-manual \
-            --branch="${{ github.ref_name }}" \
+            --sha="${{ github.sha }}" \
             --format="value(metadata.build.id)" 2>&1)
           EXIT_CODE=$?
           set -e
@@ -458,7 +465,7 @@ jobs:
         run: |
           set +e
           BUILD_ID=$(gcloud builds triggers run build-crawler-manual \
-            --branch="${{ github.ref_name }}" \
+            --sha="${{ github.sha }}" \
             --format="value(metadata.build.id)" 2>&1)
           EXIT_CODE=$?
           set -e


### PR DESCRIPTION
## The bug

All five build jobs invoke their Cloud Build trigger by **branch**:

```yaml
gcloud builds triggers run build-crawler-manual \
  --branch="${{ github.ref_name }}"
```

That builds whatever `main` points at **when the trigger fires** — not the commit the run validated.

## It already happened

| time | event |
|---|---|
| 13:49:36 | #417 merged (`c6082b1f`) — build starts |
| 13:50:03 | #418 merged (`797faa05`) |
| 13:50:18 | #417's run triggers **processor** build → tags `797faa0` |
| 13:50:44 | #417's run triggers **crawler** build → tags `797faa0` |

#417's run validated `c6082b1f` and then built and shipped **#418's tree**, tagged `797faa0`. The images now running in production were produced by a run that reported against a different commit.

It was harmless **only by luck**: #418's branch had `main` merged in, so `797faa05` happened to contain #417's code. Had the second merge been a revert, or dropped a dependency, this would have shipped code no CI run had validated — tagged with a SHA that was never built from.

The `concurrency:` group serialises Actions *runs*, and its comment already documents a related 2026-07-20 incident, but it cannot prevent this: the SHA was never pinned.

## The fix

All five triggers now take `--sha="${{ github.sha }}"`. An image always contains the commit it was validated against, and `SHORT_SHA` tags it accordingly.

`gcloud builds triggers run` supports `--sha`, and these are GitHub-connected triggers (`LocalNewsImpact/MizzouNewsCrawler`), so a commit SHA resolves.

A comment records the incident above, so the reason survives the next simplification.

## Test plan

- [x] All 5 invocations converted; **0** `--branch` invocations remain
- [x] YAML validates
- [ ] Real proof is the next service-code merge: the built image tag must equal the merge commit the run reports against. Worth watching once, since a trigger that rejects `--sha` would fail the build loudly rather than silently mis-tag.

## Scope

Workflow-only — no service rebuild, so merging this does not itself deploy.

Related: #419 (apply the Argo template from the repo) and #418 (versions.env never updated). All three are cases of the deploy path quietly doing something other than what it reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)