### PR TITLE
fix(deploy): the Argo WorkflowTemplate never updated on deploy

### DIFF
--- a/gcp/cloudbuild/cloudbuild-crawler.yaml
+++ b/gcp/cloudbuild/cloudbuild-crawler.yaml
@@ -83,12 +83,17 @@ steps:
     args:
       - '-c'
       - |
-        if [ "${BRANCH_NAME}" = "main" ]; then
-          echo "🔄 Updating Argo WorkflowTemplate with crawler:${SHORT_SHA}..."
-          bash gcp/cloudbuild/update-workflow-template.sh crawler "${SHORT_SHA}" "${_REGISTRY}"
-        else
-          echo "ℹ️  Skipping Argo WorkflowTemplate update - not on main branch (${BRANCH_NAME})"
-        fi
+        # NOT gated on BRANCH_NAME. CI/CD invokes this trigger as
+        # `gcloud builds triggers run build-crawler-manual --sha=<sha>`, and a
+        # run started by SHA leaves BRANCH_NAME empty -- so this step took the
+        # "not on main" path on EVERY deploy and the WorkflowTemplate silently
+        # never updated. Live proof 2026-07-28: Deployments were on 60872f7
+        # while the template still ran 2bc05a2, i.e. extraction would have kept
+        # using the previous image. Every other deploy step in this file
+        # (update-work-queue, the cronjob) is ungated and repoints production
+        # already; this one was the odd one out.
+        echo "🔄 Updating Argo WorkflowTemplate with crawler:${SHORT_SHA}..."
+        bash gcp/cloudbuild/update-workflow-template.sh crawler "${SHORT_SHA}" "${_REGISTRY}"
     waitFor: ['get-gke-credentials']
 
 images:

--- a/gcp/cloudbuild/cloudbuild-processor.yaml
+++ b/gcp/cloudbuild/cloudbuild-processor.yaml
@@ -122,12 +122,17 @@ steps:
     args:
       - '-c'
       - |
-        if [ "${BRANCH_NAME}" = "main" ]; then
-          echo "🔄 Updating Argo WorkflowTemplate with processor:${SHORT_SHA}..."
-          bash gcp/cloudbuild/update-workflow-template.sh processor "${SHORT_SHA}" "${_REGISTRY}"
-        else
-          echo "ℹ️  Skipping Argo WorkflowTemplate update - not on main branch (${BRANCH_NAME})"
-        fi
+        # NOT gated on BRANCH_NAME. CI/CD invokes this trigger as
+        # `gcloud builds triggers run build-processor-manual --sha=<sha>`, and a
+        # run started by SHA leaves BRANCH_NAME empty -- so this step took the
+        # "not on main" path on EVERY deploy and the WorkflowTemplate silently
+        # never updated. Live proof 2026-07-28: Deployments were on 60872f7
+        # while the template still ran 2bc05a2, i.e. extraction would have kept
+        # using the previous image. Every other deploy step in this file
+        # (update-work-queue, the cronjob) is ungated and repoints production
+        # already; this one was the odd one out.
+        echo "🔄 Updating Argo WorkflowTemplate with processor:${SHORT_SHA}..."
+        bash gcp/cloudbuild/update-workflow-template.sh processor "${SHORT_SHA}" "${_REGISTRY}"
     waitFor: ['get-gke-credentials']
 
 images:

--- a/scripts/render_workflow_template.py
+++ b/scripts/render_workflow_template.py
@@ -93,7 +93,21 @@ def fetch_live_tags() -> dict[str, str]:
 
 
 def kubectl_apply(rendered: str, dry_run: bool) -> tuple[int, str, str]:
-    cmd = ["kubectl", "apply", "-f", "-"]
+    """Apply the template server-side.
+
+    A client-side `kubectl apply` cannot update this object at all:
+
+        metadata.resourceVersion: Invalid value: 0: must be specified for
+        an update
+
+    The rendered manifest carries no resourceVersion (correctly -- it is
+    generated from the repo, not read from the cluster), so the client-side
+    path demands one and fails every time. Server-side apply resolves the
+    merge on the API server and needs no resourceVersion. --force-conflicts
+    takes ownership of the fields last written by the old client-side applier,
+    which otherwise conflict on every field this manifest sets.
+    """
+    cmd = ["kubectl", "apply", "--server-side", "--force-conflicts", "-f", "-"]
     if dry_run:
         cmd.append("--dry-run=server")
     proc = subprocess.run(cmd, input=rendered, capture_output=True, text=True)

--- a/tests/deploy/test_render_workflow_template.py
+++ b/tests/deploy/test_render_workflow_template.py
@@ -19,6 +19,7 @@ import yaml
 from scripts.render_workflow_template import (
     KNOWN_SERVICES,
     apply_tags,
+    kubectl_apply,
     main,
     parse_live_tags,
 )
@@ -183,3 +184,51 @@ class TestMainDoesNotTouchClusterOnFailure:
 
         assert rc == 1
         assert calls == [True], "real apply must not run after a failed dry run"
