### PR TITLE
fix(deploy): the Argo WorkflowTemplate never updated, and versions.env could never land

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -666,6 +666,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v7
@@ -688,6 +689,8 @@ jobs:
           PROCESSOR_BUILD_ID: ${{ needs.build-processor.outputs.build_id }}
           API_BUILD_ID: ${{ needs.build-api.outputs.build_id }}
           CRAWLER_BUILD_ID: ${{ needs.build-crawler.outputs.build_id }}
+          # Required by `gh pr create` below.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHORT=${SHORT_SHA:0:7}
           ARGS=()
@@ -710,6 +713,25 @@ jobs:
             echo "versions.env and Argo workflow already up to date"
             exit 0
           fi
+          # A direct push to main is rejected by the repository ruleset
+          # (GH013: "Repository rule violations found for refs/heads/main"),
+          # so this job resolved the tags correctly and then failed at the very
+          # last step -- leaving versions.env stale for a permissions reason
+          # after the earlier logic bug was fixed. This repo lands changes by
+          # PR, so open one.
+          BRANCH="chore/image-tags-${SHORT}"
           git add k8s/versions.env k8s/argo/base-pipeline-workflow.yaml
           git commit -m "chore: update image tags (${SHORT}) [skip ci]"
-          git push origin HEAD
+          # --force so a re-run of the same SHA updates its branch rather than
+          # failing on a non-fast-forward.
+          git push --force origin "HEAD:refs/heads/${BRANCH}"
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR for ${BRANCH} already open; branch updated."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: update image tags (${SHORT})" \
+              --body "Automated by the update-versions-env job after a successful build of ${SHORT}. Records the image tags now deployed, so k8s/versions.env (used by envsubst for the manifests) and the repo Argo template match production. Bookkeeping only -- the images are already built and rolled out."
+          fi

--- a/gcp/cloudbuild/cloudbuild-crawler.yaml
+++ b/gcp/cloudbuild/cloudbuild-crawler.yaml
@@ -83,12 +83,17 @@ steps:
     args:
       - '-c'
       - |
-        if [ "${BRANCH_NAME}" = "main" ]; then
-          echo "🔄 Updating Argo WorkflowTemplate with crawler:${SHORT_SHA}..."
-          bash gcp/cloudbuild/update-workflow-template.sh crawler "${SHORT_SHA}" "${_REGISTRY}"
-        else
-          echo "ℹ️  Skipping Argo WorkflowTemplate update - not on main branch (${BRANCH_NAME})"
-        fi
+        # NOT gated on BRANCH_NAME. CI/CD invokes this trigger as
+        # `gcloud builds triggers run build-crawler-manual --sha=<sha>`, and a
+        # run started by SHA leaves BRANCH_NAME empty -- so this step took the
+        # "not on main" path on EVERY deploy and the WorkflowTemplate silently
+        # never updated. Live proof 2026-07-28: Deployments were on 60872f7
+        # while the template still ran 2bc05a2, i.e. extraction would have kept
+        # using the previous image. Every other deploy step in this file
+        # (update-work-queue, the cronjob) is ungated and repoints production
+        # already; this one was the odd one out.
+        echo "🔄 Updating Argo WorkflowTemplate with crawler:${SHORT_SHA}..."
+        bash gcp/cloudbuild/update-workflow-template.sh crawler "${SHORT_SHA}" "${_REGISTRY}"
     waitFor: ['get-gke-credentials']
 
 images:

--- a/gcp/cloudbuild/cloudbuild-processor.yaml
+++ b/gcp/cloudbuild/cloudbuild-processor.yaml
@@ -122,12 +122,17 @@ steps:
     args:
       - '-c'
       - |
-        if [ "${BRANCH_NAME}" = "main" ]; then
-          echo "🔄 Updating Argo WorkflowTemplate with processor:${SHORT_SHA}..."
-          bash gcp/cloudbuild/update-workflow-template.sh processor "${SHORT_SHA}" "${_REGISTRY}"
-        else
-          echo "ℹ️  Skipping Argo WorkflowTemplate update - not on main branch (${BRANCH_NAME})"
-        fi
+        # NOT gated on BRANCH_NAME. CI/CD invokes this trigger as
+        # `gcloud builds triggers run build-processor-manual --sha=<sha>`, and a
+        # run started by SHA leaves BRANCH_NAME empty -- so this step took the
+        # "not on main" path on EVERY deploy and the WorkflowTemplate silently
+        # never updated. Live proof 2026-07-28: Deployments were on 60872f7
+        # while the template still ran 2bc05a2, i.e. extraction would have kept
+        # using the previous image. Every other deploy step in this file
+        # (update-work-queue, the cronjob) is ungated and repoints production
+        # already; this one was the odd one out.
+        echo "🔄 Updating Argo WorkflowTemplate with processor:${SHORT_SHA}..."
+        bash gcp/cloudbuild/update-workflow-template.sh processor "${SHORT_SHA}" "${_REGISTRY}"
     waitFor: ['get-gke-credentials']
 
 images:

