### PR TITLE
fix(argo): extend extraction-step retry budget from 20m to 6h

### DIFF
--- a/k8s/argo/base-pipeline-workflow.yaml
+++ b/k8s/argo/base-pipeline-workflow.yaml
@@ -370,7 +370,16 @@ spec:
       backoff:
         duration: "5m"
         factor: 2
-        maxDuration: "20m"
+        # Extraction runs for hours by design (extract-batches defaults to
+        # 667). maxDuration bounds the *total* time across all retry
+        # attempts starting from the first attempt, not each attempt's own
+        # runtime -- at 20m, any transient failure on attempt 1 (a brief
+        # network blip, a spot-node preemption) truncated an otherwise
+        # healthy retry to whatever was left of that 20m window, silently
+        # cutting an hours-long run down to minutes. Matches the cron's
+        # 6-hour cadence so a retry gets the same runway a first attempt
+        # would have had.
+        maxDuration: "6h"
     container:
       image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:dcc138e
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- `extraction-step`'s `retryStrategy.backoff.maxDuration` was `20m`. That field bounds *total* elapsed time across all retry attempts, counted from the first attempt's start — not each attempt's own runtime.
- Extraction is designed to run for hours (`extract-batches` defaults to `667`, `batch-sleep` 30s between batches). A transient failure on attempt 1 (network blip, spot-node preemption, anything) starts that 20-minute clock; the retry can come up completely healthy and still get SIGTERM'd the moment the original 20-minute window closes, with the retry budget then exhausted.
- Observed live in production validation on 2026-07-26: `work-queue` briefly had 0 replicas, both extraction workers failed instantly on attempt 1 (14:27:36), the retry came up at 14:35 and extracted successfully from 5+ sites for ~12 minutes, then both were killed with `Max duration limit exceeded` at 14:47:48 — exactly 20m12s after the original failure — ending the DAG task permanently (`retryStrategy.limit: 2` exhausted).

## Fix
Bump `maxDuration` to `6h`, matching the CronWorkflow's own `0 */6 * * *` schedule, so a retry gets the same runway a first attempt would have had.

## Test plan
- [ ] `kubectl apply --dry-run=server` against the production WorkflowTemplate via `scripts/render_workflow_template.py --print-only`
- [ ] Resubmit a production validation workflow and confirm extraction survives a forced first-attempt failure without truncating the retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)