### PR TITLE
fix(telemetry): persist router_proxy per extraction so exports show which Squid served each article

### DIFF
--- a/alembic/versions/e7a1c2b3d4f5_add_router_proxy_to_extraction_telemetry.py
+++ b/alembic/versions/e7a1c2b3d4f5_add_router_proxy_to_extraction_telemetry.py
@@ -1,0 +1,47 @@
+"""Add router_proxy column to extraction_telemetry_v2.
+
+proxy_url records the raw session proxy string and was observed to be NULL on
+most rows even when the shared proxy_router had assigned mizzou_squid, so a
+per-article export could not answer which physical proxy served a request.
+router_proxy persists the router's own decision (home_squid / mizzou_squid).
+
+Revision ID: e7a1c2b3d4f5
+Revises: d5f1a2b3c4e6
+Create Date: 2026-07-26
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e7a1c2b3d4f5"
+down_revision: Union[str, None] = "d5f1a2b3c4e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add router_proxy column and an index for per-proxy aggregation."""
+    op.add_column(
+        "extraction_telemetry_v2",
+        sa.Column("router_proxy", sa.String(), nullable=True),
+    )
+    op.create_index(
+        "ix_extraction_telemetry_v2_router_proxy",
+        "extraction_telemetry_v2",
+        ["router_proxy"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove router_proxy column."""
+    op.drop_index(
+        "ix_extraction_telemetry_v2_router_proxy",
+        table_name="extraction_telemetry_v2",
+    )
+    op.drop_column("extraction_telemetry_v2", "router_proxy")

--- a/src/models/telemetry_orm.py
+++ b/src/models/telemetry_orm.py
@@ -141,6 +141,12 @@ class ExtractionTelemetryV2(Base):
     proxy_authenticated = Column(Integer, nullable=True)  # 0 or 1
     proxy_status = Column(String, nullable=True)
     proxy_error = Column(String, nullable=True)
+    # Which RouterProxy (home_squid / mizzou_squid) proxy_router actually
+    # assigned for this domain. proxy_url is the raw session proxy string and
+    # was observed to go unset/None on most rows even when the router picked
+    # mizzou_squid -- this is the field that lets a per-article export answer
+    # "which physical proxy served this" without cross-referencing Firestore.
+    router_proxy = Column(String, nullable=True, index=True)
 
     # Method tracking (JSON strings)
     methods_attempted = Column(Text, nullable=True)  # JSON array

--- a/src/utils/comprehensive_telemetry.py
+++ b/src/utils/comprehensive_telemetry.py
@@ -106,6 +106,8 @@ class ExtractionMetrics:
         # 0=disabled, 1=success, 2=failed, 3=bypassed
         self.proxy_status: int | None = None
         self.proxy_error: str | None = None
+        # RouterProxy the shared proxy_router assigned (home_squid/mizzou_squid)
+        self.router_proxy: str | None = None
 
         # Driver metrics (ChromeDriver lifecycle, proxy provider health)
         self.driver_metrics: dict[str, Any] | None = None
@@ -176,6 +178,7 @@ class ExtractionMetrics:
                     proxy_authenticated=metadata.get("proxy_authenticated", False),
                     proxy_status=metadata.get("proxy_status"),
                     proxy_error=metadata.get("proxy_error"),
+                    router_proxy=metadata.get("router_proxy"),
                 )
 
     @staticmethod
@@ -257,6 +260,7 @@ class ExtractionMetrics:
         proxy_authenticated: bool = False,
         proxy_status: str | None = None,
         proxy_error: str | None = None,
+        router_proxy: str | None = None,
     ):
         """Record proxy-level metrics.
 
@@ -266,11 +270,17 @@ class ExtractionMetrics:
             proxy_authenticated: Whether proxy credentials were present
             proxy_status: Status of proxy usage: success, failed, bypassed, disabled
             proxy_error: Error message if proxy failed
+            router_proxy: RouterProxy the shared proxy_router assigned for this
+                domain (home_squid / mizzou_squid). proxy_url alone cannot
+                answer which physical proxy served the request -- it was often
+                None even when mizzou_squid was picked.
         """
         self.proxy_used = proxy_used
         self.proxy_url = proxy_url
         self.proxy_authenticated = proxy_authenticated
         self.proxy_status = proxy_status_to_int(proxy_status)
+        if router_proxy:
+            self.router_proxy = router_proxy
         if proxy_error:
             # Truncate long error messages
             self.proxy_error = proxy_error[:500]
@@ -402,7 +412,7 @@ class ComprehensiveExtractionTelemetry:
                 http_status_code, http_error_type,
                 response_size_bytes, response_time_ms,
                 proxy_used, proxy_url, proxy_authenticated,
-                proxy_status, proxy_error,
+                proxy_status, proxy_error, router_proxy,
                 methods_attempted, successful_method,
                 method_timings, method_success, method_errors,
                 field_extraction, extracted_fields,
@@ -410,7 +420,7 @@ class ComprehensiveExtractionTelemetry:
                 driver_metrics,
                 content_length, is_success, error_message, error_type,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
@@ -439,6 +449,7 @@ class ComprehensiveExtractionTelemetry:
                     ),
                     metrics.proxy_status,
                     metrics.proxy_error,
+                    metrics.router_proxy,
                     json.dumps(metrics.methods_attempted),
                     metrics.successful_method,
                     json.dumps(metrics.method_timings),

--- a/tests/models/test_extraction_telemetry_proxy_status.py
+++ b/tests/models/test_extraction_telemetry_proxy_status.py
@@ -225,3 +225,73 @@ class TestProxyStatusColumnType:
             .count()
         )
         assert bypassed_records == 2  # Records 2 and 6
+
+
+class TestRouterProxyColumn:
+    """router_proxy persists which Squid the shared proxy_router assigned.
+
+    proxy_url (the raw session proxy string) went NULL on most rows even when
+    mizzou_squid was chosen, so it can't answer "which physical proxy served
+    this". router_proxy is the reliable per-article signal.
+    """
+
+    def test_router_proxy_stores_both_backends(self, db_session):
+        now = datetime.utcnow()
+        cases = ["home_squid", "mizzou_squid"]
+        for idx, backend in enumerate(cases):
+            db_session.add(
+                ExtractionTelemetryV2(
+                    operation_id=f"op-router-{idx}",
+                    article_id=f"article-{idx}",
+                    url=f"https://example.com/article-{idx}",
+                    host="example.com",
+                    start_time=now,
+                    end_time=now,
+                    proxy_used=1,
+                    proxy_status="success",
+                    router_proxy=backend,
+                    is_success=True,
+                    created_at=now,
+                )
+            )
+        db_session.commit()
+
+        for idx, backend in enumerate(cases):
+            result = (
+                db_session.query(ExtractionTelemetryV2)
+                .filter_by(operation_id=f"op-router-{idx}")
+                .first()
+            )
+            assert result.router_proxy == backend
+
+    def test_router_proxy_nullable_when_router_absent(self, db_session):
+        """A capture with no router decision (e.g. direct/legacy) stays NULL,
+        not silently coerced to a backend name."""
+        now = datetime.utcnow()
+        db_session.add(
+            ExtractionTelemetryV2(
+                operation_id="op-router-none",
+                article_id="article-none",
+                url="https://example.com/none",
+                host="example.com",
+                start_time=now,
+                end_time=now,
+                proxy_used=0,
+                router_proxy=None,
+                is_success=True,
+                created_at=now,
+            )
+        )
+        db_session.commit()
+
+        result = (
+            db_session.query(ExtractionTelemetryV2)
+            .filter_by(operation_id="op-router-none")
+            .first()
+        )
+        assert result.router_proxy is None
+
+    def test_router_proxy_column_present_in_schema(self, sqlite_engine):
+        inspector = inspect(sqlite_engine)
+        columns = {c["name"] for c in inspector.get_columns("extraction_telemetry_v2")}
+        assert "router_proxy" in columns

--- a/tests/utils/test_comprehensive_telemetry_metrics.py
+++ b/tests/utils/test_comprehensive_telemetry_metrics.py
@@ -686,6 +686,10 @@ def test_extraction_metrics_proxy_metrics():
         publisher="Test",
     )
 
+    # Default: no router decision supplied leaves router_proxy unset (not
+    # coerced to a backend name).
+    assert metrics.router_proxy is None
+
     # Test setting proxy metrics
     metrics.set_proxy_metrics(
         proxy_used=True,
@@ -700,6 +704,18 @@ def test_extraction_metrics_proxy_metrics():
     assert metrics.proxy_authenticated is True
     assert metrics.proxy_status == ct.PROXY_STATUS_SUCCESS
     assert metrics.proxy_error is None
+    # No router_proxy arg -> stays None even after a proxy is recorded.
+    assert metrics.router_proxy is None
+
+    # Router decision is captured when supplied.
+    metrics.set_proxy_metrics(
+        proxy_used=True,
+        proxy_url="http://proxy.example.com:8080",
+        proxy_authenticated=True,
+        proxy_status="success",
+        router_proxy="mizzou_squid",
+    )
+    assert metrics.router_proxy == "mizzou_squid"
 
     # Test with error
     metrics.set_proxy_metrics(
@@ -758,7 +774,8 @@ def test_extraction_metrics_metadata_proxy_extraction():
         publisher="Test",
     )
 
-    # Proxy info in metadata should be captured
+    # Proxy info in metadata should be captured, including the router decision
+    # the crawler spreads in via **proxy_metadata.
     metrics.end_method(
         "method1",
         success=True,
@@ -770,6 +787,7 @@ def test_extraction_metrics_metadata_proxy_extraction():
                 "proxy_authenticated": True,
                 "proxy_status": "success",
                 "proxy_error": None,
+                "router_proxy": "mizzou_squid",
             },
         },
     )
@@ -778,6 +796,7 @@ def test_extraction_metrics_metadata_proxy_extraction():
     assert metrics.proxy_url == "http://proxy.test:8080"
     assert metrics.proxy_authenticated is True
     assert metrics.proxy_status == ct.PROXY_STATUS_SUCCESS
+    assert metrics.router_proxy == "mizzou_squid"
     assert metrics.field_extraction["method1"]["metadata"] is True
 
 


### PR DESCRIPTION
## Summary
`extraction_telemetry_v2` recorded `proxy_url` (the raw session proxy string) but not which `RouterProxy` the shared `proxy_router` assigned. In the 216-article production run on 2026-07-26, Firestore confirmed 10 domains were served by `mizzou_squid`, yet every persisted telemetry row showed either NULL `proxy_url` (190/246) or the home proxy (56/246) — `mizzou_squid` never appeared.

The crawler computes the router decision correctly and already spreads it into result metadata as `router_proxy`, but the telemetry layer dropped it: `set_proxy_metrics()` had no such parameter and the table had no column. So the one field that answers *"which physical proxy served this article"* never reached the database.

## Changes
- Add `router_proxy` column to `ExtractionTelemetryV2` (indexed) + an Alembic migration off head `d5f1a2b3c4e6`
- Thread `router_proxy` through `set_proxy_metrics()` and the metadata-extraction path in `end_method()`
- Add it to the raw INSERT (verified 33 columns / 33 placeholders)
- Tests cover both states — router decision present (`home_squid`/`mizzou_squid`) and absent (NULL, not coerced) — via the direct setter and the metadata path

## Test plan
- [x] `tests/models/test_extraction_telemetry_proxy_status.py` + `tests/utils/test_comprehensive_telemetry_metrics.py` (32 pass locally)
- [ ] Migration applies cleanly on next deploy; a subsequent run shows `mizzou_squid` in `router_proxy` for Mizzou-routed domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)