### PR TITLE
fix(proxy): consult the shared router on the fingerprint fetch path

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -1048,8 +1048,13 @@ class ContentExtractor:
         # Skip UA rotation if fingerprint profile is loaded (maintain consistency)
         if self._fingerprint_profile and self._fingerprint_profile.user_agent:
             if domain not in self.domain_sessions:
-                # Create new session with fingerprint UA
-                new_session = self._create_session_with_fingerprint_ua()
+                # Create new session with fingerprint UA. Pass the domain so the
+                # session is routed through the shared proxy_router (home vs
+                # mizzou Squid) and records which one it picked -- without this
+                # the fingerprint path applied a static SQUID_PROXY_URL and never
+                # consulted the router, so router selection AND its telemetry
+                # (router_proxy) were dead on the primary fetch path.
+                new_session = self._create_session_with_fingerprint_ua(domain)
                 self.domain_sessions[domain] = new_session
                 self.domain_user_agents[domain] = self._fingerprint_profile.user_agent
                 self.request_counts[domain] = 0
@@ -1178,8 +1183,16 @@ class ContentExtractor:
 
         return self.domain_sessions[domain]
 
-    def _create_session_with_fingerprint_ua(self):
-        """Create a new session using fingerprint profile user agent."""
+    def _create_session_with_fingerprint_ua(self, domain: Optional[str] = None):
+        """Create a new session using fingerprint profile user agent.
+
+        When ``domain`` is given, the session's proxy is chosen by the shared
+        proxy_router (home vs mizzou Squid, by live per-domain health) and the
+        choice is recorded on ``self.domain_router_proxy[domain]`` so it reaches
+        per-request telemetry. Falls back to the static SQUID_PROXY_URL only if
+        the router (and its own Squid fallback) resolve nothing, so the crawler
+        can never end up direct.
+        """
         if CLOUDSCRAPER_AVAILABLE and cloudscraper is not None:
             new_session = cloudscraper.create_scraper(
                 browser=CLOUDSCRAPER_BROWSER_PROFILE
@@ -1217,12 +1230,38 @@ class ContentExtractor:
 
         new_session.headers.update(headers)
 
-        # Apply Squid proxy
-        squid_proxy_url = os.getenv(
-            "SQUID_PROXY_URL", "http://t9880447.eero.online:3128"
-        )
-        squid_proxies = {"http": squid_proxy_url, "https": squid_proxy_url}
-        new_session.proxies.update(squid_proxies)
+        # Route through the shared proxy_router when we know the domain, so the
+        # home/mizzou choice and its health-based failover apply on the primary
+        # fetch path -- and record which proxy was picked for telemetry.
+        # get_requests_proxies_for_domain already falls back to the always-on
+        # home Squid if the router is unavailable or picks something
+        # unconfigured, so router_proxies is None only when even that fails.
+        router_proxies = None
+        if domain is not None:
+            try:
+                router_proxies, router_proxy, _method = (
+                    self.proxy_manager.get_requests_proxies_for_domain(
+                        domain, service="newscrawler"
+                    )
+                )
+                self.domain_router_proxy[domain] = router_proxy
+            except Exception as exc:  # never let routing break session creation
+                logger.warning(
+                    "proxy_router lookup failed for %s (%s); using static Squid",
+                    domain,
+                    exc,
+                )
+
+        if router_proxies:
+            new_session.proxies.update(router_proxies)
+        else:
+            # No domain, or the router resolved nothing: static Squid, never direct.
+            squid_proxy_url = os.getenv(
+                "SQUID_PROXY_URL", "http://t9880447.eero.online:3128"
+            )
+            new_session.proxies.update(
+                {"http": squid_proxy_url, "https": squid_proxy_url}
+            )
 
         return new_session
 

--- a/tests/crawler/test_mcmetadata_proxy_routing.py
+++ b/tests/crawler/test_mcmetadata_proxy_routing.py
@@ -130,6 +130,68 @@ class TestFetchPageHtml:
         with pytest.raises(NotFoundError):
             extractor._fetch_page_html("https://example.com/gone")
 
+
+class TestFingerprintSessionRouting:
+    """The fingerprint session is the primary fetch path; it must go through
+    the shared proxy_router, not a static Squid, or router selection and its
+    router_proxy telemetry are dead on every normal extraction."""
+
+    def _fp_extractor(self, extractor):
+        extractor._fingerprint_profile = Mock(
+            user_agent="Mozilla/5.0 (Macintosh) FP", accept_language="en-US"
+        )
+        extractor.current_user_agent = "Mozilla/5.0 (Macintosh) FP"
+        extractor.accept_header_pool = ["text/html"]
+        extractor.accept_language_pool = ["en-US"]
+        extractor.accept_encoding_pool = ["gzip"]
+        return extractor
+
+    def test_routes_through_router_and_records_choice(self, extractor):
+        from src.crawler.proxy_router import RouterProxy
+
+        ex = self._fp_extractor(extractor)
+        proxies = {
+            "http": "http://u:p@mizzou.squid:3128",
+            "https": "http://u:p@mizzou.squid:3128",
+        }
+        ex.proxy_manager.get_requests_proxies_for_domain.return_value = (
+            proxies,
+            RouterProxy.MIZZOU_SQUID,
+            "sticky",
+        )
+
+        session = ex._create_session_with_fingerprint_ua("example.com")
+
+        # The router's proxy was applied, and its choice recorded for telemetry.
+        assert session.proxies.get("https") == "http://u:p@mizzou.squid:3128"
+        assert ex.domain_router_proxy["example.com"] == RouterProxy.MIZZOU_SQUID
+        ex.proxy_manager.get_requests_proxies_for_domain.assert_called_once_with(
+            "example.com", service="newscrawler"
+        )
+
+    def test_no_domain_uses_static_squid_and_skips_router(self, extractor, monkeypatch):
+        ex = self._fp_extractor(extractor)
+        monkeypatch.setenv("SQUID_PROXY_URL", "http://static.squid:3128")
+
+        session = ex._create_session_with_fingerprint_ua()
+
+        assert session.proxies.get("https") == "http://static.squid:3128"
+        ex.proxy_manager.get_requests_proxies_for_domain.assert_not_called()
+
+    def test_router_failure_falls_back_to_static_never_direct(
+        self, extractor, monkeypatch
+    ):
+        ex = self._fp_extractor(extractor)
+        monkeypatch.setenv("SQUID_PROXY_URL", "http://static.squid:3128")
+        ex.proxy_manager.get_requests_proxies_for_domain.side_effect = RuntimeError(
+            "firestore down"
+        )
+
+        session = ex._create_session_with_fingerprint_ua("example.com")
+
+        # Never direct: a router blow-up degrades to the static Squid.
+        assert session.proxies.get("https") == "http://static.squid:3128"
+
     def test_500_raises_rate_limit_with_backoff(self, extractor):
         backoffs = []
         extractor._handle_rate_limit_error = lambda domain, resp=None: backoffs.append(


### PR DESCRIPTION
## The gap (found verifying #422 live, 2026-07-26)
`_create_session_with_fingerprint_ua()` — the **primary** extraction fetch path, taken whenever a fingerprint profile is loaded (the default) — applied a static `SQUID_PROXY_URL` and never called `get_requests_proxies_for_domain()`. `domain_router_proxy[domain]` was only ever set in the UA-rotation branch, which the fingerprint path skips via early `return`.

Consequences, both confirmed in production:
- The shared proxy_router's home-vs-mizzou **selection and health-based failover (#413)** were dead on the hot path — normal extraction always used the fixed home Squid.
- **`router_proxy` (#422) was NULL on every extraction** (140/140, then 205/205 observed) even though the migration, column, and telemetry plumbing all deployed correctly — there was simply no router decision to record.

## Fix
Pass `domain` into the session creator and route through the router there, recording the choice on `domain_router_proxy[domain]` (which then reaches per-request telemetry and drives `report_domain_result`). `get_requests_proxies_for_domain` already falls back to the always-on home Squid; a router exception degrades to the static Squid; `domain=None` keeps static behaviour. The crawler can never end up direct.

## Tests
`TestFingerprintSessionRouting` — routes through router + records choice; `domain=None` → static Squid, no router call; router raises → static-Squid fallback (never direct). All 23 in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)