### PR TITLE
fix(selenium+telemetry): restore Selenium proxy auth (Chrome 150 killed MV2) and make telemetry report reality

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -1937,7 +1937,12 @@ def _process_batch(
 
                     metrics.set_content_type_detection(detection_payload)
                     _attach_driver_metrics(metrics, extractor, domain)
-                    metrics.finalize(content or {})
+                    # Hand telemetry our own verdict. A filtered body
+                    # (paywall/not_article) is emptied above, so no body-based
+                    # rule can tell a deliberate drop from a failed capture --
+                    # which is why 407 filtered rows looked like errors and 75
+                    # stored articles looked like losses.
+                    metrics.finalize(content or {}, outcome=article_status)
 
                     # Diagnostic: optionally dump SQL and parameters before execution
                     try:

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -45,6 +45,7 @@ from .fingerprint_profile import (
     prepare_user_data_dir,
 )
 from .proxy_config import ProxyProvider, get_proxy_manager
+from .proxy_relay import get_relay_proxy
 from .utils import mask_proxy_url
 
 UNBLOCK_MIN_HTML_BYTES = 3000
@@ -4864,83 +4865,40 @@ class ContentExtractor:
         logger.info(
             f"🔀 Selenium proxy URL from env: {_mask_proxy_url(selenium_proxy)}"
         )
-        proxy_extension_path = None
 
-        # Parse proxy URL: https://user:pass@host:port or http://host:port
-        import re
-
-        proxy_match = re.match(
-            r"https?://(?:([^:]+):([^@]+)@)?([^:]+):(\d+)", selenium_proxy
-        )
-        if proxy_match:
-            proxy_user, proxy_pass, proxy_host, proxy_port = proxy_match.groups()
-
-            # If proxy has authentication, create Chrome extension
-            if proxy_user and proxy_pass:
-                # Create Chrome extension for proxy authentication
-                import tempfile
-                import zipfile
-
-                manifest_json = """{
-                    "version": "1.0.0",
-                    "manifest_version": 2,
-                    "name": "Chrome Proxy Auth",
-                    "permissions": ["proxy", "tabs", "unlimitedStorage", "storage", "<all_urls>", "webRequest", "webRequestBlocking"],
-                    "background": {"scripts": ["background.js"]},
-                    "minimum_chrome_version": "76.0.0"
-                }"""
-
-                background_js = f"""
-                var config = {{
-                    mode: "fixed_servers",
-                    rules: {{
-                        singleProxy: {{
-                            scheme: "http",
-                            host: "{proxy_host}",
-                            port: parseInt({proxy_port})
-                        }},
-                        bypassList: ["localhost"]
-                    }}
-                }};
-
-                chrome.proxy.settings.set({{value: config, scope: "regular"}}, function() {{}});
-
-                function callbackFn(details) {{
-                    return {{
-                        authCredentials: {{
-                            username: "{proxy_user}",
-                            password: "{proxy_pass}"
-                        }}
-                    }};
-                }}
-
-                chrome.webRequest.onAuthRequired.addListener(
-                    callbackFn,
-                    {{urls: ["<all_urls>"]}},
-                    ['blocking']
-                );
-                """
-
-                # Create extension zip file
-                proxy_extension_path = tempfile.mktemp(suffix=".zip")
-                with zipfile.ZipFile(proxy_extension_path, "w") as zp:
-                    zp.writestr("manifest.json", manifest_json)
-                    zp.writestr("background.js", background_js)
-
-                options.add_extension(proxy_extension_path)
-                logger.debug(
-                    f"Configured proxy extension for {proxy_host}:{proxy_port}"
-                )
-            else:
-                # Proxy without authentication - use --proxy-server argument
-                options.add_argument(f"--proxy-server={selenium_proxy}")
-                logger.info(
-                    f"🔀 Selenium using Squid proxy via --proxy-server: {selenium_proxy}"
-                )
-        else:
-            logger.error(
-                f"Could not parse proxy URL: {mask_proxy_url(selenium_proxy)} - Selenium connections will FAIL"
+        # Chrome has no command-line syntax for proxy credentials. This used
+        # to be solved with a Manifest V2 extension answering
+        # chrome.webRequest.onAuthRequired -- but Chrome removed Manifest V2,
+        # and by Chrome 150 that extension is ignored SILENTLY: no error, no
+        # warning, just an unauthenticated browser. Every Selenium fetch then
+        # got 407 from Squid and returned a ~0.2s "successful" navigation to
+        # an empty error page. Production 2026-07-27: zero Selenium successes
+        # since 07-25 across ~500 attempts; from inside a pod, no-cred -> 407
+        # and with-cred -> 200. Manifest V3 cannot fix it either (blocking
+        # onAuthRequired is gone).
+        #
+        # So credentials leave the browser entirely: a loopback relay speaks
+        # unauthenticated proxy to Chrome and injects Proxy-Authorization
+        # upstream. No browser release can break that the way MV2 removal did.
+        try:
+            relay_endpoint = get_relay_proxy(selenium_proxy)
+            options.add_argument(f"--proxy-server={relay_endpoint}")
+            logger.info(
+                "🔀 Selenium proxying via auth relay %s -> %s",
+                relay_endpoint,
+                mask_proxy_url(selenium_proxy),
             )
+        except Exception as exc:
+            # Never fall through to a direct browser: an unproxied Selenium
+            # egresses the pod IP, which is exactly the leak the proxy exists
+            # to prevent.
+            logger.error(
+                "Proxy auth relay unavailable for %s (%s) - refusing to start "
+                "an unproxied browser",
+                mask_proxy_url(selenium_proxy),
+                exc,
+            )
+            raise
 
         # Use ephemeral user-data-dir per attempt to avoid profile locks
         try:
@@ -5006,38 +4964,20 @@ class ContentExtractor:
                     "SELENIUM_PROXY",
                     os.getenv("SQUID_PROXY_URL", "http://t9880447.eero.online:3128"),
                 )
-                import re as _re
-
-                pm = _re.match(
-                    r"https?://(?:([^:]+):([^@]+)@)?([^:]+):(\d+)", selenium_proxy
-                )
-                if pm:
-                    pu, pp, ph, pport = pm.groups()
-                    if pu and pp:
-                        import tempfile
-                        import zipfile
-
-                        proxy_ext_path_fb = tempfile.mktemp(suffix=".zip")
-                        manifest_json = """{
-                            \"version\": \"1.0.0\",
-                            \"manifest_version\": 2,
-                            \"name\": \"Chrome Proxy Auth\",
-                            \"permissions\": [\"proxy\", \"tabs\", \"unlimitedStorage\", \"storage\", \"<all_urls>\", \"webRequest\", \"webRequestBlocking\"],
-                            \"background\": {\"scripts\": [\"background.js\"]},
-                            \"minimum_chrome_version\": \"76.0.0\"
-                        }"""
-                        background_js = f"""
-                        var config = {{ mode: \"fixed_servers\", rules: {{ singleProxy: {{ scheme: \"http\", host: \"{ph}\", port: parseInt({pport}) }}, bypassList: [\"localhost\"] }} }};
-                        chrome.proxy.settings.set({{value: config, scope: \"regular\"}}, function() {{}});
-                        function callbackFn(details) {{ return {{ authCredentials: {{ username: \"{pu}\", password: \"{pp}\" }} }}; }}
-                        chrome.webRequest.onAuthRequired.addListener(callbackFn, {{urls: [\"<all_urls>\"]}}, ['blocking']);
-                        """
-                        with zipfile.ZipFile(proxy_ext_path_fb, "w") as zp:
-                            zp.writestr("manifest.json", manifest_json)
-                            zp.writestr("background.js", background_js)
-                        options_fb.add_extension(proxy_ext_path_fb)
-                    else:
-                        options_fb.add_argument(f"--proxy-server={selenium_proxy}")
+                # Same relay as the primary path: Chrome cannot take proxy
+                # credentials on the command line, and the old Manifest V2
+                # auth extension is silently ignored by modern Chrome.
+                try:
+                    options_fb.add_argument(
+                        f"--proxy-server={get_relay_proxy(selenium_proxy)}"
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "Proxy auth relay unavailable (%s) - refusing an "
+                        "unproxied fallback browser",
+                        exc,
+                    )
+                    raise
                 # Ephemeral profile
                 try:
                     tmp_dir_fb = Path(f"/tmp/uc-profile-{uuid.uuid4().hex}")
@@ -5062,13 +5002,6 @@ class ContentExtractor:
                     f"Failed to create undetected driver (fallback use_subprocess=False, headless): {e_fallback}"
                 )
                 raise
-        finally:
-            # Clean up temporary proxy extension file
-            if proxy_extension_path and os.path.exists(proxy_extension_path):
-                try:
-                    os.unlink(proxy_extension_path)
-                except Exception:
-                    pass  # Non-critical cleanup
 
         # Set timeouts - use longer timeouts for headful to allow JS challenges to resolve
         if headless_mode:
@@ -5197,7 +5130,9 @@ class ContentExtractor:
             "SELENIUM_PROXY",
             os.getenv("SQUID_PROXY_URL", "http://t9880447.eero.online:3128"),
         )
-        chrome_options.add_argument(f"--proxy-server={selenium_proxy}")
+        # Via the auth relay -- credentials embedded in --proxy-server are
+        # ignored by Chrome, which is how this path silently ran unauthenticated.
+        chrome_options.add_argument(f"--proxy-server={get_relay_proxy(selenium_proxy)}")
         logger.debug(
             f"Squid proxy ENFORCED for stealth driver: {_mask_proxy_url(selenium_proxy)}"
         )

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -777,15 +777,15 @@ class ContentExtractor:
         self.domain_locks: dict[str, Any] = {}
 
         # Rate limiting and backoff management
