### PR TITLE
fix(ci): detect-changes was blind to src/cli/ and src/reporting/ changes

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -133,20 +133,27 @@ jobs:
             echo "✅ ML base image changed (Dockerfile.ml-base / requirements-ml.txt)"
           fi
 
-          # Processor: processor-specific changes, ML code, or migrations
-          if echo "$CHANGED_FILES" | grep -qE 'Dockerfile\.processor|requirements-processor\.txt|src/(models|pipeline|utils|services|ml)/|pyproject\.toml|orchestration/|alembic/versions/'; then
+          # Processor: processor-specific changes, ML code, or migrations.
+          # src/cli/ is the entrypoint the processor runs (continuous_processor
+          # shells out to `cli_modular extract/analyze/extract-entities`), and
+          # src/reporting/ ships in the processor image — both were MISSING here,
+          # so #423 (which touched only src/cli/ and src/reporting/) built
+          # nothing at all and shipped no image. See 2026-07-26.
+          if echo "$CHANGED_FILES" | grep -qE 'Dockerfile\.processor|requirements-processor\.txt|src/(models|pipeline|utils|services|ml|cli|reporting)/|pyproject\.toml|orchestration/|alembic/versions/'; then
             PROCESSOR=true
             echo "✅ Processor changed (processor code or migrations)"
           fi
 
-          # API: API-specific changes, shared models, or migrations
-          if echo "$CHANGED_FILES" | grep -qE 'Dockerfile\.api|requirements-api\.txt|src/(models|services)/|backend/|pyproject\.toml|alembic/versions/'; then
+          # API: API-specific changes, shared models, or migrations. src/cli/
+          # and src/reporting/ ship in the API image (report generation).
+          if echo "$CHANGED_FILES" | grep -qE 'Dockerfile\.api|requirements-api\.txt|src/(models|services|cli|reporting)/|backend/|pyproject\.toml|alembic/versions/'; then
             API=true
             echo "✅ API changed (API code or shared models)"
           fi
 
-          # Crawler: crawler-specific changes
-          if echo "$CHANGED_FILES" | grep -qE 'Dockerfile\.crawler|requirements-crawler\.txt|src/(crawler|models|services|utils)/|pyproject\.toml'; then
+          # Crawler: crawler-specific changes. src/cli/ is the crawler entrypoint
+          # (`cli_modular extract` runs the extraction path in the crawler image).
+          if echo "$CHANGED_FILES" | grep -qE 'Dockerfile\.crawler|requirements-crawler\.txt|src/(crawler|models|services|utils|cli)/|pyproject\.toml'; then
             CRAWLER=true
             echo "✅ Crawler changed (crawler code)"
           fi


### PR DESCRIPTION
## The bug
`detect-changes` path filters for processor/api/crawler matched `src/(models|pipeline|utils|services|ml|crawler)/` but **not** `src/cli/` or `src/reporting/`. Yet `src/cli/` is the entrypoint every service actually runs — the crawler and processor shell out to `cli_modular extract`, and `continuous_processor` also runs `analyze` / `extract-entities`.

## Impact (observed 2026-07-26)
PR #423 touched **only** `src/cli/commands/*.py` and `src/reporting/county_report.py`. detect-changes computed `crawler=processor=api=false`, every Build job logged *"image not requested; skipping"*, Wait-for-Cloud-Builds saw `SERVICES="none"`, and the merge **deployed nothing while every job reported success**. #421/#422/#423 never reached a production image. Earlier PRs escaped only because they also touched a matched path.

## Fix
- processor: `+ cli, reporting`
- api: `+ cli, reporting`
- crawler: `+ cli`

## Note
This PR changes only `.github/`, so merging it does **not** self-trigger a service build (`.github/` matches no filter, by design). A follow-up trivial commit to a service path triggers the corrected full build that actually ships #421/#422/#423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)