+
+
+class TestApplyUsesServerSide:
+    """Client-side apply cannot update this object at all.
+
+    The rendered manifest carries no resourceVersion -- correctly, since it is
+    generated from the repo rather than read from the cluster. A client-side
+    `kubectl apply` then rejects it outright:
+
+        metadata.resourceVersion: Invalid value: 0: must be specified for
+        an update
+
+    so the deploy step failed every time it was reached. Combined with the
+    BRANCH_NAME gate that stopped it being reached at all, the WorkflowTemplate
+    had two independent reasons never to update -- which is how production ran
+    extraction on 2bc05a2 while every Deployment was already on 60872f7.
+    """
+
+    def _cmd(self, monkeypatch, *, dry_run):
+        seen = {}
+
+        class _Proc:
+            returncode = 0
+            stdout = "applied"
+            stderr = ""
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return _Proc()
+
+        monkeypatch.setattr("scripts.render_workflow_template.subprocess.run", fake_run)
+        kubectl_apply("apiVersion: v1\n", dry_run=dry_run)
+        return seen["cmd"]
+
+    def test_apply_is_server_side(self, monkeypatch):
+        assert "--server-side" in self._cmd(monkeypatch, dry_run=False)
+
+    def test_conflicts_are_forced(self, monkeypatch):
+        """The old client-side applier owns these fields; take them over."""
+        assert "--force-conflicts" in self._cmd(monkeypatch, dry_run=False)
+
+    def test_validation_pass_is_also_server_side(self, monkeypatch):
+        cmd = self._cmd(monkeypatch, dry_run=True)
+        assert "--server-side" in cmd
+        assert "--dry-run=server" in cmd
+
+    def test_still_reads_the_manifest_from_stdin(self, monkeypatch):
+        assert self._cmd(monkeypatch, dry_run=False)[-2:] == ["-f", "-"]


### PR DESCRIPTION
Found while verifying the #426 deploy. **Every Deployment moved to `60872f7` while the Argo WorkflowTemplate still ran `crawler:2bc05a2` / `processor:2bc05a2`.** Extraction runs from that template, so the Selenium proxy-auth fix in that same deploy would not have reached a single extraction pod — while the build and the rollout both reported success.

## Two independent causes

**1. The step was never reached.** It was gated on `[ "${BRANCH_NAME}" = "main" ]`, but CI/CD starts these builds with:

```
gcloud builds triggers run build-crawler-manual --sha=<sha>
```

A run started **by SHA leaves `BRANCH_NAME` empty**, so the gate failed on every deploy and logged `Skipping Argo WorkflowTemplate update - not on main branch` into a log nobody reads. Confirmed on all three `60872f7` builds: `BRANCH_NAME=None`.

This was the **only** gated step in either file — `update-work-queue`, `update-crawler-cronjob`, `force-processor-update` and the rest are ungated and repoint production unconditionally. That inconsistency is precisely why the Deployments updated correctly and the template silently did not. Gate removed for consistency with them.

**2. Had it been reached, it would have failed anyway.** The renderer used a client-side `kubectl apply`, which cannot update this object:

```
metadata.resourceVersion: Invalid value: 0: must be specified for an update
```

The rendered manifest carries no `resourceVersion` — correctly, since it is generated from the repo rather than read from the cluster. Now applied with `--server-side --force-conflicts`, which resolves the merge on the API server and takes over the fields the old client-side applier owns.

Either cause alone was sufficient. Together they explain the drift `render_workflow_template.py`'s own docstring already recorded: *"the cluster copy was seeded by hand and drifted indefinitely."*

## Production state

The live template was brought to `60872f7` **by hand** while diagnosing this. The diff against the cluster was **exactly the six image tags and nothing else** — no hidden drift. Deployments, template and DB (`e7a1c2b3d4f5`; that merge added no migrations) are all consistent right now, so this PR is about stopping the next deploy from re-opening the gap rather than repairing current state.

## Verification

- Tests pin the server-side apply — **3 of 4 fail on the previous client-side code.**
- Both cloudbuild files re-parse as valid YAML with their step lists intact (6 and 9 steps).
- `Validate GCP Cloud Build Triggers` exercises these files directly.
- Pre-push hook green.

## Deliberately not included

An earlier version of this branch (#427, closed) also moved `update-versions-env` off its direct push to `main`, which the ruleset rejects with GH013. That change is parked: routing it through a PR means every deploy opens a chore PR that runs the **5 required checks (~8 min)** against two lines of generated bookkeeping. Note `paths-ignore` is *not* the fix — a path-skipped workflow leaves required checks pending forever and would deadlock that PR. The workable route is the existing `changes` job's `if:` gating, which this repo already relies on for workflow/docs-only PRs.

So `k8s/versions.env` remains stale after deploys until that is settled. It is bookkeeping for `envsubst`, not something the running cluster reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)