--- a/k8s/versions.env
+++ b/k8s/versions.env
@@ -6,12 +6,11 @@
 # IDs from jobs it did not declare in `needs:`, so they were always empty),
 # which left these tags months behind what was actually deployed.
 #
-# 2026-07-28: that job now resolves the tags correctly, but its push to
-# main is rejected by a repository ruleset (GH013) -- it commits
-# `chore: update image tags` and cannot land it. So this file still goes
-# stale after every deploy, now for a permissions reason rather than a
-# logic one. Either exempt the bot from the ruleset or have the job open
-# a PR; until then these values are reconciled by hand.
+# 2026-07-28: the job resolved the tags correctly but pushed straight to main,
+# which the repository ruleset rejects (GH013) -- so it failed at the last step
+# and this file stayed stale for a permissions reason rather than a logic one.
+# It now opens a PR instead, matching how everything else lands here. The values
+# below were reconciled by hand for the 60872f7 deploy that hit the old bug.
 export PROCESSOR_TAG=60872f7
 export CRAWLER_TAG=60872f7
 export API_TAG=60872f7

--- a/k8s/versions.env
+++ b/k8s/versions.env
@@ -4,8 +4,14 @@
 # Maintained by the update-versions-env job in build-and-deploy-services.yml.
 # That job silently no-opped from 2026-04-03 until 2026-07-26 (it read build
 # IDs from jobs it did not declare in `needs:`, so they were always empty),
-# which left these tags months behind what was actually deployed. Values below
-# were reconciled by hand against the live cluster at the time of that fix.
-export PROCESSOR_TAG=613a942
-export CRAWLER_TAG=2bba720
-export API_TAG=2bba720
+# which left these tags months behind what was actually deployed.
+#
+# 2026-07-28: that job now resolves the tags correctly, but its push to
+# main is rejected by a repository ruleset (GH013) -- it commits
+# `chore: update image tags` and cannot land it. So this file still goes
+# stale after every deploy, now for a permissions reason rather than a
+# logic one. Either exempt the bot from the ruleset or have the job open
+# a PR; until then these values are reconciled by hand.
+export PROCESSOR_TAG=60872f7
+export CRAWLER_TAG=60872f7
+export API_TAG=60872f7

--- a/scripts/render_workflow_template.py
+++ b/scripts/render_workflow_template.py
@@ -93,7 +93,21 @@ def fetch_live_tags() -> dict[str, str]:
 
 
 def kubectl_apply(rendered: str, dry_run: bool) -> tuple[int, str, str]:
-    cmd = ["kubectl", "apply", "-f", "-"]
+    """Apply the template server-side.
+
+    A client-side `kubectl apply` cannot update this object at all:
+
+        metadata.resourceVersion: Invalid value: 0: must be specified for
+        an update
+
+    The rendered manifest carries no resourceVersion (correctly -- it is
+    generated from the repo, not read from the cluster), so the client-side
+    path demands one and fails every time. Server-side apply resolves the
+    merge on the API server and needs no resourceVersion. --force-conflicts
+    takes ownership of the fields last written by the old client-side applier,
+    which otherwise conflict on every field this manifest sets.
+    """
+    cmd = ["kubectl", "apply", "--server-side", "--force-conflicts", "-f", "-"]
     if dry_run:
         cmd.append("--dry-run=server")
     proc = subprocess.run(cmd, input=rendered, capture_output=True, text=True)

--- a/tests/deploy/test_render_workflow_template.py
+++ b/tests/deploy/test_render_workflow_template.py
@@ -19,6 +19,7 @@ import yaml
 from scripts.render_workflow_template import (
     KNOWN_SERVICES,
     apply_tags,
+    kubectl_apply,
     main,
     parse_live_tags,
 )
@@ -183,3 +184,51 @@ class TestMainDoesNotTouchClusterOnFailure:
 
         assert rc == 1
         assert calls == [True], "real apply must not run after a failed dry run"