-        self.domain_request_times: dict[
-            str, float
-        ] = {}  # Track last request time per domain
-        self.domain_backoff_until: dict[
-            str, float
-        ] = {}  # Track when domain is available again
-        self.domain_error_counts: dict[
-            str, int
-        ] = {}  # Track consecutive errors per domain
+        self.domain_request_times: dict[str, float] = (
+            {}
+        )  # Track last request time per domain
+        self.domain_backoff_until: dict[str, float] = (
+            {}
+        )  # Track when domain is available again
+        self.domain_error_counts: dict[str, int] = (
+            {}
+        )  # Track consecutive errors per domain
 
         try:
             self.unblock_rate_limit_seconds = float(
@@ -798,9 +798,9 @@ class ContentExtractor:
 
         # Selenium-specific failure tracking (separate from requests failures)
         # This prevents disabling Selenium for CAPTCHA-protected domains
-        self._selenium_failure_counts: dict[
-            str, int
-        ] = {}  # Track Selenium failures per domain
+        self._selenium_failure_counts: dict[str, int] = (
+            {}
+        )  # Track Selenium failures per domain
 
         # Base inter-request delay (env tunable)
         try:
@@ -3553,11 +3553,41 @@ class ContentExtractor:
                 "proxy_used": bool(session_proxy_url),
                 "proxy_url": mask_proxy_url(session_proxy_url),
                 "proxy_authenticated": "@" in (session_proxy_url or ""),
-                "proxy_status": http_status,
+                # A status WORD, not the HTTP code. proxy_status_to_int() maps
+                # success/failed/bypassed/disabled; handing it the int status
+                # raised AttributeError and killed router_proxy on the way
+                # through set_proxy_metrics. The HTTP code is already recorded
+                # separately by set_http_metrics -> http_status_code.
+                "proxy_status": "success" if session_proxy_url else None,
                 "proxy_error": None,
                 "router_proxy": router_proxy.value if router_proxy else None,
             }
             self._last_fetch_proxy_metadata = fetch_meta
+
+            # Record onto the metrics object HERE, where the fetch actually
+            # happened. This dict used to reach telemetry only by way of
+            # _parse_with_newspaper's result metadata (the sole reader of
+            # _last_fetch_proxy_metadata), so whenever newspaper4k did not run
+            # -- the common case, since mcmetadata/http_fetch usually satisfy
+            # the required fields first -- proxy_used, proxy_url AND
+            # router_proxy were silently dropped. Confirmed live 2026-07-27:
+            # 2,621 of 3,150 rows in 6h reported proxy_used=0 and 100% had
+            # router_proxy NULL, with a perfect correlation to newspaper4k not
+            # running, even though every one of those fetches went through
+            # Squid. The proxy was never bypassed; the evidence was.
+            # Wrapped so telemetry can never break a capture we already hold.
+            if metrics is not None:
+                try:
+                    metrics.set_proxy_metrics(
+                        proxy_used=fetch_meta["proxy_used"],
+                        proxy_url=fetch_meta["proxy_url"],
+                        proxy_authenticated=fetch_meta["proxy_authenticated"],
+                        proxy_status=fetch_meta["proxy_status"],
+                        proxy_error=fetch_meta["proxy_error"],
+                        router_proxy=fetch_meta["router_proxy"],
+                    )
+                except Exception as exc:
+                    logger.warning("proxy metrics recording failed: %s", exc)
 
             logger.info(
                 f"📥 Received {http_status} for {domain} "

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -4089,11 +4089,18 @@ class ContentExtractor:
                         exc,
                     )
 
+            # Both branches must end with a real URL string. A truthy
+            # router_proxies dict that happens to carry neither "http" nor
+            # "https" would otherwise leave this None, and requests treats
+            # proxies={"http": None} as NO PROXY -- egressing the pod IP, the
+            # exact leak the Squid requirement exists to prevent. mypy caught
+            # it as `Any | None` where `str` was expected.
+            squid_proxy_url = None
             if router_proxies:
                 squid_proxy_url = router_proxies.get("http") or router_proxies.get(
                     "https"
                 )
-            else:
+            if not squid_proxy_url:
                 squid_proxy_url = os.getenv(
                     "SQUID_PROXY_URL", "http://t9880447.eero.online:3128"
                 )

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -719,10 +719,7 @@ class ContentExtractor:
                 "Gecko/20100101 Firefox/130.0"
             ),
             # Firefox on Linux
-            (
-                "Mozilla/5.0 (X11; Linux x86_64; rv:130.0) "
-                "Gecko/20100101 Firefox/130.0"
-            ),
+            ("Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"),
             # Safari on macOS (latest versions)
             (
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -780,15 +777,15 @@ class ContentExtractor:
         self.domain_locks: dict[str, Any] = {}
 
         # Rate limiting and backoff management
-        self.domain_request_times: dict[str, float] = (
-            {}
-        )  # Track last request time per domain
-        self.domain_backoff_until: dict[str, float] = (
-            {}
-        )  # Track when domain is available again
-        self.domain_error_counts: dict[str, int] = (
-            {}
-        )  # Track consecutive errors per domain
+        self.domain_request_times: dict[
+            str, float
+        ] = {}  # Track last request time per domain
+        self.domain_backoff_until: dict[
+            str, float
+        ] = {}  # Track when domain is available again
+        self.domain_error_counts: dict[
+            str, int
+        ] = {}  # Track consecutive errors per domain
 
         try:
             self.unblock_rate_limit_seconds = float(
@@ -801,9 +798,9 @@ class ContentExtractor:
 
         # Selenium-specific failure tracking (separate from requests failures)
         # This prevents disabling Selenium for CAPTCHA-protected domains
-        self._selenium_failure_counts: dict[str, int] = (
-            {}
-        )  # Track Selenium failures per domain
+        self._selenium_failure_counts: dict[
+            str, int
+        ] = {}  # Track Selenium failures per domain
 
         # Base inter-request delay (env tunable)
         try:
@@ -863,7 +860,7 @@ class ContentExtractor:
             )
 
         logger.info(
-            f"🔀 Proxy manager initialized with provider: " f"{active_provider.value}"
+            f"🔀 Proxy manager initialized with provider: {active_provider.value}"
         )
 
         # MODIFIED: Use Squid proxy for all proxy traffic
@@ -1328,8 +1325,7 @@ class ContentExtractor:
                     new_proxy = random.choice(available)
                     self.domain_proxies[domain] = new_proxy
                     logger.info(
-                        f"Escalated proxy for {domain}: "
-                        f"{current_proxy} → {new_proxy}"
+                        f"Escalated proxy for {domain}: {current_proxy} → {new_proxy}"
                     )
 
     def _generate_referer(self, url: str) -> Optional[str]:
@@ -2354,7 +2350,7 @@ class ContentExtractor:
                         "secure": bool(c.get("secure", False)),
                         "httpOnly": bool(c.get("httpOnly", False)),
                         "domain": cookie_domain,
-                        "url": f"https://{domain}{c.get('path','/')}",
+                        "url": f"https://{domain}{c.get('path', '/')}",
                     }
                     expires = c.get("expires")
                     if isinstance(expires, (int, float)) and expires > 0:
@@ -2986,7 +2982,9 @@ class ContentExtractor:
                 if metrics:
                     metrics.start_method("unblock_proxy")
 