+
+
+class TestApplyUsesServerSide:
+    """Client-side apply cannot update this object at all.
+
+    The rendered manifest carries no resourceVersion -- correctly, since it is
+    generated from the repo rather than read from the cluster. A client-side
+    `kubectl apply` then rejects it outright:
+
+        metadata.resourceVersion: Invalid value: 0: must be specified for
+        an update
+
+    so the deploy step failed every time it was reached. Combined with the
+    BRANCH_NAME gate that stopped it being reached at all, the WorkflowTemplate
+    had two independent reasons never to update -- which is how production ran
+    extraction on 2bc05a2 while every Deployment was already on 60872f7.
+    """
+
+    def _cmd(self, monkeypatch, *, dry_run):
+        seen = {}
+
+        class _Proc:
+            returncode = 0
+            stdout = "applied"
+            stderr = ""
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return _Proc()
+
+        monkeypatch.setattr("scripts.render_workflow_template.subprocess.run", fake_run)
+        kubectl_apply("apiVersion: v1\n", dry_run=dry_run)
+        return seen["cmd"]
+
+    def test_apply_is_server_side(self, monkeypatch):
+        assert "--server-side" in self._cmd(monkeypatch, dry_run=False)
+
+    def test_conflicts_are_forced(self, monkeypatch):
+        """The old client-side applier owns these fields; take them over."""
+        assert "--force-conflicts" in self._cmd(monkeypatch, dry_run=False)
+
+    def test_validation_pass_is_also_server_side(self, monkeypatch):
+        cmd = self._cmd(monkeypatch, dry_run=True)
+        assert "--server-side" in cmd
+        assert "--dry-run=server" in cmd
+
+    def test_still_reads_the_manifest_from_stdin(self, monkeypatch):
+        assert self._cmd(monkeypatch, dry_run=False)[-2:] == ["-f", "-"]


### PR DESCRIPTION
Found while verifying the #426 deploy. **Every Deployment moved to `60872f7` while the Argo WorkflowTemplate still ran `crawler:2bc05a2` / `processor:2bc05a2`.** Extraction runs from that template, so the Selenium proxy-auth fix would not have reached a single extraction pod — while the build and the rollout both reported success.

## Why the template never updated — two independent causes

**1. The step was never reached.** It was gated on `[ "${BRANCH_NAME}" = "main" ]`, but CI/CD starts these builds with:

```
gcloud builds triggers run build-crawler-manual --sha=<sha>
```

A run started **by SHA leaves `BRANCH_NAME` empty**, so the gate failed on every deploy and logged `Skipping Argo WorkflowTemplate update - not on main branch` into a log nobody reads. Confirmed on all three `60872f7` builds: `BRANCH_NAME=None`.

Worth noting this was the **only** gated step in either file — `update-work-queue`, `update-crawler-cronjob`, `force-processor-update` and the rest are ungated and repoint production unconditionally. That inconsistency is exactly why the Deployments updated correctly and the template silently did not. Gate removed for consistency with them.

**2. Had it been reached, it would have failed anyway.** The renderer used a client-side `kubectl apply`, which cannot update this object:

```
metadata.resourceVersion: Invalid value: 0: must be specified for an update
```

The rendered manifest carries no `resourceVersion` — correctly, since it is generated from the repo rather than read from the cluster. Now applied with `--server-side --force-conflicts`, which resolves the merge on the API server and takes over the fields the old client-side applier owns.

Either cause alone was sufficient. Together they explain the drift `render_workflow_template.py`'s own docstring already recorded: *"the cluster copy was seeded by hand and drifted indefinitely."*

## versions.env could never land either

The `update-versions-env` job was fixed on 2026-07-26 to resolve build IDs properly, and it now does — the `60872f7` run logged `✅ Updated PROCESSOR_TAG to 60872f7` and the other two. It then failed on the last command:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
```

It pushes straight to `main`, which the ruleset rejects. So the file kept going stale after every deploy — for a permissions reason once the logic bug was gone — and every deploy run reported failure. This repo lands changes by PR, so the job now pushes `chore/image-tags-<sha>` and opens one (force-push so re-running a SHA updates its branch; skips creation if a PR is already open; `pull-requests: write` + `GH_TOKEN` added).

## Production state

The live template was brought to `60872f7` **by hand** while diagnosing this. The diff against the cluster was **exactly the six image tags and nothing else** — no hidden drift. Deployments, template and DB (`e7a1c2b3d4f5`, no migrations in that merge) are all consistent right now.

`k8s/versions.env` is reconciled to `60872f7` here.

## Verification

- Tests pin the server-side apply; **3 of 4 fail on the previous client-side code.**
- Both cloudbuild files re-parse as valid YAML with their step lists intact.
- Workflow YAML validated: `pushes to main: False`, `opens PR: True`.
- Pre-push hook green on all six steps.

**Merging this triggers a deploy, which is itself the end-to-end test:** the Argo step should now run and apply server-side, and `update-versions-env` should open a PR rather than fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)