-                unblock_result = self._extract_with_unblock_proxy(url, None, metrics)
+                unblock_result = self._extract_with_unblock_proxy(
+                    url, None, metrics, domain=domain
+                )
 
                 if unblock_result and unblock_result.get("content"):
                     self._merge_extraction_results(
@@ -4010,6 +4008,7 @@ class ContentExtractor:
         url: str,
         browser_actions: Optional[list] = None,
         metrics: Optional[ExtractionMetrics] = None,
+        domain: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Extract content using Squid proxy for strong bot protection.
 
@@ -4018,6 +4017,12 @@ class ContentExtractor:
 
         Args:
             url: URL to extract
+            domain: When given, the proxy is chosen by the shared proxy_router
+                (home vs mizzou Squid, by live per-domain health) instead of
+                the static SQUID_PROXY_URL -- this was the one fetch rung that
+                still bypassed the router after #416/d30ee7f0 fixed the
+                primary session path; every unblock-proxy challenge always
+                landed on home Squid because mizzou Squid was never tried.
 
         Returns:
             Extraction result dict with title, author, content, etc.
@@ -4027,10 +4032,36 @@ class ContentExtractor:
 
             warnings.filterwarnings("ignore", message="Unverified HTTPS request")
 
-            # Route ALL unblock traffic through residential Squid proxy
-            squid_proxy_url = os.getenv(
-                "SQUID_PROXY_URL", "http://t9880447.eero.online:3128"
-            )
+            # Route through the shared proxy_router when we know the domain, so
+            # the home/mizzou choice and its health-based failover apply here
+            # too. get_requests_proxies_for_domain already falls back to the
+            # always-on home Squid if the router is unavailable or picks
+            # something unconfigured, so this can never end up direct.
+            router_proxies = None
+            router_proxy = None
+            if domain is not None:
+                try:
+                    router_proxies, router_proxy, _method = (
+                        self.proxy_manager.get_requests_proxies_for_domain(
+                            domain, service="newscrawler"
+                        )
+                    )
+                    self.domain_router_proxy[domain] = router_proxy
+                except Exception as exc:  # never let routing break extraction
+                    logger.warning(
+                        "proxy_router lookup failed for %s (%s); using static Squid",
+                        domain,
+                        exc,
+                    )
+
+            if router_proxies:
+                squid_proxy_url = router_proxies.get("http") or router_proxies.get(
+                    "https"
+                )
+            else:
+                squid_proxy_url = os.getenv(
+                    "SQUID_PROXY_URL", "http://t9880447.eero.online:3128"
+                )
 
             logger.info(
                 f"Using Squid proxy for unblock extraction: {_mask_proxy_url(squid_proxy_url)}"
@@ -4213,6 +4244,10 @@ class ContentExtractor:
                 logger.info(
                     f"✅ Squid proxy extraction successful for {url}: {len(result['content'])} chars"
                 )
+                if domain is not None:
+                    self.proxy_manager.report_domain_result(
+                        domain, router_proxy, success=True, service="newscrawler"
+                    )
                 return result
 
             except Exception as e:
@@ -4228,6 +4263,14 @@ class ContentExtractor:
 
         except Exception as e:
             logger.error(f"Squid proxy extraction failed for {url}: {e}")
+            if domain is not None:
+                self.proxy_manager.report_domain_result(
+                    domain,
+                    router_proxy,
+                    success=False,
+                    reason=str(e)[:200],
+                    service="newscrawler",
+                )
             # Don't wrap ProxyChallengeError - let it pass through with original message
             if isinstance(e, ProxyChallengeError):
                 raise e
@@ -4804,7 +4847,6 @@ class ContentExtractor:
 
             # If proxy has authentication, create Chrome extension
             if proxy_user and proxy_pass:
-
                 # Create Chrome extension for proxy authentication
                 import tempfile
                 import zipfile
@@ -5508,8 +5550,7 @@ class ContentExtractor:
             # Check for subscription wall (separate from CAPTCHA)
             if self._detect_subscription_wall(driver):
                 logger.warning(
-                    f"Subscription wall detected on {url} "
-                    f"(modal_closed={modal_closed})"
+                    f"Subscription wall detected on {url} (modal_closed={modal_closed})"
                 )
                 if modal_closed:
                     logger.info(

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -3409,9 +3409,13 @@ class ContentExtractor:
                 logger.debug(f"Primary extraction method: {method} (based on {field})")
                 return method
 
-        # Fallback to newspaper4k if no methods tracked
-        logger.warning("No extraction methods tracked, defaulting to newspaper4k")
-        return "newspaper4k"
+        # Nothing tracked: say so. This used to return "newspaper4k", which
+        # invented an attribution for whatever actually ran and silently
+        # inflated newspaper4k in every per-method analysis (19 occurrences in
+        # a 2h production sample). "unknown" is the honest answer;
+        # _select_raw_html_for_archive simply finds no match for it.
+        logger.warning("No extraction methods tracked; attribution is unknown")
+        return "unknown"
 
     def _is_extraction_successful(self, result: Dict[str, Any]) -> bool:
         """Check if extraction result contains meaningful content."""

--- a/src/crawler/proxy_relay.py
+++ b/src/crawler/proxy_relay.py
@@ -32,7 +32,7 @@ import logging
 import socket
 import threading
 import urllib.parse
-from typing import Optional, Tuple
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ _CONNECT_TIMEOUT = 20
 _IDLE_TIMEOUT = 180
 
 
-def split_proxy_url(proxy_url: str) -> Tuple[str, int, Optional[str], Optional[str]]:
+def split_proxy_url(proxy_url: str) -> tuple[str, int, str | None, str | None]:
     """Return (host, port, username, password) for a proxy URL.
 
     Accepts values with or without a scheme and with or without credentials.

--- a/src/crawler/proxy_relay.py
+++ b/src/crawler/proxy_relay.py
@@ -1,0 +1,247 @@
+"""Local unauthenticated proxy relay that adds Squid credentials upstream.
+
+Chrome cannot be given proxy credentials on the command line: ``--proxy-server``
+has no syntax for them. The long-standing workaround was a Manifest V2
+extension answering ``chrome.webRequest.onAuthRequired``. Chrome removed
+Manifest V2, and by Chrome 150 such an extension is ignored *silently* -- no
+error, no warning. Every Selenium fetch then reached the authenticated Squid
+with no credentials, got 407, and returned a ~0.2s "successful" navigation to
+an empty error page. Confirmed in production 2026-07-27: zero Selenium
+successes since 07-25 across ~500 attempts, and from inside an extraction pod
+``no-cred -> 407`` / ``with-cred -> 200``.
+
+Manifest V3 cannot replace it either -- blocking ``onAuthRequired`` is gone.
+
+So the credentials move out of the browser entirely. This relay listens on
+127.0.0.1, speaks plain HTTP proxy to Chrome with **no** authentication, and
+injects ``Proxy-Authorization`` on the way to the real Squid. Chrome never sees
+a credential and never has to support one, so no future browser change can
+break this the way MV2 removal did.
+
+Handles both proxy modes:
+  * ``CONNECT host:port``  -- HTTPS tunnels (the overwhelming majority)
+  * absolute-URI requests  -- plain HTTP
+
+Credentials are never logged; only the upstream host:port is.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import socket
+import threading
+import urllib.parse
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_BUF = 65536
+_CONNECT_TIMEOUT = 20
+_IDLE_TIMEOUT = 180
+
+
+def split_proxy_url(proxy_url: str) -> Tuple[str, int, Optional[str], Optional[str]]:
+    """Return (host, port, username, password) for a proxy URL.
+
+    Accepts values with or without a scheme and with or without credentials.
+    Raises ValueError when no host/port can be determined -- callers must not
+    silently fall through to an unproxied browser.
+    """
+    if not proxy_url:
+        raise ValueError("empty proxy url")
+
+    # Parsed by hand rather than with urlsplit: proxy passwords routinely
+    # contain ':' and '/', which make the URL invalid enough that urlsplit
+    # raises ("Port could not be cast to integer"). Raising here would refuse
+    # to start Selenium at all -- trading a silent outage for a loud one --
+    # so accept the raw forms operators actually put in SQUID_PROXY_URL.
+    rest = proxy_url.split("://", 1)[1] if "://" in proxy_url else proxy_url
+
+    # Credentials come off FIRST: a password may contain '/', so stripping a
+    # trailing path before this would silently truncate it.
+    username = password = None
+    if "@" in rest:
+        creds, rest = rest.rsplit("@", 1)  # last '@' -- host cannot contain one
+        if ":" in creds:
+            username, password = creds.split(":", 1)  # first ':' -- pw may hold more
+        else:
+            username = creds
+        username = urllib.parse.unquote(username)
+        password = urllib.parse.unquote(password) if password is not None else None
+
+    rest = rest.split("/", 1)[0]  # now safe: drop any trailing path
+    if ":" in rest:
+        host, _, port_text = rest.rpartition(":")
+        try:
+            port = int(port_text)
+        except ValueError as exc:
+            raise ValueError(
+                f"proxy url has a non-numeric port: {port_text!r}"
+            ) from exc
+    else:
+        host, port = rest, 3128
+
+    if not host:
+        raise ValueError("proxy url has no host")
+    return host, port, username, password
+
+
+def _pipe(src: socket.socket, dst: socket.socket) -> None:
+    """Shuttle bytes one way until either side closes."""
+    try:
+        while True:
+            chunk = src.recv(_BUF)
+            if not chunk:
+                break
+            dst.sendall(chunk)
+    except OSError:
+        pass
+    finally:
+        for sock in (src, dst):
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+
+class ProxyAuthRelay:
+    """Loopback proxy that forwards to an authenticated upstream proxy."""
+
+    def __init__(self, upstream_url: str):
+        host, port, user, password = split_proxy_url(upstream_url)
+        self.upstream_host = host
+        self.upstream_port = port
+        self._auth_header = b""
+        if user is not None and password is not None:
+            token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
+            self._auth_header = f"Proxy-Authorization: Basic {token}\r\n".encode()
+        self._server: Optional[socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self.port: Optional[int] = None
+
+    @property
+    def requires_auth(self) -> bool:
+        return bool(self._auth_header)
+
+    def start(self) -> str:
+        """Bind an ephemeral loopback port and serve. Returns the proxy URL."""
+        if self.port is not None:
+            return self.proxy_url
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", 0))
+        server.listen(128)
+        self._server = server
+        self.port = server.getsockname()[1]
+        self._thread = threading.Thread(
+            target=self._serve, name="proxy-auth-relay", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "🔐 Proxy auth relay on 127.0.0.1:%s -> %s:%s (credentials injected "
+            "server-side; Chrome sees an unauthenticated proxy)",
+            self.port,
+            self.upstream_host,
+            self.upstream_port,
+        )
+        return self.proxy_url
+
+    @property
+    def proxy_url(self) -> str:
+        if self.port is None:
+            raise RuntimeError("relay not started")
+        return f"127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        if self._server is not None:
+            try:
+                self._server.close()
+            except OSError:
+                pass
+        self._server = None
+        self.port = None
+
+    def _serve(self) -> None:
+        while True:
+            server = self._server
+            if server is None:
+                return
+            try:
+                client, _ = server.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(client,), daemon=True).start()
+
+    def _handle(self, client: socket.socket) -> None:
+        upstream: Optional[socket.socket] = None
+        try:
+            client.settimeout(_IDLE_TIMEOUT)
+            head = b""
+            while b"\r\n\r\n" not in head:
+                chunk = client.recv(_BUF)
+                if not chunk:
+                    return
+                head += chunk
+                if len(head) > 1_048_576:  # runaway header guard
+                    return
+
+            upstream = socket.create_connection(
+                (self.upstream_host, self.upstream_port), timeout=_CONNECT_TIMEOUT
+            )
+            upstream.settimeout(_IDLE_TIMEOUT)
+            upstream.sendall(self._with_auth(head))
+
+            threading.Thread(target=_pipe, args=(client, upstream), daemon=True).start()
+            _pipe(upstream, client)
+        except OSError as exc:
+            logger.debug("relay connection ended: %s", exc)
+        finally:
+            for sock in (client, upstream):
+                if sock is not None:
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
+
+    def _with_auth(self, head: bytes) -> bytes:
+        """Insert Proxy-Authorization after the request line.
+
+        Any client-supplied Proxy-Authorization is dropped first so ours is
+        authoritative and can't be duplicated.
+        """
+        if not self._auth_header:
+            return head
+        line_end = head.find(b"\r\n")
+        if line_end == -1:
+            return head
+        request_line = head[: line_end + 2]
+        rest = head[line_end + 2 :]
+        cleaned = b"".join(
+            line + b"\r\n"
+            for line in rest.split(b"\r\n")
+            if not line.lower().startswith(b"proxy-authorization:")
+        )
+        # split/rejoin leaves a trailing empty element -> normalise the
+        # header/body separator back to exactly one blank line.
+        cleaned = cleaned.rstrip(b"\r\n") + b"\r\n\r\n"
+        return request_line + self._auth_header + cleaned
+
+
+_relay: Optional[ProxyAuthRelay] = None
+_relay_lock = threading.Lock()
+
+
+def get_relay_proxy(upstream_url: str) -> str:
+    """Return a loopback ``host:port`` that proxies to ``upstream_url``.
+
+    One relay per process, reused across drivers. Raises ValueError if the
+    upstream URL is unusable -- callers must fail loudly rather than hand
+    Chrome no proxy at all.
+    """
+    global _relay
+    with _relay_lock:
+        if _relay is None or _relay.port is None:
+            _relay = ProxyAuthRelay(upstream_url)
+            _relay.start()
+        return _relay.proxy_url

--- a/src/utils/bot_sensitivity_manager.py
+++ b/src/utils/bot_sensitivity_manager.py
@@ -119,7 +119,18 @@ SENSITIVITY_ADJUSTMENT_RULES = {
     "rate_limit_429": (1, 8, 0.5),  # 30min base, scales up
     "connection_timeout": (1, 7, 0.5),  # 30min base, scales up
     "multiple_failures": (2, 9, 1.5),  # 1.5hr base, scales up
+    # AMP outcomes. These were emitted by the crawler but had no rule, so every
+    # one of them hit the "Unknown event type ... no adjustment" branch and the
+    # feedback loop was dead (19 occurrences in a 2h production sample). A
+    # successful AMP fetch is evidence the host is serving us fine, so it
+    # RELAXES sensitivity -- the only negative adjustments in this table.
+    "amp_preemptive_success": (-1, 10, 0.5),  # AMP worked first try
+    "amp_bypass_success": (-1, 10, 0.5),  # AMP got us past a block
+    "amp_bypass_failure": (1, 8, 0.5),  # AMP did not help; tighten
 }
+
+# Sensitivity is defined on 1..10; negative adjustments must not undershoot it.
+SENSITIVITY_FLOOR = 1
 
 # Known bot-sensitive publishers (pre-configured)
 # Add known aggressive bot detectors here with their sensitivity levels (1-10)
@@ -364,7 +375,10 @@ class BotSensitivityManager:
             return current
 
         # Calculate new sensitivity
+        # Clamped at both ends: max_cap bounds increases, SENSITIVITY_FLOOR
+        # bounds the negative (relaxing) adjustments added for AMP successes.
         new_sensitivity = min(current + increase, max_cap)
+        new_sensitivity = max(SENSITIVITY_FLOOR, new_sensitivity)
 
         return new_sensitivity
 

--- a/src/utils/comprehensive_telemetry.py
+++ b/src/utils/comprehensive_telemetry.py
@@ -32,8 +32,17 @@ PROXY_STATUS_BYPASSED = 3
 
 
 def proxy_status_to_int(status: str | None) -> int | None:
-    """Convert string proxy status to integer for database storage."""
+    """Convert string proxy status to integer for database storage.
+
+    Non-string input returns None rather than raising. Callers have passed an
+    int HTTP status here (the fetch path did exactly that), and the resulting
+    AttributeError propagated out of set_proxy_metrics *before* it assigned
+    router_proxy -- silently nulling that column on every row. A telemetry
+    coercion helper must never be able to take down the metrics it serves.
+    """
     if status is None:
+        return None
+    if not isinstance(status, str):
         return None
     status_map = {
         "disabled": PROXY_STATUS_DISABLED,
@@ -278,12 +287,18 @@ class ExtractionMetrics:
         self.proxy_used = proxy_used
         self.proxy_url = proxy_url
         self.proxy_authenticated = proxy_authenticated
-        self.proxy_status = proxy_status_to_int(proxy_status)
+        # Assign router_proxy BEFORE the status coercion. When that coercion
+        # raised (an int HTTP status reached proxy_status_to_int), the
+        # exception escaped this method with proxy_used/proxy_url already set
+        # but router_proxy never assigned -- which is precisely how
+        # router_proxy stayed NULL on 100% of rows while proxy_url looked
+        # fine. Ordering keeps the cheapest, most load-bearing field safe.
         if router_proxy:
             self.router_proxy = router_proxy
         if proxy_error:
             # Truncate long error messages
             self.proxy_error = proxy_error[:500]
+        self.proxy_status = proxy_status_to_int(proxy_status)
 
     def set_driver_metrics(self, payload: dict[str, Any] | None):
         """Attach driver/proxy telemetry payload for downstream analysis."""

--- a/src/utils/comprehensive_telemetry.py
+++ b/src/utils/comprehensive_telemetry.py
@@ -30,6 +30,11 @@ PROXY_STATUS_SUCCESS = 1
 PROXY_STATUS_FAILED = 2
 PROXY_STATUS_BYPASSED = 3
 
+# candidate_links.status values that mean "the pipeline deliberately declined
+# this body", as opposed to "extraction failed". Kept here so telemetry and the
+# extraction command cannot drift apart on what counts as a filter.
+_FILTERED_OUTCOMES = frozenset({"paywall", "not_article"})
+
 
 def proxy_status_to_int(status: str | None) -> int | None:
     """Convert string proxy status to integer for database storage.
@@ -322,8 +327,15 @@ class ExtractionMetrics:
 
         self.driver_metrics = sanitized
 
-    def finalize(self, final_result: dict[str, Any]):
-        """Finalize metrics with the overall extraction result."""
+    def finalize(self, final_result: dict[str, Any], outcome: str | None = None):
+        """Finalize metrics with the overall extraction result.
+
+        Args:
+            final_result: the extracted content dict.
+            outcome: the pipeline's own verdict for this URL (the value it
+                stored as candidate_links.status: extracted / wire / paywall /
+                not_article). When given it is AUTHORITATIVE -- see below.
+        """
         self.end_time = datetime.utcnow()
         duration_sec = (self.end_time - self.start_time).total_seconds()
         self.total_duration_ms = duration_sec * 1000
@@ -355,6 +367,32 @@ class ExtractionMetrics:
             # raw character count nor a title fixes that, because a wall can be
             # arbitrarily wordy — so qualify on what survives the boilerplate.
             self.is_success = looks_like_article(body)
+
+        # The pipeline's verdict wins over the inference above. Re-deriving
+        # success here made telemetry disagree with what was actually stored,
+        # in both directions (measured over 6h of production, 2026-07-27):
+        #
+        #  * 407 rows the furniture/paywall gate deliberately filtered were
+        #    recorded as is_success=false with NO error_type and NO message --
+        #    indistinguishable from a genuine failure. They are the reason the
+        #    failure rate read as 27% when much of it was by-design filtering.
+        #  * 75 rows stored as status='extracted', with a body, were recorded
+        #    as failures because looks_like_article() is stricter than the save
+        #    path. The pipeline kept the article and telemetry called it a loss.
+        #
+        # The gate empties `content` before finalize, so no body-based rule can
+        # tell "we chose to drop this" from "we failed to get it". Only the
+        # caller knows, so the caller says.
+        if outcome:
+            if outcome in _FILTERED_OUTCOMES:
+                self.is_success = False
+                self.error_type = f"filtered_{outcome}"
+                self.error_message = (
+                    f"Filtered by the extraction pipeline as {outcome}; "
+                    "body intentionally dropped, metadata retained"
+                )
+            else:
+                self.is_success = True
 
 
 class ComprehensiveExtractionTelemetry:

--- a/tests/cli/commands/test_extraction_content_validation.py
+++ b/tests/cli/commands/test_extraction_content_validation.py
@@ -249,7 +249,10 @@ class TestContentValidationLogic:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -375,7 +378,10 @@ class TestContentValidationLogic:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -505,7 +511,10 @@ class TestContentValidationLogic:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -624,7 +633,10 @@ class TestContentValidationLogic:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -744,7 +756,10 @@ class TestContentValidationLogic:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -851,7 +866,10 @@ class TestContentValidationLogic:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -1020,7 +1038,10 @@ class TestFurnitureShapeGate:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "DatabaseManager", FakeDBManager)
@@ -1295,7 +1316,10 @@ class TestInsufficientContentIntegration:
             def set_content_type_detection(self, *args):
                 pass
 
-            def finalize(self, *args):
+            # **kwargs so a new finalize() argument cannot silently blow up
+            # this fake: the production call now passes outcome=<status>,
+            # and a TypeError here is swallowed as an extraction failure.
+            def finalize(self, *args, **kwargs):
                 pass
 
         monkeypatch.setattr(extraction, "ExtractionMetrics", FakeMetrics)

--- a/tests/crawler/test_fetch_proxy_telemetry.py
+++ b/tests/crawler/test_fetch_proxy_telemetry.py
@@ -1,0 +1,218 @@
+"""Proxy/router telemetry must survive the fetch, on every parser path.
+
+Two independent defects nulled these columns in production simultaneously
+(confirmed live 2026-07-27 over 3,150 rows in 6h):
+
+1. ``set_proxy_metrics`` assigned ``proxy_status`` -- via
+   ``proxy_status_to_int`` -- BEFORE ``router_proxy``. The fetch path passed
+   the int HTTP status (200), ``status.lower()`` raised AttributeError, and
+   the exception escaped the method with proxy_used/proxy_url already set but
+   router_proxy never assigned. Result: router_proxy NULL on 100% of rows and
+   proxy_status NULL on 100% of rows, while proxy_url looked perfectly fine --
+   which is exactly why it read as "routing is broken" rather than
+   "telemetry is broken".
+
+2. ``_fetch_page_html`` recorded the proxy metadata only onto
+   ``self._last_fetch_proxy_metadata``, whose sole reader is
+   ``_parse_with_newspaper``. Whenever newspaper4k did not run -- the common
+   case -- proxy_used/proxy_url/router_proxy never reached telemetry at all.
+   2,621 of 3,150 rows reported proxy_used=0 with a perfect correlation to
+   newspaper4k not running, though every one of those fetches went through
+   Squid. The proxy was never bypassed; the evidence was.
+
+Both paths are covered here, in both the proxied and un-proxied states, so a
+regression on either cannot pass as green again.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.crawler import ContentExtractor
+from src.crawler.proxy_config import RouterProxy
+from src.utils.comprehensive_telemetry import (
+    PROXY_STATUS_SUCCESS,
+    ExtractionMetrics,
+    proxy_status_to_int,
+)
+
+
+class _NullLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def extractor():
+    """Bare extractor with just enough state for the fetch layer."""
+    ex = ContentExtractor.__new__(ContentExtractor)
+    ex.timeout = 30
+    ex.dead_url_ttl = 0
+    ex.dead_urls = {}
+    ex.domain_router_proxy = {}
+    ex.domain_sessions = {}
+    ex.domain_user_agents = {}
+    ex.proxy_manager = Mock()
+    ex.bot_sensitivity_manager = Mock()
+    ex._latest_wire_hints = None
+    ex._last_bot_protection_detection = None
+    ex._update_wire_hints_from_html = lambda *a, **k: None
+    ex._record_raw_html = lambda *a, **k: None
+    ex._check_rate_limit = lambda domain: False
+    ex._get_domain_lock = lambda domain: _NullLock()
+    ex._generate_referer = lambda url: None
+    ex._get_domain_amp_support = lambda domain: None
+    ex._reset_error_count = lambda domain: None
+    ex._handle_rate_limit_error = lambda *a, **k: None
+    ex._handle_connection_error_with_proxy_escalation = lambda *a, **k: None
+    ex._detect_bot_protection_in_response = lambda response: None
+    ex._record_bot_protection_detection = lambda *a, **k: None
+    return ex
+
+
+def _response(text="<html>page</html>", status=200):
+    response = Mock()
+    response.status_code = status
+    response.headers = {"content-type": "text/html"}
+    response.encoding = "utf-8"
+    response.apparent_encoding = "utf-8"
+    response.text = text
+    response.elapsed.total_seconds.return_value = 0.4
+    return response
+
+
+def _metrics():
+    return ExtractionMetrics(
+        "op-1", "article-1", "https://example.com/s", "example.com"
+    )
+
+
+class TestProxyStatusCoercion:
+    """proxy_status_to_int must never raise -- it runs inside telemetry."""
+
+    def test_int_status_returns_none_instead_of_raising(self):
+        # The exact production input. Used to raise AttributeError.
+        assert proxy_status_to_int(200) is None
+
+    def test_none_status_returns_none(self):
+        assert proxy_status_to_int(None) is None
+
+    def test_known_words_still_map(self):
+        assert proxy_status_to_int("success") == PROXY_STATUS_SUCCESS
+        assert proxy_status_to_int("SUCCESS") == PROXY_STATUS_SUCCESS
+
+    def test_unknown_word_returns_none(self):
+        assert proxy_status_to_int("nonsense") is None
+
+
+class TestSetProxyMetricsOrdering:
+    """router_proxy must not depend on the status coercion succeeding."""
+
+    def test_router_proxy_survives_bad_status_type(self):
+        metrics = _metrics()
+        # Shape of the call that used to silently drop router_proxy.
+        metrics.set_proxy_metrics(
+            proxy_used=True,
+            proxy_url="http://squid.example:3128",
+            proxy_authenticated=True,
+            proxy_status=200,
+            router_proxy="mizzou_squid",
+        )
+        assert metrics.router_proxy == "mizzou_squid"
+        assert metrics.proxy_used is True
+        assert metrics.proxy_url == "http://squid.example:3128"
+
+    def test_status_word_recorded_when_well_formed(self):
+        metrics = _metrics()
+        metrics.set_proxy_metrics(
+            proxy_used=True,
+            proxy_url="http://squid.example:3128",
+            proxy_status="success",
+            router_proxy="home_squid",
+        )
+        assert metrics.proxy_status == PROXY_STATUS_SUCCESS
+        assert metrics.router_proxy == "home_squid"
+
+
+class TestFetchRecordsProxyTelemetry:
+    """The fetch step itself must report proxy/router onto the metrics object.
+
+    Previously this only reached telemetry through _parse_with_newspaper, so
+    these assertions fail on the pre-fix code even though the fetch was
+    correctly proxied.
+    """
+
+    def test_records_router_proxy_without_any_parser_running(self, extractor):
+        session = Mock()
+        session.proxies = {"https": "http://user:pw@squid.example:3128"}
+        session.get.return_value = _response()
+        extractor._get_domain_session = lambda url: session
+        extractor.domain_router_proxy["example.com"] = RouterProxy.MIZZOU_SQUID
+
+        metrics = _metrics()
+        extractor._fetch_page_html("https://example.com/story", metrics=metrics)
+
+        # No parser has run at this point -- this is the fetch step alone.
+        assert metrics.router_proxy == RouterProxy.MIZZOU_SQUID.value
+        assert metrics.proxy_used is True
+        assert metrics.proxy_status == PROXY_STATUS_SUCCESS
+        assert "squid.example" in (metrics.proxy_url or "")
+
+    def test_credentials_are_masked_in_recorded_url(self, extractor):
+        session = Mock()
+        session.proxies = {"https": "http://user:sekret@squid.example:3128"}
+        session.get.return_value = _response()
+        extractor._get_domain_session = lambda url: session
+        extractor.domain_router_proxy["example.com"] = RouterProxy.HOME_SQUID
+
+        metrics = _metrics()
+        extractor._fetch_page_html("https://example.com/story", metrics=metrics)
+
+        assert "sekret" not in (metrics.proxy_url or "")
+        assert metrics.proxy_authenticated is True
+
+    def test_unproxied_session_records_no_proxy_and_no_status(self, extractor):
+        """The other state: a session without proxies must not claim one."""
+        session = Mock()
+        session.proxies = {}
+        session.get.return_value = _response()
+        extractor._get_domain_session = lambda url: session
+
+        metrics = _metrics()
+        extractor._fetch_page_html("https://example.com/story", metrics=metrics)
+
+        assert metrics.proxy_used is False
+        assert metrics.proxy_url is None
+        # No proxy was used, so there is no proxy status to report.
+        assert metrics.proxy_status is None
+        assert metrics.router_proxy is None
+
+    def test_router_proxy_absent_when_router_made_no_choice(self, extractor):
+        """Proxied by the static fallback, but the router never assigned one."""
+        session = Mock()
+        session.proxies = {"https": "http://squid.example:3128"}
+        session.get.return_value = _response()
+        extractor._get_domain_session = lambda url: session
+        # domain_router_proxy deliberately left empty for this domain.
+
+        metrics = _metrics()
+        extractor._fetch_page_html("https://example.com/story", metrics=metrics)
+
+        assert metrics.proxy_used is True
+        assert metrics.router_proxy is None
+
+    def test_fetch_still_returns_html_if_metrics_recording_breaks(self, extractor):
+        """Telemetry must never be able to discard a capture we already hold."""
+        session = Mock()
+        session.proxies = {"https": "http://squid.example:3128"}
+        session.get.return_value = _response(text="<html>body</html>")
+        extractor._get_domain_session = lambda url: session
+
+        metrics = Mock()
+        metrics.set_proxy_metrics.side_effect = RuntimeError("telemetry down")
+
+        html = extractor._fetch_page_html("https://example.com/story", metrics=metrics)
+        assert "body" in html

--- a/tests/crawler/test_mcmetadata_proxy_routing.py
+++ b/tests/crawler/test_mcmetadata_proxy_routing.py
@@ -18,7 +18,12 @@ from unittest.mock import Mock
 import pytest
 
 import src.crawler as crawler_module
-from src.crawler import ContentExtractor, NotFoundError, RateLimitError
+from src.crawler import (
+    ContentExtractor,
+    NotFoundError,
+    ProxyChallengeError,
+    RateLimitError,
+)
 
 
 class _NullLock:
@@ -228,6 +233,141 @@ class TestFingerprintSessionRouting:
 
         with pytest.raises(Exception, match="Bot protection"):
             extractor._fetch_page_html("https://example.com/story")
+
+
+class TestUnblockProxyRouting:
+    """The unblock-proxy fallback rung is what actually serves every
+    challenge/block retry (mcmetadata/newspaper4k/BeautifulSoup all failed
+    first). It bypassed the router even after d30ee7f0 fixed the primary
+    session path -- every challenge landed on home Squid because mizzou
+    Squid was never tried from here."""
+
+    def _article_html(self):
+        # >1000 bytes and no challenge-page phrase, so it clears the
+        # size/challenge checks and newspaper3k has something to parse.
+        body = "<p>Real article body text goes here. " * 40 + "</p>"
+        return f"<html><head><title>A Real Headline</title></head><body>{body}</body></html>"
+
+    def test_routes_through_router_and_records_choice(self, extractor, monkeypatch):
+        from src.crawler.proxy_router import RouterProxy
+
+        proxies = {
+            "http": "http://u:p@mizzou.squid:3128",
+            "https": "http://u:p@mizzou.squid:3128",
+        }
+        extractor.proxy_manager.get_requests_proxies_for_domain.return_value = (
+            proxies,
+            RouterProxy.MIZZOU_SQUID,
+            "sticky",
+        )
+        monkeypatch.setattr(
+            crawler_module.requests,
+            "get",
+            Mock(return_value=_response(text=self._article_html())),
+        )
+
+        extractor._extract_with_unblock_proxy(
+            "https://example.com/story", domain="example.com"
+        )
+
+        assert extractor.domain_router_proxy["example.com"] == RouterProxy.MIZZOU_SQUID
+        extractor.proxy_manager.get_requests_proxies_for_domain.assert_called_once_with(
+            "example.com", service="newscrawler"
+        )
+        _, get_kwargs = crawler_module.requests.get.call_args
+        assert get_kwargs["proxies"] == proxies
+
+    def test_no_domain_uses_static_squid_and_skips_router(self, extractor, monkeypatch):
+        monkeypatch.setenv("SQUID_PROXY_URL", "http://static.squid:3128")
+        monkeypatch.setattr(
+            crawler_module.requests,
+            "get",
+            Mock(return_value=_response(text=self._article_html())),
+        )
+
+        extractor._extract_with_unblock_proxy("https://example.com/story")
+
+        extractor.proxy_manager.get_requests_proxies_for_domain.assert_not_called()
+        _, get_kwargs = crawler_module.requests.get.call_args
+        assert get_kwargs["proxies"] == {
+            "http": "http://static.squid:3128",
+            "https": "http://static.squid:3128",
+        }
+
+    def test_router_failure_falls_back_to_static_never_direct(
+        self, extractor, monkeypatch
+    ):
+        monkeypatch.setenv("SQUID_PROXY_URL", "http://static.squid:3128")
+        extractor.proxy_manager.get_requests_proxies_for_domain.side_effect = (
+            RuntimeError("firestore down")
+        )
+        monkeypatch.setattr(
+            crawler_module.requests,
+            "get",
+            Mock(return_value=_response(text=self._article_html())),
+        )
+
+        extractor._extract_with_unblock_proxy(
+            "https://example.com/story", domain="example.com"
+        )
+
+        _, get_kwargs = crawler_module.requests.get.call_args
+        assert get_kwargs["proxies"] == {
+            "http": "http://static.squid:3128",
+            "https": "http://static.squid:3128",
+        }
+
+    def test_success_reports_to_router(self, extractor, monkeypatch):
+        from src.crawler.proxy_router import RouterProxy
+
+        extractor.proxy_manager.get_requests_proxies_for_domain.return_value = (
+            {
+                "http": "http://u:p@home.squid:3128",
+                "https": "http://u:p@home.squid:3128",
+            },
+            RouterProxy.HOME_SQUID,
+            "sticky",
+        )
+        monkeypatch.setattr(
+            crawler_module.requests,
+            "get",
+            Mock(return_value=_response(text=self._article_html())),
+        )
+
+        extractor._extract_with_unblock_proxy(
+            "https://example.com/story", domain="example.com"
+        )
+
+        extractor.proxy_manager.report_domain_result.assert_called_once_with(
+            "example.com", RouterProxy.HOME_SQUID, success=True, service="newscrawler"
+        )
+
+    def test_challenge_page_reports_failure_to_router(self, extractor, monkeypatch):
+        from src.crawler.proxy_router import RouterProxy
+
+        extractor.proxy_manager.get_requests_proxies_for_domain.return_value = (
+            {
+                "http": "http://u:p@mizzou.squid:3128",
+                "https": "http://u:p@mizzou.squid:3128",
+            },
+            RouterProxy.MIZZOU_SQUID,
+            "sticky",
+        )
+        monkeypatch.setattr(
+            crawler_module.requests,
+            "get",
+            Mock(return_value=_response(text="short", status=403)),
+        )
+
+        with pytest.raises(ProxyChallengeError):
+            extractor._extract_with_unblock_proxy(
+                "https://example.com/story", domain="example.com"
+            )
+
+        args, kwargs = extractor.proxy_manager.report_domain_result.call_args
+        assert args[0] == "example.com"
+        assert args[1] == RouterProxy.MIZZOU_SQUID
+        assert kwargs["success"] is False
 
 
 class TestOptionalDependencyBothStates:

--- a/tests/crawler/test_selenium_proxy_auth.py
+++ b/tests/crawler/test_selenium_proxy_auth.py
@@ -1,0 +1,231 @@
+"""Selenium must reach Squid *authenticated*, by a mechanism Chrome supports.
+
+The outage these tests pin against (production, 2026-07-25 → 07-27): Chrome
+cannot take proxy credentials on the command line, so the code shipped them in
+a Manifest V2 extension answering ``chrome.webRequest.onAuthRequired``. Chrome
+removed Manifest V2. By Chrome 150 the extension is ignored **silently** -- no
+exception, no warning -- so every Selenium fetch hit the authenticated Squid
+with no credentials, got 407, and returned a ~0.2s "navigation succeeded" on an
+empty error page. Zero Selenium successes across ~500 attempts; stltoday.com
+(Selenium-only, HTTP methods disabled) went to 100% failure with no fallback.
+
+Nothing caught it because **no test touched the Selenium proxy-auth path at
+all** -- no reference anywhere in tests/ to manifest_version, onAuthRequired,
+add_extension or --proxy-server. It was pure configuration, and configuration
+is exactly what a mocked driver cannot validate.
+
+So these tests assert the property that actually matters and that a browser
+upgrade can silently violate: **credentials must leave the process attached to
+the request**, and the browser must never be handed a bare proxy it cannot
+authenticate to. They exercise the real relay over real sockets against a fake
+upstream Squid that demands Proxy-Authorization -- no Chrome required.
+"""
+
+import base64
+import socket
+import threading
+
+import pytest
+
+from src.crawler.proxy_relay import ProxyAuthRelay, split_proxy_url
+
+UPSTREAM_USER = "mizzoucrawler"
+UPSTREAM_PASS = "s3kr3t:with/chars"
+
+
+class FakeSquid:
+    """Minimal upstream proxy that requires Basic auth, like the real Squid."""
+
+    def __init__(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(8)
+        self.port = self.sock.getsockname()[1]
+        self.seen_headers: list[bytes] = []
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while True:
+            try:
+                conn, _ = self.sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn):
+        try:
+            head = b""
+            while b"\r\n\r\n" not in head:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    return
+                head += chunk
+            self.seen_headers.append(head)
+            expected = base64.b64encode(
+                f"{UPSTREAM_USER}:{UPSTREAM_PASS}".encode()
+            ).decode("ascii")
+            if (
+                f"Proxy-Authorization: Basic {expected}".lower()
+                in head.decode("latin-1").lower()
+            ):
+                conn.sendall(b"HTTP/1.1 200 Connection established\r\n\r\nOK-BODY")
+            else:
+                # Exactly what production Chrome received: 407, fast, empty.
+                conn.sendall(
+                    b"HTTP/1.1 407 Proxy Authentication Required\r\n"
+                    b'Proxy-Authenticate: Basic realm="squid"\r\n\r\n'
+                )
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def stop(self):
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def squid():
+    s = FakeSquid()
+    yield s
+    s.stop()
+
+
+@pytest.fixture
+def relay(squid):
+    r = ProxyAuthRelay(f"http://{UPSTREAM_USER}:{UPSTREAM_PASS}@127.0.0.1:{squid.port}")
+    r.start()
+    yield r
+    r.stop()
+
+
+def _speak(endpoint: str, request: bytes) -> bytes:
+    host, port = endpoint.split(":")
+    with socket.create_connection((host, int(port)), timeout=10) as sock:
+        sock.sendall(request)
+        sock.settimeout(10)
+        out = b""
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                out += chunk
+        except OSError:
+            pass
+        return out
+
+
+class TestProxyUrlParsing:
+    def test_extracts_credentials(self):
+        host, port, user, password = split_proxy_url("http://u:p@squid.example:3128")
+        assert (host, port, user, password) == ("squid.example", 3128, "u", "p")
+
+    def test_percent_encoded_credentials_are_decoded(self):
+        _, _, user, password = split_proxy_url("http://u%40x:p%2Fw@h:3128")
+        assert (user, password) == ("u@x", "p/w")
+
+    def test_no_credentials(self):
+        host, port, user, password = split_proxy_url("http://squid.example:3128")
+        assert (host, port) == ("squid.example", 3128)
+        assert user is None and password is None
+
+    def test_scheme_optional(self):
+        assert split_proxy_url("squid.example:3128")[0] == "squid.example"
+
+    @pytest.mark.parametrize("bad", ["", "://", "http://"])
+    def test_unusable_url_raises(self, bad):
+        """Must raise, never silently yield an unproxied browser."""
+        with pytest.raises(ValueError):
+            split_proxy_url(bad)
+
+
+class TestRelayAuthenticatesUpstream:
+    """The regression: the browser is unauthenticated; the relay supplies auth."""
+
+    def test_connect_tunnel_is_authenticated(self, relay, squid):
+        # Chrome speaks CONNECT with NO credentials -- it has no way to send any.
+        reply = _speak(
+            relay.proxy_url,
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+        )
+        assert b"200" in reply, f"expected upstream 200, got: {reply[:80]!r}"
+        assert b"407" not in reply
+
+    def test_plain_http_request_is_authenticated(self, relay, squid):
+        reply = _speak(
+            relay.proxy_url,
+            b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n",
+        )
+        assert b"200" in reply
+        assert b"407" not in reply
+
+    def test_credentials_actually_reach_upstream(self, relay, squid):
+        _speak(
+            relay.proxy_url,
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+        )
+        assert squid.seen_headers, "upstream never saw a request"
+        assert b"Proxy-Authorization: Basic " in squid.seen_headers[0]
+
+    def test_request_line_is_preserved_verbatim(self, relay, squid):
+        """Auth is inserted after the request line, not over it."""
+        _speak(
+            relay.proxy_url,
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+        )
+        assert squid.seen_headers[0].startswith(b"CONNECT example.com:443 HTTP/1.1\r\n")
+
+    def test_client_supplied_auth_is_replaced_not_duplicated(self, relay, squid):
+        _speak(
+            relay.proxy_url,
+            b"CONNECT example.com:443 HTTP/1.1\r\n"
+            b"Proxy-Authorization: Basic Zm9yZ2Vk\r\n"
+            b"Host: example.com:443\r\n\r\n",
+        )
+        head = squid.seen_headers[0]
+        assert head.count(b"Proxy-Authorization:") == 1
+        assert b"Zm9yZ2Vk" not in head
+
+    def test_headers_end_with_exactly_one_blank_line(self, relay, squid):
+        """A mangled header/body separator would break the upstream parse."""
+        _speak(
+            relay.proxy_url,
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+        )
+        head = squid.seen_headers[0]
+        assert head.endswith(b"\r\n\r\n")
+        assert not head.endswith(b"\r\n\r\n\r\n")
+
+
+class TestRelayWithoutCredentials:
+    """The other state: an upstream that needs no auth must still work."""
+
+    def test_unauthenticated_upstream_is_passed_through(self, squid):
+        relay = ProxyAuthRelay(f"http://127.0.0.1:{squid.port}")
+        relay.start()
+        try:
+            assert relay.requires_auth is False
+            reply = _speak(
+                relay.proxy_url,
+                b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+            )
+            # FakeSquid demands auth, so this correctly fails -- proving the
+            # relay does not fabricate credentials it was never given.
+            assert b"407" in reply
+            assert b"Proxy-Authorization" not in squid.seen_headers[0]
+        finally:
+            relay.stop()
+
+    def test_relay_binds_loopback_only(self, relay):
+        """Never expose an open proxy to the network."""
+        host, _ = relay.proxy_url.split(":")
+        assert host == "127.0.0.1"

--- a/tests/crawler/test_tls_capture_rung.py
+++ b/tests/crawler/test_tls_capture_rung.py
@@ -105,7 +105,12 @@ def harness(monkeypatch):
         calls.append("beautifulsoup")
         return _partial_result("beautifulsoup")
 
-    def tls(url, html=None, metrics=None):
+    def tls(url, html=None, metrics=None, domain=None):
+        # `domain` mirrors the production signature: 3a06db3c threaded it in so
+        # this rung consults the shared proxy_router. A stub missing it raises
+        # TypeError, which the caller's broad `except Exception` swallows -- the
+        # rung then silently never runs and every assertion here fails with
+        # "'tls_client' is not in list" rather than a signature error.
         calls.append("tls_client")
         return _full_result("unblock_proxy")
 
@@ -191,8 +196,10 @@ def test_successful_tls_capture_prevents_the_selenium_escalation(harness):
 
 def test_tls_failure_still_escalates_to_selenium(harness):
     """A failed rung must not strand the article."""
-    harness.ex._extract_with_unblock_proxy = lambda url, html=None, metrics=None: (
-        harness.calls.append("tls_client") or {}
+    harness.ex._extract_with_unblock_proxy = (
+        lambda url, html=None, metrics=None, domain=None: (
+            harness.calls.append("tls_client") or {}
+        )
     )
 
     _run(harness)
@@ -208,7 +215,7 @@ def test_tls_failure_still_escalates_to_selenium(harness):
 def test_challenge_on_flagged_domain_is_still_terminal(harness):
     """Flagged domains mark the article for retry and skip Selenium — as before."""
 
-    def challenged(url, html=None, metrics=None):
+    def challenged(url, html=None, metrics=None, domain=None):
         harness.calls.append("tls_client")
         raise ProxyChallengeError("blocked")
 
@@ -228,7 +235,7 @@ def test_challenge_on_unflagged_domain_must_not_abort_extraction(harness):
     failing outright.
     """
 
-    def challenged(url, html=None, metrics=None):
+    def challenged(url, html=None, metrics=None, domain=None):
         harness.calls.append("tls_client")
         raise ProxyChallengeError("blocked")
 
@@ -243,7 +250,7 @@ def test_challenge_on_unflagged_domain_must_not_abort_extraction(harness):
 def test_unexpected_error_in_the_rung_is_swallowed(harness):
     """A broken rung degrades to the previous escalation path."""
 
-    def boom(url, html=None, metrics=None):
+    def boom(url, html=None, metrics=None, domain=None):
         harness.calls.append("tls_client")
         raise RuntimeError("tls_client exploded")
 

--- a/tests/test_telemetry_outcome_fidelity.py
+++ b/tests/test_telemetry_outcome_fidelity.py
@@ -1,0 +1,150 @@
+"""Telemetry must report what the pipeline actually did.
+
+Three defects found by reading 6h of production rows on 2026-07-27, all of the
+same shape -- telemetry re-deriving or inventing a fact it was never told:
+
+1. ``finalize()`` decided success by re-running ``looks_like_article()`` on the
+   body. But the furniture/paywall gate EMPTIES the body before finalize, so a
+   deliberate filter was indistinguishable from a failed capture: 407 rows
+   landed as is_success=false with no error_type and no message. They are why
+   the failure rate read as 27% when much of it was by-design filtering.
+
+2. The same re-derivation disagreed in the other direction: 75 rows stored as
+   ``status='extracted'`` WITH a body were recorded as failures, because
+   ``looks_like_article()`` is stricter than the save path. The pipeline kept
+   the article; telemetry called it a loss.
+
+3. ``_determine_primary_extraction_method()`` returned a hardcoded
+   "newspaper4k" when nothing was tracked, inventing an attribution for
+   whatever really ran and inflating newspaper4k in per-method analysis.
+
+Plus the dead feedback loop: every AMP event the crawler emitted was missing
+from SENSITIVITY_ADJUSTMENT_RULES, so all of them hit "Unknown event type, no
+adjustment".
+"""
+
+import pytest
+
+from src.utils.bot_sensitivity_manager import (
+    SENSITIVITY_ADJUSTMENT_RULES,
+    SENSITIVITY_FLOOR,
+)
+from src.utils.comprehensive_telemetry import ExtractionMetrics
+
+ARTICLE = "The council approved the measure on Tuesday evening. " * 8
+
+
+def _metrics():
+    return ExtractionMetrics("op", "art", "https://example.com/s", "example.com")
+
+
+class TestFilteredOutcomesAreDistinguishable:
+    """A deliberate filter must not look like a failed extraction."""
+
+    @pytest.mark.parametrize("outcome", ["paywall", "not_article"])
+    def test_filter_records_a_reason(self, outcome):
+        m = _metrics()
+        # The gate empties the body before finalize -- that is the whole problem.
+        m.finalize({"title": "Headline", "content": ""}, outcome=outcome)
+
+        assert m.is_success is False
+        assert m.error_type == f"filtered_{outcome}", "must not be a bare failure"
+        assert m.error_message, "a filtered row must say why"
+
+    def test_filtered_is_not_confusable_with_a_real_error(self):
+        """The 551 silent rows had error_type IS NULL -- that is the tell."""
+        m = _metrics()
+        m.finalize({"content": ""}, outcome="not_article")
+        assert m.error_type is not None
+
+
+class TestPipelineVerdictWins:
+    """The caller knows the outcome; telemetry must not overrule it."""
+
+    def test_stored_article_is_not_recorded_as_a_failure(self):
+        """The 75-row contradiction: saved as extracted, logged as failed."""
+        m = _metrics()
+        # Short body the save path accepted but looks_like_article() rejects.
+        m.finalize({"title": "Headline", "content": "Brief item."}, outcome="extracted")
+        assert m.is_success is True
+
+    def test_wire_counts_as_a_success(self):
+        m = _metrics()
+        m.finalize({"title": "H", "content": ARTICLE}, outcome="wire")
+        assert m.is_success is True
+        assert m.error_type is None
+
+    def test_without_an_outcome_the_body_still_decides(self):
+        """Callers that pass no verdict keep the old inference."""
+        good = _metrics()
+        good.finalize({"title": "H", "content": ARTICLE})
+        assert good.is_success is True
+
+        empty = _metrics()
+        empty.finalize({"title": "H", "content": ""})
+        assert empty.is_success is False
+
+    def test_content_length_still_reflects_the_stored_body(self):
+        m = _metrics()
+        m.finalize({"content": ARTICLE}, outcome="extracted")
+        assert m.content_length == len(ARTICLE)
+
+
+class TestAttributionIsNotInvented:
+    """An untracked method is "unknown", not a guess dressed up as a fact."""
+
+    def test_no_tracked_methods_reports_unknown(self):
+        from src.crawler import ContentExtractor
+
+        ex = ContentExtractor.__new__(ContentExtractor)
+        # Used to return "newspaper4k" here, inflating it in every per-method
+        # analysis for whatever method had actually run.
+        assert ex._determine_primary_extraction_method({"extraction_methods": {}}) == (
+            "unknown"
+        )
+
+    def test_a_tracked_method_is_still_reported(self):
+        from src.crawler import ContentExtractor
+
+        ex = ContentExtractor.__new__(ContentExtractor)
+        result = {"extraction_methods": {"content": "mcmetadata"}}
+        assert ex._determine_primary_extraction_method(result) == "mcmetadata"
+
+    def test_none_valued_methods_do_not_count_as_tracked(self):
+        from src.crawler import ContentExtractor
+
+        ex = ContentExtractor.__new__(ContentExtractor)
+        result = {"extraction_methods": {"content": "none", "title": None}}
+        assert ex._determine_primary_extraction_method(result) == "unknown"
+
+
+class TestAmpEventsAdjustSensitivity:
+    """Every event the crawler emits must have a rule, or the loop is dead."""
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            "amp_preemptive_success",
+            "amp_bypass_success",
+            "amp_bypass_failure",
+            "captcha_detected",
+        ],
+    )
+    def test_emitted_event_is_known(self, event):
+        assert event in SENSITIVITY_ADJUSTMENT_RULES
+
+    @pytest.mark.parametrize("event", ["amp_preemptive_success", "amp_bypass_success"])
+    def test_success_relaxes_rather_than_tightens(self, event):
+        increase, _, _ = SENSITIVITY_ADJUSTMENT_RULES[event]
+        assert increase < 0, "a working fetch must not raise sensitivity"
+
+    def test_bypass_failure_tightens(self):
+        increase, _, _ = SENSITIVITY_ADJUSTMENT_RULES["amp_bypass_failure"]
+        assert increase > 0
+
+    def test_every_rule_stays_inside_the_valid_range(self):
+        """A negative adjustment must not be able to undershoot the floor."""
+        for event, (increase, max_cap, _) in SENSITIVITY_ADJUSTMENT_RULES.items():
+            for current in range(SENSITIVITY_FLOOR, 11):
+                new = max(SENSITIVITY_FLOOR, min(current + increase, max_cap))
+                assert SENSITIVITY_FLOOR <= new <= 10, f"{event} at {current} -> {new}"


### PR DESCRIPTION
## The headline: Selenium has extracted nothing since 2026-07-25

Not degraded — **zero successes across ~500 attempts**. `www.stltoday.com` went 77-100% → **0% on 07-22** and stayed there. It looked like a single-site problem only because stltoday is Selenium-only with HTTP methods disabled, so it has no fallback; every other Selenium-dependent domain was failing quietly behind HTTP fallbacks.

**Root cause.** Chrome has no command-line syntax for proxy credentials, so the code shipped them in a **Manifest V2** extension answering `chrome.webRequest.onAuthRequired`. Chrome removed Manifest V2. The pods run **Chrome 150**, which ignores such an extension **silently** — no exception, no warning. Chrome then hit the authenticated Squid with no credentials, got 407, and Selenium logged `navigation succeeded on attempt 1` in ~0.2s with a body present and no content — indistinguishable from a slow or empty site.

Proven from inside an extraction pod: **no-cred → 407, with-cred → 200.** The tell in the logs was `SELENIUM_PHASE driver_get 0.23s`; a real proxied load takes seconds.

Manifest V3 cannot restore it — blocking `onAuthRequired` no longer exists. So credentials leave the browser entirely: a **loopback relay** (`src/crawler/proxy_relay.py`) speaks unauthenticated proxy to Chrome and injects `Proxy-Authorization` upstream. Chrome never sees a credential and never needs to support one, so no future browser release can break it the same way. **Verified end-to-end inside a production pod against the real Squid**: the same unauthenticated CONNECT that returned 407 now returns 200.

All **three** driver paths were affected and all three now use the relay — the primary undetected driver, its fallback (which built a *second* MV2 extension), and the stealth driver (which passed credentials inside `--proxy-server`, where Chrome discards them). Relay failure now raises rather than proceeding: an unproxied browser egresses the pod IP, the exact leak the proxy exists to prevent.

## Telemetry was misreporting production in four ways

Found by reading 6h of rows, not by reading CI.

1. **`router_proxy` NULL on 100% of rows** despite #422 (column) and #425 (router) both being correctly deployed — the running container was confirmed to contain the fix. `set_proxy_metrics()` assigned `proxy_status` *before* `router_proxy`; the fetch path passed the int HTTP status into `proxy_status_to_int()`, whose `status.lower()` raised, escaping the method before `router_proxy` was ever set. That is why `proxy_url` looked healthy while `router_proxy` was empty. Routing itself was never broken.
2. **`proxy_used=0` on 2,621 of 3,150 rows.** `_fetch_page_html()` published proxy metadata only to `_last_fetch_proxy_metadata`, whose sole reader is `_parse_with_newspaper`. Correlation was exact: 100% of `proxy_used=1` rows had newspaper4k in `methods_attempted`, 100% of `proxy_used=0` rows did not. **Those fetches were proxied — only the evidence was lost.** Not a proxy bypass.
3. **407 filtered rows recorded as bare failures** (no `error_type`, no message) and **75 stored articles recorded as losses.** `finalize()` re-derived success from the body, but the furniture/paywall gate empties the body first, so a deliberate filter was indistinguishable from a failed capture. It now takes the caller's own verdict (`candidate_links.status`) as authoritative. This is why the failure rate read as 27% when much of it was by-design filtering.
4. **Dead feedback loop + invented data.** Every AMP event the crawler emits was missing from `SENSITIVITY_ADJUSTMENT_RULES`, so all hit "Unknown event type, no adjustment"; successes now *relax* sensitivity (with a floor clamp, since `min(current + increase, max_cap)` alone would undershoot 1). And `_determine_primary_extraction_method()` returned a hardcoded `"newspaper4k"` when nothing was tracked, inflating it in every per-method analysis — now `"unknown"`.

## Fallout from `3a06db3c` (already on this branch)

That commit could not have passed the pre-push hook as written. Three separate blockers, all fixed here:

- **6 broken tests** in `test_tls_capture_rung.py` — it added a `domain=` kwarg without updating the stubs. The stub raised `TypeError`, the caller's broad `except Exception` swallowed it, and the rung silently never ran, so failures pointed at trigger logic instead of a signature mismatch.
- **A mypy-visible egress hole** — a truthy `router_proxies` dict missing both keys left the proxy URL `None`, and `requests` reads `proxies={"http": None}` as **no proxy**.
- **Black drift** — 26 lines reformatted with an older black, restored to match `main`.

## Why no test caught the Selenium outage

**Nothing in `tests/` referenced `manifest_version`, `onAuthRequired`, `add_extension`, or `--proxy-server.`** The entire auth path was unasserted configuration, and configuration is exactly what a mocked driver cannot validate — the same class of miss as the pod-IP proxy bypass. The new tests drive the real relay over real sockets against a fake Squid that demands `Proxy-Authorization`, asserting the property a browser upgrade can silently violate: credentials must arrive upstream. Writing them caught a further latent bug — a password containing `:` or `/` broke `urlsplit` and would have refused to start Selenium at all.

## Verification

- Full suite **2901 passed, 0 failed**; pre-push hook green on all six steps including the 80% coverage gate.
- Regression tests confirmed to **fail on the pre-fix code** (stashed and re-run), not just pass on the new — 5 for the router_proxy fix, 6 for the outcome fix, plus the relay and event-rule assertions.
- Both states covered throughout: proxied/un-proxied, filtered/stored, tracked/untracked attribution, authenticated/open upstream.

## After deploy — verify against data, not CI

```sql
-- Selenium should come back to life; stltoday especially
SELECT date_trunc('day', created_at)::date, count(*), sum(is_success::int)
FROM extraction_telemetry_v2
WHERE host = 'www.stltoday.com' AND created_at > now() - interval '3 days'
GROUP BY 1 ORDER BY 1 DESC;

-- router_proxy must stop being NULL
SELECT coalesce(router_proxy,'(NULL)'), count(*)
FROM extraction_telemetry_v2
WHERE created_at > now() - interval '1 hour' GROUP BY 1;
```

**Deploy note:** the `detect-changes` path filter does not map `src/crawler/` to the **processor**, but `continuous_processor` runs extraction — so a crawler-only change rebuilds the crawler and leaves the processor on the old image. This PR touches `src/crawler/`, `src/utils/` and `src/cli/`, so confirm both crawler *and* processor images actually rebuild before assuming the Selenium fix is live.

Extraction is currently **stopped**, backlog frozen at **8,130**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
