### PR TITLE
fix(pipeline): make content the immutable canonical, and stop losing the signal downstream of it

### DIFF
--- a/src/cli/commands/content_cleaning.py
+++ b/src/cli/commands/content_cleaning.py
@@ -427,7 +427,9 @@ def clean_article(article_id, confidence_threshold, dry_run, show_content):
     cursor = conn.cursor()
 
     cursor.execute(
-        "SELECT url, content FROM articles WHERE id = ?",
+        # Cleaned body if a prior pass produced one, canonical on first pass.
+        # Cleaning must compose -- see the UPDATE below; `content` is read-only.
+        "SELECT url, COALESCE(text, content) FROM articles WHERE id = ?",
         (article_id,),
     )
     result = cursor.fetchone()
@@ -489,7 +491,14 @@ def clean_article(article_id, confidence_threshold, dry_run, show_content):
         # Update database if not dry run
         if not dry_run:
             cursor.execute(
-                "UPDATE articles SET content = ? WHERE id = ?",
+                # `text` is the cleaned, consumable column. `content` is the
+                # canonical capture and is NEVER written back to -- doing so
+                # made `content` a cleaned derivative, so the two columns
+                # converged (151 of 183 rows byte-identical in one export) and
+                # the raw capture was no longer recoverable from the row. The
+                # 30-day GCS raw HTML was then the only witness left, and it
+                # ages out.
+                "UPDATE articles SET text = ? WHERE id = ?",
                 (cleaned_content, article_id),
             )
             conn.commit()
@@ -523,7 +532,8 @@ def apply_cleaning(domain, confidence_threshold, limit, dry_run, verbose):
     cursor = conn.cursor()
 
     # Build query
-    query = "SELECT id, url, content FROM articles"
+    # COALESCE(text, content): prior cleaning if any, canonical on first pass.
+    query = "SELECT id, url, COALESCE(text, content) FROM articles"
     params = []
 
     if domain:
@@ -593,7 +603,8 @@ def apply_cleaning(domain, confidence_threshold, limit, dry_run, verbose):
     # Apply updates if not dry run
     if updates and not dry_run:
         cursor.executemany(
-            "UPDATE articles SET content = ? WHERE id = ?",
+            # Cleaned output goes to `text`; `content` stays as captured.
+            "UPDATE articles SET text = ? WHERE id = ?",
             updates,
         )
         conn.commit()

--- a/src/cli/commands/entity_extraction.py
+++ b/src/cli/commands/entity_extraction.py
@@ -111,8 +111,14 @@ def handle_entity_extraction_command(args, extractor=None) -> int:
                 SELECT a.id, a.text, a.text_hash, cl.source_id, cl.dataset_id, cl.source
                 FROM articles a
                 JOIN candidate_links cl ON a.candidate_link_id = cl.id
-                WHERE a.content IS NOT NULL
-                AND a.text IS NOT NULL
+                -- Gate on `text`, which is the column this query SELECTs and
+                -- entity extraction consumes. It used to also require
+                -- `content IS NOT NULL`: a canonical-capture check standing in
+                -- for "has a body", on a field this query never reads. That was
+                -- silently exclusionary while the wall/furniture branches blanked
+                -- content before insert -- rows with a perfectly good cleaned
+                -- body were skipped because the raw capture had been emptied.
+                WHERE a.text IS NOT NULL
                 AND a.entities_extracted_at IS NULL
                 AND a.status NOT IN ('error', 'paywall', 'wire', 'not_article')
                 """

--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -33,7 +33,7 @@ from src.models.database import (
 # crawler image, which carries no ML dependencies.
 from src.pipeline.text_cleaning import decode_rot47_segments
 from src.services.wire_detection import resolve_api_token
-from src.utils.boilerplate import looks_like_furniture
+from src.utils.boilerplate import looks_like_furniture, looks_like_paywall
 
 # Lazy import: entity_extraction only needed for entity-extraction command
 # Importing at top level causes ModuleNotFoundError in crawler image (no rapidfuzz)
@@ -470,8 +470,13 @@ PAUSE_CANDIDATE_LINKS_SQL = text(
     "WHERE url LIKE :host_like OR source = :host"
 )
 
+# `content` is deliberately absent: it is the canonical capture and is never
+# written after insert. This statement used to carry "content = :content" bound
+# to original_content -- the value it had just SELECTed -- so dropping it is a
+# no-op today and makes the column immutable by construction rather than by
+# every caller remembering to pass the value back unchanged.
 ARTICLE_UPDATE_SQL = text(
-    "UPDATE articles SET content = :content, text = :text, "
+    "UPDATE articles SET text = :text, "
     "text_hash = :text_hash, text_excerpt = :excerpt, status = :status "
     "WHERE id = :id"
 )
@@ -1743,6 +1748,36 @@ def _process_batch(
                     now = datetime.utcnow()
                     content_text = content.get("content", "")
 
+                    # THE CANONICAL CAPTURE. Decoded once, never emptied.
+                    #
+                    # Everything below reads progressively less of the page:
+                    # the wall/furniture branches blank content_text and
+                    # content["content"] so a wall is never STORED as a body,
+                    # and the cleaner strips boilerplate out of what is left.
+                    # Both are correct for what gets saved and both destroy the
+                    # evidence a classifier needs. looks_like_paywall() even
+                    # documents this -- "matches on the raw body, NOT the
+                    # stripped one: strip_boilerplate removes these very
+                    # phrases" -- yet the gate below asked the cleaned text
+                    # anyway, so a wall whose phrases had just been stripped
+                    # read as an empty body and was filed not_article. Sedalia,
+                    # nwaonline and ~298 rows in one run: real headline, real
+                    # date, body gone, labelled "never was an article".
+                    #
+                    # So the split is explicit: CLASSIFICATION (is this a wall,
+                    # is this wire) reads the canonical, SUFFICIENCY (is there
+                    # a story left after cleaning) reads the cleaned output.
+                    # This is never reassigned -- do not blank it to signal a
+                    # decision; the storage variables above already do that.
+                    canonical_text = _decode_capture(content_text or "")
+
+                    # "Body dropped" is now an explicit decision rather than a
+                    # side effect of blanking variables. It has to be: with the
+                    # canonical preserved, the cleaned_text fallback further
+                    # down (stripped or decoded or content_text) would restore
+                    # the very wall/furniture the gate just rejected.
+                    body_dropped = False
+
                     # Validate content length - mark paywall articles
                     # Articles with <150 chars non-boilerplate: status='paywall'
                     # Tracked in DB but excluded from ML/BigQuery:
@@ -1777,8 +1812,8 @@ def _process_batch(
                         # Drop the wall text so furniture is never stored as a
                         # body; the headline/byline/date captured alongside it
                         # are kept by the save below.
-                        content_text = ""
-                        content["content"] = ""
+                        # Canonical preserved: only the cleaned body is
+                        # dropped. See the note on the furniture branch below.
 
                     if content_text:
                         from urllib.parse import urlparse
@@ -1810,11 +1845,34 @@ def _process_batch(
                         decoded_text = ""
                         stripped_content = ""
 
-                    # Check if content is insufficient AND has paywall indicators
-                    has_paywall_patterns = gate_says_paywall or any(
-                        pattern in cleaning_metadata.get("patterns_matched", [])
-                        for pattern in ["subscription", "paywall"]
+                    # CLASSIFICATION -- read the canonical, not the cleaned
+                    # text. The marker list already covers these walls: the
+                    # Sedalia prompt matches "otherwise, click here to view
+                    # your options for subscribing", which is in
+                    # PAYWALL_MARKERS today. It was never missing detection,
+                    # only ever asked of text the cleaner had already stripped
+                    # the phrases out of. Note this is additive -- it does not
+                    # replace gate_says_paywall or the cleaner's own patterns,
+                    # so a wall any one of the three recognises still counts.
+                    paywall_marker = looks_like_paywall(canonical_text)
+                    has_paywall_patterns = (
+                        gate_says_paywall
+                        or paywall_marker is not None
+                        or any(
+                            pattern in cleaning_metadata.get("patterns_matched", [])
+                            for pattern in ["subscription", "paywall"]
+                        )
                     )
+                    if paywall_marker and not gate_says_paywall:
+                        # Record WHICH prompt fired: looks_like_paywall returns
+                        # the phrase rather than a bool precisely so the verdict
+                        # can be audited and the list tuned from real captures.
+                        logger.info(
+                            "Paywall marker in canonical capture (%r) that the "
+                            "cleaned text no longer carried: %s",
+                            paywall_marker,
+                            url,
+                        )
                     is_insufficient_content = (
                         not stripped_content
                         or len(stripped_content.strip()) < MIN_CONTENT_LENGTH
@@ -1842,7 +1900,26 @@ def _process_batch(
                     # drops the furniture body. Long non-prose without a wall
                     # marker is a mis-extraction or prose-less page -> not_article
                     # (also kept, also body-dropped, also excluded from ML).
-                    if (
+                    # WIRE IS TERMINAL. Once wire is affirmatively identified
+                    # -- by byline above, or by the content detector, and only
+                    # after the evidence guard has had its say -- no later stage
+                    # may reclassify it. This gate ran unconditionally and did
+                    # exactly that: syndicated stories behind a wall arrived
+                    # here with an empty body and were rewritten to not_article,
+                    # discarding a wire attribution that had already been
+                    # established. Observed on rows carrying
+                    # wire=["The Associated Press"] and wire=["Washington Post"]
+                    # -- the syndicator was known and thrown away.
+                    #
+                    # A wire story that is also walled is still a wire story;
+                    # its provenance does not depend on whether we got the body.
+                    if article_status == "wire":
+                        logger.info(
+                            "Wire already established (%s); shape gate skipped: %s",
+                            wire_service_info,
+                            url,
+                        )
+                    elif (
                         is_insufficient_content or is_furniture
                     ) and has_paywall_patterns:
                         non_boilerplate_len = (
@@ -1859,8 +1936,16 @@ def _process_batch(
                         # headline/byline/date captured alongside it are kept.
                         # decoded_text is cleared too, or the cleaned_text
                         # fallback below would restore the furniture from it.
-                        content_text = ""
-                        content["content"] = ""
+                        # Drop the BODY, not the canonical. `content` is the
+                        # capture as taken and is never edited after capture --
+                        # `text` is the cleaned, consumable field, and emptying
+                        # that is what "body dropped" means. Blanking
+                        # content["content"] here destroyed the only durable
+                        # copy of the wall (raw HTML in GCS ages out at 30
+                        # days), which is why these rows show content=0 AND
+                        # text=0, and why the paywall could not be recognised
+                        # afterwards from the row itself.
+                        body_dropped = True
                         stripped_content = ""
                         decoded_text = ""
                     elif is_furniture:
@@ -1871,8 +1956,16 @@ def _process_batch(
                         )
                         # Keep the record and its metadata, drop the furniture body.
                         article_status = "not_article"
-                        content_text = ""
-                        content["content"] = ""
+                        # Drop the BODY, not the canonical. `content` is the
+                        # capture as taken and is never edited after capture --
+                        # `text` is the cleaned, consumable field, and emptying
+                        # that is what "body dropped" means. Blanking
+                        # content["content"] here destroyed the only durable
+                        # copy of the wall (raw HTML in GCS ages out at 30
+                        # days), which is why these rows show content=0 AND
+                        # text=0, and why the paywall could not be recognised
+                        # afterwards from the row itself.
+                        body_dropped = True
                         stripped_content = ""
                         decoded_text = ""
                     elif is_insufficient_content:
@@ -1928,7 +2021,13 @@ def _process_batch(
                     # The fallback takes the DECODED text, never the raw capture:
                     # on a ROT47 page a cleaner failure would otherwise store
                     # ciphertext as the article body.
-                    cleaned_text = stripped_content or decoded_text or content_text
+                    # An explicitly dropped body stays dropped: `text` is
+                    # empty, `content` keeps the capture. Without this the
+                    # fallback would reach content_text and store the wall.
+                    if body_dropped:
+                        cleaned_text = ""
+                    else:
+                        cleaned_text = stripped_content or decoded_text or content_text
 
                     # Hash the cleaned side: text_hash describes `text`, and entity
                     # extraction records it as article_entities.article_text_hash to
@@ -2564,7 +2663,6 @@ def _run_post_extraction_cleaning(domains_to_articles, db=None):
                                 # raw capture stays as it was, so this can be
                                 # re-run against improved rules and the result
                                 # compared with what it replaced.
-                                "content": original_content,
                                 "text": cleaned_content,
                                 "text_hash": new_hash,
                                 "excerpt": excerpt,

--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -2086,7 +2086,7 @@ def _process_batch(
                         except Exception:
                             logger.exception("Failed to log diagnostic SQL/params")
 
-                    safe_session_execute(
+                    insert_result = safe_session_execute(
                         session,
                         ARTICLE_INSERT_SQL,
                         {
@@ -2111,11 +2111,35 @@ def _process_batch(
                             "raw_gcs_path": raw_gcs_path,
                         },
                     )
-                    safe_session_execute(
-                        session,
-                        CANDIDATE_STATUS_UPDATE_SQL,
-                        {"status": article_status, "id": str(url_id)},
-                    )
+                    # Did the INSERT actually write a row? ARTICLE_INSERT_SQL
+                    # ends in ON CONFLICT DO NOTHING against uq_articles_url, so
+                    # a URL already stored under a different candidate_link is
+                    # skipped silently -- and until safe_session_execute stopped
+                    # swallowing failures, so was any other error. Either way the
+                    # next statement marked the link 'extracted' and committed,
+                    # so the status asserted an article that did not exist: 176
+                    # such links on one publisher, 142 of them with no article
+                    # anywhere and the captured body gone.
+                    #
+                    # Claim 'extracted' only when a row was written. A conflict
+                    # is not an error -- the article exists, under another link --
+                    # but this link did not produce one and must not say it did.
+                    inserted = getattr(insert_result, "rowcount", 1)
+                    if inserted == 0:
+                        logger.error(
+                            "Article INSERT wrote no row for %s (id=%s); most "
+                            "likely a uq_articles_url conflict with an existing "
+                            "article. Leaving candidate_link status unchanged "
+                            "rather than claiming 'extracted'.",
+                            article_url,
+                            article_id,
+                        )
+                    else:
+                        safe_session_execute(
+                            session,
+                            CANDIDATE_STATUS_UPDATE_SQL,
+                            {"status": article_status, "id": str(url_id)},
+                        )
 
                     # Explicit commit with logging to catch silent failures
                     try:

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -4204,6 +4204,35 @@ class ContentExtractor:
                 html_len = len(html)
                 self._record_raw_html(html, "unblock_proxy")
 
+                # Record proxy telemetry HERE. This capture path never touches
+                # _fetch_page_html, which until now was the only place
+                # set_proxy_metrics() was called -- so every extraction captured
+                # by this rung reported proxy_used=0, proxy_url NULL and
+                # router_proxy NULL despite going through Squid. Measured
+                # 2026-07-28 on 250 rows: all 47 with router_proxy NULL were
+                # captured by this path or by Selenium, never by http_fetch.
+                # Same defect class as the one fixed on the fetch path: the
+                # proxy was never bypassed, only the evidence was lost.
+                if metrics is not None:
+                    try:
+                        router_choice = (
+                            self.domain_router_proxy.get(domain) if domain else None
+                        )
+                        metrics.set_proxy_metrics(
+                            proxy_used=bool(proxy_url),
+                            proxy_url=mask_proxy_url(proxy_url),
+                            proxy_authenticated="@" in (proxy_url or ""),
+                            proxy_status="success" if proxy_url else None,
+                            proxy_error=None,
+                            router_proxy=(
+                                router_choice.value if router_choice else None
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "unblock proxy metrics recording failed: %s", exc
+                        )
+
                 logger.info(
                     f"Squid proxy returned {html_len} bytes for {url} (status: {status_code})"
                 )
@@ -4408,6 +4437,19 @@ class ContentExtractor:
                 self.close_persistent_driver()
             return {}
 
+    @staticmethod
+    def _resolve_selenium_proxy() -> str:
+        """The proxy Selenium egresses through.
+
+        Defined once so telemetry cannot report a different value than the
+        driver actually uses -- the three driver-creation sites each inline
+        this same lookup, and a divergence between them would be invisible.
+        """
+        return os.getenv(
+            "SELENIUM_PROXY",
+            os.getenv("SQUID_PROXY_URL", "http://t9880447.eero.online:3128"),
+        )
+
     def _run_selenium_extraction(
         self,
         url: str,
@@ -4437,6 +4479,33 @@ class ContentExtractor:
 
         if metrics:
             metrics.start_method("selenium")
+            # A Selenium capture skips _fetch_page_html entirely, which was the
+            # only caller of set_proxy_metrics -- so every Selenium-captured
+            # extraction reported proxy_used=0 with a NULL proxy_url even
+            # though Chrome egresses through the auth relay to Squid. That
+            # under-reporting was invisible while Selenium was broken (it
+            # produced no rows at all from 2026-07-25 to 07-27) and appeared
+            # the moment it started working again: 2026-07-28, all 47 of 250
+            # rows missing proxy data were Selenium- or unblock-captured.
+            #
+            # router_proxy stays None deliberately: Selenium reads a static
+            # SELENIUM_PROXY and never calls get_requests_proxies_for_domain(),
+            # so no router decision exists to record. That is a real gap in
+            # #413's home-vs-mizzou failover -- browser traffic is exempt from
+            # it -- but it is a behaviour change, not a telemetry one, so it is
+            # recorded honestly here rather than papered over with a guess.
+            try:
+                selenium_proxy = self._resolve_selenium_proxy()
+                metrics.set_proxy_metrics(
+                    proxy_used=bool(selenium_proxy),
+                    proxy_url=mask_proxy_url(selenium_proxy),
+                    proxy_authenticated="@" in (selenium_proxy or ""),
+                    proxy_status="success" if selenium_proxy else None,
+                    proxy_error=None,
+                    router_proxy=None,
+                )
+            except Exception as exc:
+                logger.warning("selenium proxy metrics recording failed: %s", exc)
 
         try:
             if self._check_rate_limit(dom):
@@ -4869,10 +4938,7 @@ class ContentExtractor:
         # PerimeterX blocks GKE datacenter IPs, residential proxy required
         # Use Chrome extension for proxy auth (standard approach)
         # CRITICAL: ALWAYS use Squid proxy - no direct connections allowed
-        selenium_proxy = os.getenv(
-            "SELENIUM_PROXY",
-            os.getenv("SQUID_PROXY_URL", "http://t9880447.eero.online:3128"),
-        )
+        selenium_proxy = self._resolve_selenium_proxy()
         logger.info(
             f"🔀 Selenium proxy URL from env: {_mask_proxy_url(selenium_proxy)}"
         )
@@ -4971,10 +5037,7 @@ class ContentExtractor:
                 realistic_ua_fb = self._resolve_selenium_user_agent()
                 options_fb.add_argument(f"--user-agent={realistic_ua_fb}")
                 # Proxy
-                selenium_proxy = os.getenv(
-                    "SELENIUM_PROXY",
-                    os.getenv("SQUID_PROXY_URL", "http://t9880447.eero.online:3128"),
-                )
+                selenium_proxy = self._resolve_selenium_proxy()
                 # Same relay as the primary path: Chrome cannot take proxy
                 # credentials on the command line, and the old Manifest V2
                 # auth extension is silently ignored by modern Chrome.
@@ -5137,10 +5200,7 @@ class ContentExtractor:
         chrome_options.add_argument(f"--user-agent={realistic_ua}")
 
         # CRITICAL: ALWAYS use Squid proxy for Selenium - no direct connections allowed
-        selenium_proxy = os.getenv(
-            "SELENIUM_PROXY",
-            os.getenv("SQUID_PROXY_URL", "http://t9880447.eero.online:3128"),
-        )
+        selenium_proxy = self._resolve_selenium_proxy()
         # Via the auth relay -- credentials embedded in --proxy-server are
         # ignored by Chrome, which is how this path silently ran unauthenticated.
         chrome_options.add_argument(f"--proxy-server={get_relay_proxy(selenium_proxy)}")

--- a/src/crawler/proxy_relay.py
+++ b/src/crawler/proxy_relay.py
@@ -32,7 +32,7 @@ import logging
 import socket
 import threading
 import urllib.parse
-from typing import Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -108,17 +108,85 @@ def _pipe(src: socket.socket, dst: socket.socket) -> None:
 class ProxyAuthRelay:
     """Loopback proxy that forwards to an authenticated upstream proxy."""
 
-    def __init__(self, upstream_url: str):
+    def __init__(
+        self,
+        upstream_url: str,
+        resolve_upstream: Optional[Callable[[str], Optional[str]]] = None,
+    ):
+        """
+        Args:
+            upstream_url: the Squid used when no resolver is given, or when the
+                resolver declines to choose.
+            resolve_upstream: maps a target host to the proxy URL that should
+                serve it. Routing lives HERE rather than at driver creation
+                because Chrome fixes --proxy-server when the process starts and
+                drivers are reused across domains (SELENIUM_DRIVER_REUSE_LIMIT),
+                so a per-domain choice made at launch would be carried to the
+                next domain. The relay sees every request's target host, so it
+                can route each connection independently behind one fixed
+                loopback endpoint.
+        """
+        self._default_upstream = upstream_url
+        self._resolve_upstream = resolve_upstream
         host, port, user, password = split_proxy_url(upstream_url)
         self.upstream_host = host
         self.upstream_port = port
-        self._auth_header = b""
-        if user is not None and password is not None:
-            token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
-            self._auth_header = f"Proxy-Authorization: Basic {token}\r\n".encode()
+        self._auth_header = self._auth_for(user, password)
         self._server: Optional[socket.socket] = None
         self._thread: Optional[threading.Thread] = None
         self.port: Optional[int] = None
+
+    @staticmethod
+    def _auth_for(user: Optional[str], password: Optional[str]) -> bytes:
+        if user is None or password is None:
+            return b""
+        token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
+        return f"Proxy-Authorization: Basic {token}\r\n".encode()
+
+    @staticmethod
+    def target_host(head: bytes) -> Optional[str]:
+        """Host this request is FOR, from the proxy request line.
+
+        `CONNECT example.com:443 HTTP/1.1` -> example.com
+        `GET http://example.com/x HTTP/1.1` -> example.com
+        """
+        try:
+            line = head.split(b"\r\n", 1)[0].decode("latin-1")
+        except Exception:
+            return None
+        parts = line.split()
+        if len(parts) < 2:
+            return None
+        method, target = parts[0].upper(), parts[1]
+        if method == "CONNECT":
+            return target.rsplit(":", 1)[0] or None
+        if "://" in target:
+            rest = target.split("://", 1)[1].split("/", 1)[0]
+            return rest.rsplit("@", 1)[-1].rsplit(":", 1)[0] or None
+        return None
+
+    def _upstream_for(self, head: bytes) -> tuple[str, int, bytes]:
+        """(host, port, auth_header) for this connection."""
+        if self._resolve_upstream is not None:
+            host = self.target_host(head)
+            if host:
+                try:
+                    chosen = self._resolve_upstream(host)
+                except Exception as exc:
+                    # Never fail a page load over a routing decision: the
+                    # default upstream is always reachable.
+                    logger.debug("relay upstream resolution failed: %s", exc)
+                    chosen = None
+                if chosen:
+                    try:
+                        h, p, u, pw = split_proxy_url(chosen)
+                        return h, p, self._auth_for(u, pw)
+                    except ValueError as exc:
+                        logger.warning(
+                            "relay ignoring unusable routed proxy (%s); using default",
+                            exc,
+                        )
+        return self.upstream_host, self.upstream_port, self._auth_header
 
     @property
     def requires_auth(self) -> bool:
@@ -186,11 +254,10 @@ class ProxyAuthRelay:
                 if len(head) > 1_048_576:  # runaway header guard
                     return
 
-            upstream = socket.create_connection(
-                (self.upstream_host, self.upstream_port), timeout=_CONNECT_TIMEOUT
-            )
+            host, port, auth = self._upstream_for(head)
+            upstream = socket.create_connection((host, port), timeout=_CONNECT_TIMEOUT)
             upstream.settimeout(_IDLE_TIMEOUT)
-            upstream.sendall(self._with_auth(head))
+            upstream.sendall(self._with_auth(head, auth))
 
             threading.Thread(target=_pipe, args=(client, upstream), daemon=True).start()
             _pipe(upstream, client)
@@ -204,13 +271,14 @@ class ProxyAuthRelay:
                     except OSError:
                         pass
 
-    def _with_auth(self, head: bytes) -> bytes:
+    def _with_auth(self, head: bytes, auth: Optional[bytes] = None) -> bytes:
         """Insert Proxy-Authorization after the request line.
 
         Any client-supplied Proxy-Authorization is dropped first so ours is
         authoritative and can't be duplicated.
         """
-        if not self._auth_header:
+        auth = self._auth_header if auth is None else auth
+        if not auth:
             return head
         line_end = head.find(b"\r\n")
         if line_end == -1:
@@ -225,23 +293,53 @@ class ProxyAuthRelay:
         # split/rejoin leaves a trailing empty element -> normalise the
         # header/body separator back to exactly one blank line.
         cleaned = cleaned.rstrip(b"\r\n") + b"\r\n\r\n"
-        return request_line + self._auth_header + cleaned
+        return request_line + auth + cleaned
 
 
 _relay: Optional[ProxyAuthRelay] = None
 _relay_lock = threading.Lock()
 
 
-def get_relay_proxy(upstream_url: str) -> str:
-    """Return a loopback ``host:port`` that proxies to ``upstream_url``.
+def _router_upstream(host: str) -> Optional[str]:
+    """Ask the shared proxy_router which Squid should serve ``host``.
 
-    One relay per process, reused across drivers. Raises ValueError if the
-    upstream URL is unusable -- callers must fail loudly rather than hand
-    Chrome no proxy at all.
+    Selenium previously egressed through a single static SELENIUM_PROXY, so
+    browser traffic was exempt from #413's home-vs-mizzou selection and its
+    health-based backoff -- the router would log
+    ``home_squid backed off for <domain> (62 failures)`` while Chrome kept
+    sending requests there anyway, with no failover available.
+
+    Returns None on any failure so the caller falls back to its default
+    upstream: a routing decision must never be able to stop a page loading.
+    """
+    try:
+        from .proxy_config import get_proxy_manager
+
+        proxies, _choice, _method = get_proxy_manager().get_requests_proxies_for_domain(
+            host, service="selenium"
+        )
+    except Exception as exc:  # router unavailable, misconfigured, anything
+        logger.debug("router lookup failed for %s: %s", host, exc)
+        return None
+    if not proxies:
+        return None
+    return proxies.get("https") or proxies.get("http")
+
+
+def get_relay_proxy(upstream_url: str, *, route: bool = True) -> str:
+    """Return a loopback ``host:port`` that proxies to Squid.
+
+    One relay per process, reused across drivers. With ``route`` the relay
+    picks the upstream per connection from the shared router, keyed on each
+    request's target host; ``upstream_url`` is the fallback when the router
+    declines or fails. Raises ValueError if that fallback is unusable --
+    callers must fail loudly rather than hand Chrome no proxy at all.
     """
     global _relay
     with _relay_lock:
         if _relay is None or _relay.port is None:
-            _relay = ProxyAuthRelay(upstream_url)
+            _relay = ProxyAuthRelay(
+                upstream_url, resolve_upstream=_router_upstream if route else None
+            )
             _relay.start()
         return _relay.proxy_url

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -200,14 +200,26 @@ def safe_session_execute(session, sql, params=None):
     from sqlalchemy.exc import ArgumentError
     from sqlalchemy.sql import text as _text
 
-    # If caller passed a SQLAlchemy Core object, try to execute directly
+    # If caller passed a SQLAlchemy Core object, try to execute directly.
+    #
+    # Only ArgumentError falls through. This used to catch bare Exception and
+    # `pass`, so ANY failure -- a constraint violation, a type error, a dead
+    # connection -- was swallowed here and the caller carried on believing the
+    # statement had run. In the extraction save path that meant the article
+    # INSERT could fail while the very next statement still marked the
+    # candidate_link 'extracted' and committed: 142 links on one publisher were
+    # recorded as extracted with no article row anywhere and their captured
+    # bodies gone (telemetry had logged success, 2,171 chars). The fallthrough
+    # exists to retry legacy parameter styles, which is precisely what
+    # ArgumentError signals; nothing else here is retryable, and silence about
+    # the rest is what turned a failed write into a lie about the outcome.
     if not isinstance(sql, (str,)):
         try:
             if params is not None:
                 return session.execute(sql, params)
             return session.execute(sql)
-        except Exception:
-            # fallthrough to string-based handling
+        except ArgumentError:
+            # Legacy parameter style -- fall through to string-based handling.
             pass
 
     sql_str = str(sql)
@@ -829,17 +841,39 @@ def upsert_candidate_link(
     # Get scheme-agnostic version for deduplication check
     dedup_path = normalize_url_for_dedup(url)
 
-    # Check both http and https variants to avoid duplicates
-    http_url = f"http://{dedup_path}"
-    https_url = f"https://{dedup_path}"
+    # Every stored form this page could already be under. The www. variants are
+    # the point: normalize_url_for_dedup strips "www.", but normalize_url KEEPS
+    # it for storage, so this lookup previously searched for
+    # "https://example.com/x" while the row was stored as
+    # "https://www.example.com/x" and could never match. Both scheme variants
+    # were then inserted as separate rows -- one publisher carried 471
+    # candidate_links against 300 articles, with 142 links marked 'extracted'
+    # whose article was stored under the other scheme. Nothing was lost; the
+    # link simply pointed at nothing.
+    candidates = [
+        f"{scheme}://{prefix}{dedup_path}"
+        for scheme in ("https", "http")
+        for prefix in ("", "www.")
+    ]
 
     existing = (
         session.query(CandidateLink)
-        .filter(CandidateLink.url.in_([http_url, https_url]))
+        .filter(CandidateLink.url.in_(candidates))
+        .order_by(CandidateLink.url.startswith("https").desc())
         .first()
     )
 
     if existing:
+        # Prefer https for the surviving row. Both schemes serve the same page;
+        # keeping the secure form means later discoveries converge on it rather
+        # than alternating and re-creating the split this dedup exists to stop.
+        if normalized_url.startswith("https://") and existing.url.startswith("http://"):
+            logger.info(
+                "Upgrading candidate link to https: %s -> %s",
+                existing.url,
+                normalized_url,
+            )
+            existing.url = normalized_url
         # Update existing record with new data
         for key, value in kwargs.items():
             if hasattr(existing, key) and value is not None:

--- a/src/services/llm/article_pipeline.py
+++ b/src/services/llm/article_pipeline.py
@@ -106,7 +106,14 @@ class ArticleLLMPipeline:
             yield article
 
     def _render_prompt(self, article: Article) -> str:
-        content = article.content or article.text or ""
+        # `text` is the cleaned body; `content` is the raw capture and may
+        # carry navigation menus, cookie notices and paywall prompts. Summarising
+        # the raw capture summarises the furniture -- the CIN classifier reached
+        # the same conclusion and reads `text` first for exactly this reason
+        # (classification_service._BODY_FIELD_PREFERENCE). `content` stays as the
+        # fallback for rows extracted before the two columns diverged, where the
+        # raw capture is the only body that exists.
+        content = article.text or article.content or ""
         content = (content or "").strip()
         if len(content) > 4000:
             content = content[:4000] + "\n..."

--- a/src/utils/content_cleaning_telemetry.py
+++ b/src/utils/content_cleaning_telemetry.py
@@ -367,7 +367,7 @@ class ContentCleaningTelemetry:
                 # legacy domain-keyed row (transition: rows predate source_id).
                 cursor.execute(
                     """
-                    SELECT id, occurrences_total, last_seen
+                    SELECT id, occurrences_total, last_seen, confidence_score
                     FROM persistent_boilerplate_patterns
                     WHERE text_hash = ?
                       AND (source_id = ? OR (source_id IS NULL AND domain = ?))
@@ -378,6 +378,25 @@ class ContentCleaningTelemetry:
                 existing = cursor.fetchone()
 
                 if existing:
+                    # Keep the higher confidence, computed HERE rather than in
+                    # SQL. This read `MAX(confidence_score, ?)`, which is
+                    # SQLite's two-argument scalar max. Postgres has no such
+                    # function -- max() there is a one-argument aggregate -- so
+                    # on Postgres the statement failed with
+                    #   42883: function max(double precision, unknown) does not exist
+                    # every single time. The damage was not limited to this
+                    # table: the failed statement aborts the transaction, so
+                    # every later write on that connection died with
+                    # "InterfaceError: in failed transaction block" (10 of each
+                    # per 45 min in production, 2026-07-28). GREATEST() would
+                    # fix Postgres and break SQLite, which this module also
+                    # targets, so the comparison moves to Python and the SQL
+                    # stays dialect-neutral.
+                    prior_confidence = existing[3] if len(existing) > 3 else None
+                    best_confidence = max(
+                        float(prior_confidence or 0.0),
+                        float(segment.get("boundary_score") or 0.0),
+                    )
                     # Stamp source_id onto a legacy (domain-only) row as it is
                     # re-seen, so it becomes source-keyed without a backfill.
                     cursor.execute(
@@ -385,7 +404,7 @@ class ContentCleaningTelemetry:
                         UPDATE persistent_boilerplate_patterns
                         SET occurrences_total = occurrences_total + ?,
                             last_seen = ?,
-                            confidence_score = MAX(confidence_score, ?),
+                            confidence_score = ?,
                             is_ml_training_eligible = ?,
                             source_id = COALESCE(source_id, ?),
                             updated_at = CURRENT_TIMESTAMP
@@ -394,7 +413,7 @@ class ContentCleaningTelemetry:
                         (
                             segment.get("occurrences"),
                             datetime.now(),
-                            segment.get("boundary_score"),
+                            best_confidence,
                             is_ml_eligible,
                             source_id,
                             existing[0],

--- a/tests/cli/commands/test_content_cleaning.py
+++ b/tests/cli/commands/test_content_cleaning.py
@@ -228,7 +228,15 @@ def test_clean_article_updates_database(monkeypatch, runner):
     assert "Article content updated" in result.output
     assert cleaner.calls == [("example.com", "article-123", False)]
     queries = [q for q, _ in cursor.executed]
-    assert any("UPDATE articles SET content" in q for q in queries)
+    # Cleaned output goes to `text`. `content` is the canonical capture and must
+    # never be written after insert -- writing cleaned text back into it made the
+    # two columns converge (151 of 183 rows byte-identical in one production
+    # export), so the raw capture was no longer recoverable from the row and the
+    # 30-day GCS raw HTML became the only remaining witness.
+    assert any("UPDATE articles SET text" in q for q in queries)
+    assert not any(
+        "UPDATE articles SET content" in q for q in queries
+    ), "the canonical capture must never be overwritten"
     assert connection.commits == 1
 
 

--- a/tests/cli/commands/test_extraction_content_validation.py
+++ b/tests/cli/commands/test_extraction_content_validation.py
@@ -1077,10 +1077,15 @@ class TestFurnitureShapeGate:
         assert len(inserts) == 1
         row = inserts[0]
         assert row["status"] == "not_article"
-        # Furniture body dropped from both columns...
-        assert row["content"] == ""
+        # The BODY is dropped -- `text` is the cleaned, consumable column and
+        # that is what "body dropped" means. `content` is the canonical capture
+        # and is NOT edited after capture: blanking it destroyed the only
+        # durable copy of the furniture (raw HTML in GCS ages out at 30 days),
+        # leaving rows that could not afterwards be re-examined to see why they
+        # were rejected, or re-filed when a wall went unrecognised.
         assert row["text"] == ""
-        # ...but the metadata captured alongside it is preserved.
+        assert row["content"] == self.COUNTRY_DROPDOWN
+        # ...and the metadata captured alongside it is preserved.
         assert row["title"] == "Headline Outside The Furniture"
 
     def test_nav_wrapped_wall_with_paywall_pattern_marked_paywall(self, monkeypatch):
@@ -1092,8 +1097,10 @@ class TestFurnitureShapeGate:
         assert len(inserts) == 1
         row = inserts[0]
         assert row["status"] == "paywall"
-        assert row["content"] == ""
+        # Same rule: cleaned body dropped, canonical wall text retained so the
+        # row itself still evidences WHY it was filed paywall.
         assert row["text"] == ""
+        assert row["content"] != ""
         assert row["title"] == "Headline Outside The Furniture"
 
     def test_nav_wrapped_wall_without_pattern_falls_back_to_not_article(

--- a/tests/cli/commands/test_gate_reads_canonical.py
+++ b/tests/cli/commands/test_gate_reads_canonical.py
@@ -1,0 +1,134 @@
+"""Classification reads the canonical capture; only sufficiency reads cleaned text.
+
+The save path degrades its input in stages:
+
+    content["content"]  ->  _decode_capture  ->  content_cleaner  ->  stripped
+         canonical              decoded            boilerplate removed
+
+Both later stages are correct for deciding what to STORE, and both destroy the
+evidence a classifier needs. The wall branch blanks ``content_text`` outright so
+a wall is never saved as a body, and ``strip_boilerplate`` removes paywall
+phrases because that is its job. The gate then asked the *cleaned* text whether
+the page was a wall -- of text those very phrases had just been taken out of.
+
+``looks_like_paywall`` documents the trap in its own docstring ("matches on the
+raw body, NOT the stripped one") and the gate did it anyway. The result, over
+one production run: 298 of 316 ``not_article`` rows carried a real headline and
+a real publish date. Sedalia's prompt matches a marker that has been in
+PAYWALL_MARKERS the whole time -- detection never failed, it was asked of the
+wrong text.
+
+Separately, this gate ran unconditionally and could overwrite an affirmative
+wire classification, discarding an attribution already established from the
+byline or the content detector: rows carrying wire=["The Associated Press"] and
+wire=["Washington Post"] were filed not_article.
+
+These tests pin the rule rather than the three symptoms, because the next
+cleaning rule added is what breaks this again.
+"""
+
+import inspect
+
+import pytest
+
+from src.utils.boilerplate import PAYWALL_MARKERS, looks_like_paywall
+
+SEDALIA_WALL = """Attention subscribers
+
+To continue reading, you will need to either log into your subscriber account
+or purchase a new subscription.
+
+If you are a digital subscriber with an active subscription, then you already
+have an online account. Please log in below to access this article.
+
+Otherwise, click here to view your options for subscribing."""
+
+
+class TestDetectionWasNeverTheProblem:
+    """The marker list already covers these walls."""
+
+    def test_sedalia_wall_is_recognised_on_raw_text(self):
+        assert looks_like_paywall(SEDALIA_WALL) is not None
+
+    def test_the_matching_marker_already_shipped(self):
+        marker = looks_like_paywall(SEDALIA_WALL)
+        assert marker in PAYWALL_MARKERS, (
+            "no new phrase was needed -- the gate simply never asked this "
+            "function about the canonical capture"
+        )
+
+    def test_stripping_the_wall_hides_it(self):
+        """Why asking the cleaned text cannot work.
+
+        Remove the marker, as strip_boilerplate does, and the same page is
+        undetectable. This is the mechanism, not a hypothetical.
+        """
+        marker = looks_like_paywall(SEDALIA_WALL)
+        stripped = SEDALIA_WALL.lower().replace(marker, "")
+        assert looks_like_paywall(stripped) is None
+
+
+class TestGateReadsCanonical:
+    """The rule: classify on canonical, measure sufficiency on cleaned."""
+
+    def _gate_source(self) -> str:
+        import src.cli.commands.extraction as mod
+
+        src = inspect.getsource(mod)
+        start = src.index("THE CANONICAL CAPTURE")
+        end = src.index("elif is_insufficient_content", start)
+        return src[start:end]
+
+    def test_canonical_is_captured_before_any_branch_blanks_it(self):
+        src = self._gate_source()
+        assert "canonical_text = _decode_capture(" in src
+
+    def test_paywall_is_classified_on_canonical(self):
+        """Not on stripped_content, and not on the cleaner's pattern names."""
+        src = self._gate_source()
+        assert "looks_like_paywall(canonical_text)" in src
+
+    def test_sufficiency_still_measures_the_cleaned_text(self):
+        """The other half of the rule.
+
+        "Is there a story left after cleaning" is genuinely a question about
+        the cleaned output -- moving it to the canonical would count furniture
+        as article body.
+        """
+        src = self._gate_source()
+        assert "is_insufficient_content = (" in src
+        assert "len(stripped_content.strip()) < MIN_CONTENT_LENGTH" in src
+
+    def test_canonical_is_never_reassigned(self):
+        """Blanking it to signal a decision is what broke this originally.
+
+        The storage variables (content_text, content["content"]) already carry
+        that signal; the canonical must stay readable for classification.
+        """
+        import src.cli.commands.extraction as mod
+
+        body = inspect.getsource(mod)
+        assert body.count("canonical_text = ") == 1
+
+    def test_paywall_detection_is_additive_not_a_replacement(self):
+        """A wall any one of the three sources recognises must still count."""
+        src = self._gate_source()
+        assert "gate_says_paywall" in src
+        assert "patterns_matched" in src
+        assert "paywall_marker is not None" in src
+
+
+class TestWireIsTerminal:
+    def test_the_shape_gate_cannot_reclassify_wire(self):
+        src = TestGateReadsCanonical()._gate_source()
+        assert 'if article_status == "wire":' in src, (
+            "an affirmative wire classification must short-circuit the shape "
+            "gate -- a walled wire story is still a wire story"
+        )
+
+    def test_wire_branch_precedes_the_paywall_branch(self):
+        """Ordering is the fix; both branches assigning is not enough."""
+        src = TestGateReadsCanonical()._gate_source()
+        wire = src.index('if article_status == "wire":')
+        paywall = src.index("and has_paywall_patterns:")
+        assert wire < paywall

--- a/tests/crawler/test_capture_path_proxy_telemetry.py
+++ b/tests/crawler/test_capture_path_proxy_telemetry.py
@@ -1,0 +1,212 @@
+"""Every capture path must report the proxy it used, not just the HTTP one.
+
+Extraction captures a page one of three ways: the plain proxied HTTP fetch
+(`_fetch_page_html`), the tls_client/unblock rung
+(`_extract_with_unblock_proxy`), or a Selenium render. Only the first ever
+called `set_proxy_metrics`, so an extraction captured by either of the other
+two recorded `proxy_used=0`, `proxy_url` NULL and `router_proxy` NULL -- while
+its traffic went through Squid exactly like everything else.
+
+Measured in production 2026-07-28 over 250 CIN-labelled rows: **all 47 rows
+missing proxy data were captured by Selenium or the unblock rung, and every one
+of the 203 http_fetch rows had it**. A perfect split, which is what a
+per-path instrumentation gap looks like rather than a data problem.
+
+This was invisible until it wasn't: Selenium produced no rows at all from
+2026-07-25 to 07-27 (the Manifest V2 proxy-auth outage), so there were no
+Selenium-captured extractions to under-report. Fixing Selenium exposed the gap.
+
+It is the same defect class as the fetch-path bug fixed the day before -- the
+proxy was never bypassed, only the evidence was -- and these tests exist so the
+next capture path added cannot repeat it silently.
+"""
+
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from src.crawler import ContentExtractor
+from src.crawler.proxy_config import RouterProxy
+from src.utils.comprehensive_telemetry import PROXY_STATUS_SUCCESS, ExtractionMetrics
+
+
+def _metrics():
+    return ExtractionMetrics("op", "art", "https://example.com/s", "example.com")
+
+
+class TestSeleniumProxyResolution:
+    """One definition, so telemetry cannot report a proxy the driver isn't using."""
+
+    def test_prefers_selenium_proxy(self, monkeypatch):
+        monkeypatch.setenv("SELENIUM_PROXY", "http://u:p@sel.example:3128")
+        monkeypatch.setenv("SQUID_PROXY_URL", "http://u:p@squid.example:3128")
+        assert (
+            ContentExtractor._resolve_selenium_proxy() == "http://u:p@sel.example:3128"
+        )
+
+    def test_falls_back_to_squid_proxy_url(self, monkeypatch):
+        monkeypatch.delenv("SELENIUM_PROXY", raising=False)
+        monkeypatch.setenv("SQUID_PROXY_URL", "http://u:p@squid.example:3128")
+        assert (
+            ContentExtractor._resolve_selenium_proxy()
+            == "http://u:p@squid.example:3128"
+        )
+
+    def test_never_resolves_to_empty(self, monkeypatch):
+        """An empty proxy would mean an unproxied browser egressing the pod IP."""
+        monkeypatch.delenv("SELENIUM_PROXY", raising=False)
+        monkeypatch.delenv("SQUID_PROXY_URL", raising=False)
+        assert ContentExtractor._resolve_selenium_proxy()
+
+    def test_the_driver_sites_use_this_helper(self):
+        """The value must not be re-derived inline anywhere.
+
+        Three driver-creation sites each inlined the same os.getenv chain. A
+        divergence between them and what telemetry reported would be invisible,
+        so the lookup lives in one place and this pins it there.
+        """
+        import inspect
+
+        import src.crawler as crawler_module
+
+        src = inspect.getsource(crawler_module)
+        # Only the helper body itself may name the variable.
+        assert src.count('"SELENIUM_PROXY"') == 1
+
+
+class TestSeleniumRecordsItsProxy:
+    def test_selenium_start_records_proxy_used(self, monkeypatch):
+        monkeypatch.setenv("SELENIUM_PROXY", "http://user:pw@squid.example:3128")
+        metrics = _metrics()
+
+        # conftest's autouse fixture forces SELENIUM_AVAILABLE False so no test
+        # spawns real Chrome. Without re-enabling it here _run_selenium_extraction
+        # returns on its first line and these assertions pass vacuously -- which
+        # is exactly what test_router_proxy_stays_unset_for_selenium did before
+        # this was noticed. Chrome is still never launched: _check_rate_limit
+        # below short-circuits the method well before any driver is created.
+        monkeypatch.setattr("src.crawler.SELENIUM_AVAILABLE", True)
+
+        ex = ContentExtractor.__new__(ContentExtractor)
+        ex._check_rate_limit = lambda d: True  # bail immediately after recording
+        ex.domain_router_proxy = {}
+        ex._selenium_failure_counts = {}
+        ex._disable_selenium_for_diagnostics = False
+
+        try:
+            ex._run_selenium_extraction(
+                "https://example.com/story",
+                {},
+                metrics,
+                reason="test",
+                missing_fields=["content"],
+            )
+        except Exception:
+            pass  # the extraction itself is not under test; the recording is
+
+        assert metrics.proxy_used is True, "a Selenium capture is proxied"
+        assert "squid.example" in (metrics.proxy_url or "")
+        assert metrics.proxy_status == PROXY_STATUS_SUCCESS
+
+    def test_selenium_masks_its_credentials(self, monkeypatch):
+        monkeypatch.setenv("SELENIUM_PROXY", "http://user:sekret@squid.example:3128")
+        metrics = _metrics()
+        # conftest's autouse fixture forces SELENIUM_AVAILABLE False so no test
+        # spawns real Chrome. Without re-enabling it here _run_selenium_extraction
+        # returns on its first line and these assertions pass vacuously -- which
+        # is exactly what test_router_proxy_stays_unset_for_selenium did before
+        # this was noticed. Chrome is still never launched: _check_rate_limit
+        # below short-circuits the method well before any driver is created.
+        monkeypatch.setattr("src.crawler.SELENIUM_AVAILABLE", True)
+
+        monkeypatch.setattr("src.crawler.SELENIUM_AVAILABLE", True)
+        ex = ContentExtractor.__new__(ContentExtractor)
+        ex._check_rate_limit = lambda d: True
+        ex.domain_router_proxy = {}
+        ex._selenium_failure_counts = {}
+        ex._disable_selenium_for_diagnostics = False
+        try:
+            ex._run_selenium_extraction(
+                "https://example.com/s", {}, metrics, "test", ["content"]
+            )
+        except Exception:
+            pass
+        assert "sekret" not in (metrics.proxy_url or "")
+        assert metrics.proxy_authenticated is True
+
+    def test_router_proxy_stays_unset_for_selenium(self, monkeypatch):
+        """Honest absence, not a guess.
+
+        Selenium reads a static SELENIUM_PROXY and never consults the shared
+        router, so there is no home/mizzou decision to report. Recording one
+        would invent a routing choice that never happened -- and would hide
+        that browser traffic is exempt from #413's health-based failover.
+        """
+        monkeypatch.setenv("SELENIUM_PROXY", "http://user:pw@squid.example:3128")
+        metrics = _metrics()
+        # conftest's autouse fixture forces SELENIUM_AVAILABLE False so no test
+        # spawns real Chrome. Without re-enabling it here _run_selenium_extraction
+        # returns on its first line and these assertions pass vacuously -- which
+        # is exactly what test_router_proxy_stays_unset_for_selenium did before
+        # this was noticed. Chrome is still never launched: _check_rate_limit
+        # below short-circuits the method well before any driver is created.
+        monkeypatch.setattr("src.crawler.SELENIUM_AVAILABLE", True)
+
+        monkeypatch.setattr("src.crawler.SELENIUM_AVAILABLE", True)
+        ex = ContentExtractor.__new__(ContentExtractor)
+        ex._check_rate_limit = lambda d: True
+        ex.domain_router_proxy = {"example.com": RouterProxy.MIZZOU_SQUID}
+        ex._selenium_failure_counts = {}
+        ex._disable_selenium_for_diagnostics = False
+        try:
+            ex._run_selenium_extraction(
+                "https://example.com/s", {}, metrics, "test", ["content"]
+            )
+        except Exception:
+            pass
+        assert metrics.router_proxy is None
+
+
+class TestTelemetryIsRecordedPerPath:
+    """Guard the shape of the bug rather than one instance of it."""
+
+    def test_every_capture_path_records_proxy_metrics(self):
+        """A capture path that never calls set_proxy_metrics under-reports.
+
+        Pins the three known paths. A fourth added without recording will not
+        trip this, but the assertion documents the requirement at the point
+        someone would look.
+        """
+        import inspect
+
+        import src.crawler as crawler_module
+
+        for fn in (
+            crawler_module.ContentExtractor._fetch_page_html,
+            crawler_module.ContentExtractor._extract_with_unblock_proxy,
+            crawler_module.ContentExtractor._run_selenium_extraction,
+        ):
+            src = inspect.getsource(fn)
+            assert "set_proxy_metrics" in src, (
+                f"{fn.__name__} captures pages but never records which proxy "
+                "served them -- the gap that made proxy_used=0 on 47 of 250 rows"
+            )
+
+    def test_recording_failure_cannot_break_a_capture(self):
+        """Telemetry must never be able to discard a capture we already hold."""
+        import inspect
+
+        import src.crawler as crawler_module
+
+        for fn in (
+            crawler_module.ContentExtractor._fetch_page_html,
+            crawler_module.ContentExtractor._extract_with_unblock_proxy,
+            crawler_module.ContentExtractor._run_selenium_extraction,
+        ):
+            src = inspect.getsource(fn)
+            # rindex on the CALL: the name also appears in explanatory
+            # comments, and matching those would pass on unguarded code.
+            idx = src.rindex("set_proxy_metrics(")
+            window = src[max(0, idx - 400) : idx]
+            assert "try:" in window, f"{fn.__name__} must guard the recording"

--- a/tests/crawler/test_selenium_proxy_auth.py
+++ b/tests/crawler/test_selenium_proxy_auth.py
@@ -229,3 +229,118 @@ class TestRelayWithoutCredentials:
         """Never expose an open proxy to the network."""
         host, _ = relay.proxy_url.split(":")
         assert host == "127.0.0.1"
+
+
+class TestTargetHostParsing:
+    """The relay routes on the host each request is FOR."""
+
+    @pytest.mark.parametrize(
+        "head,want",
+        [
+            (b"CONNECT example.com:443 HTTP/1.1\r\n\r\n", "example.com"),
+            (b"GET http://example.com/a HTTP/1.1\r\n\r\n", "example.com"),
+            (b"GET http://u:p@example.com:80/a HTTP/1.1\r\n\r\n", "example.com"),
+            (b"GET /relative HTTP/1.1\r\n\r\n", None),
+            (b"garbage\r\n\r\n", None),
+            (b"", None),
+        ],
+    )
+    def test_extracts_the_target(self, head, want):
+        assert ProxyAuthRelay.target_host(head) == want
+
+
+class TestPerConnectionRouting:
+    """Selenium's proxy choice must follow the router, per domain.
+
+    Chrome fixes --proxy-server at launch and drivers are reused across
+    domains, so choosing at driver creation would carry one domain's proxy to
+    the next. Routing therefore happens per connection inside the relay, which
+    is the only component that sees each request's target host.
+    """
+
+    def test_router_choice_is_honoured(self, squid):
+        """Two upstreams, and the resolver decides which serves each host."""
+        other = FakeSquid()
+        try:
+            routed = f"http://{UPSTREAM_USER}:{UPSTREAM_PASS}@127.0.0.1:{other.port}"
+            relay = ProxyAuthRelay(
+                f"http://{UPSTREAM_USER}:{UPSTREAM_PASS}@127.0.0.1:{squid.port}",
+                resolve_upstream=lambda host: (
+                    routed if host == "routed.example" else None
+                ),
+            )
+            relay.start()
+            try:
+                _speak(
+                    relay.proxy_url,
+                    b"CONNECT routed.example:443 HTTP/1.1\r\n\r\n",
+                )
+                _speak(
+                    relay.proxy_url,
+                    b"CONNECT default.example:443 HTTP/1.1\r\n\r\n",
+                )
+                assert other.seen_headers, "routed host did not reach the routed proxy"
+                assert squid.seen_headers, "default host did not reach the default"
+                assert b"routed.example" in other.seen_headers[0]
+                assert b"default.example" in squid.seen_headers[0]
+            finally:
+                relay.stop()
+        finally:
+            other.stop()
+
+    def test_routed_upstream_gets_its_own_credentials(self, squid):
+        """Auth is per-upstream: two Squids need not share a password."""
+        other = FakeSquid()
+        try:
+            routed = f"http://{UPSTREAM_USER}:{UPSTREAM_PASS}@127.0.0.1:{other.port}"
+            relay = ProxyAuthRelay(
+                f"http://127.0.0.1:{squid.port}", resolve_upstream=lambda h: routed
+            )
+            relay.start()
+            try:
+                reply = _speak(
+                    relay.proxy_url, b"CONNECT any.example:443 HTTP/1.1\r\n\r\n"
+                )
+                assert b"200" in reply, "routed upstream was not authenticated"
+                assert b"Proxy-Authorization: Basic " in other.seen_headers[0]
+            finally:
+                relay.stop()
+        finally:
+            other.stop()
+
+    def test_resolver_failure_falls_back_to_default(self, squid):
+        """A routing decision must never stop a page loading."""
+
+        def boom(host):
+            raise RuntimeError("router down")
+
+        relay = ProxyAuthRelay(
+            f"http://{UPSTREAM_USER}:{UPSTREAM_PASS}@127.0.0.1:{squid.port}",
+            resolve_upstream=boom,
+        )
+        relay.start()
+        try:
+            reply = _speak(relay.proxy_url, b"CONNECT any.example:443 HTTP/1.1\r\n\r\n")
+            assert b"200" in reply
+            assert b"407" not in reply
+        finally:
+            relay.stop()
+
+    @pytest.mark.parametrize("bad", ["http://", ""])
+    def test_unusable_routed_url_falls_back_rather_than_raising(self, squid, bad):
+        """A malformed routed proxy must degrade to the default, not except.
+
+        Note "://nonsense" is NOT such a case -- it parses to the host
+        "nonsense", which is a legitimate-looking name whose connection simply
+        fails. Only a URL with no host at all is unusable at parse time.
+        """
+        relay = ProxyAuthRelay(
+            f"http://{UPSTREAM_USER}:{UPSTREAM_PASS}@127.0.0.1:{squid.port}",
+            resolve_upstream=lambda h: bad,
+        )
+        relay.start()
+        try:
+            reply = _speak(relay.proxy_url, b"CONNECT any.example:443 HTTP/1.1\r\n\r\n")
+            assert b"200" in reply
+        finally:
+            relay.stop()

--- a/tests/models/test_candidate_link_scheme_dedup.py
+++ b/tests/models/test_candidate_link_scheme_dedup.py
@@ -1,0 +1,122 @@
+"""One page, one candidate_link -- regardless of scheme or www.
+
+upsert_candidate_link deduplicates on a scheme- and www-agnostic path, but the
+lookup rebuilt candidate URLs from that stripped path while storage kept "www.".
+So it searched for "https://example.com/x" against a row stored as
+"https://www.example.com/x", never matched, and inserted a second row for the
+other scheme.
+
+Effect in production: one publisher held 471 candidate_links against 300
+articles. 142 links were marked 'extracted' with no article of their own --
+their article existed under the other scheme's link. Not data loss, but a link
+asserting an article it did not have, which is indistinguishable from loss when
+querying by candidate_link_id.
+
+https wins: both schemes serve the same page, and converging on the secure form
+stops later discoveries alternating and re-creating the split.
+"""
+
+import pytest
+
+from src.models.database import upsert_candidate_link
+
+
+class _Query:
+    def __init__(self, rows):
+        self.rows = rows
+        self.filtered = None
+
+    def filter(self, criterion):
+        self.criterion = criterion
+        return self
+
+    def order_by(self, *_):
+        return self
+
+    def first(self):
+        return self.rows[0] if self.rows else None
+
+
+class _Session:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.added = []
+        self.committed = 0
+        self.last_query = None
+
+    def query(self, _model):
+        self.last_query = _Query(self.rows)
+        return self.last_query
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed += 1
+
+
+class _Existing:
+    def __init__(self, url):
+        self.url = url
+        self.source = "seed"
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    monkeypatch.setattr(
+        "src.models.database._commit_with_retry", lambda session: session.commit()
+    )
+
+
+def _candidates(session):
+    """The URL forms the dedup lookup actually searched for."""
+    return list(session.last_query.criterion.right.value)
+
+
+class TestLookupCoversStoredForms:
+    def test_www_variants_are_searched(self):
+        """The regression: storage keeps www., so the lookup must too."""
+        session = _Session()
+        upsert_candidate_link(session, "https://www.example.com/story", source="s")
+        assert "https://www.example.com/story" in _candidates(session)
+
+    def test_both_schemes_are_searched(self):
+        session = _Session()
+        upsert_candidate_link(session, "https://www.example.com/story", source="s")
+        found = _candidates(session)
+        assert "http://www.example.com/story" in found
+        assert "https://www.example.com/story" in found
+
+    def test_bare_host_variants_are_searched_too(self):
+        session = _Session()
+        upsert_candidate_link(session, "https://www.example.com/story", source="s")
+        found = _candidates(session)
+        assert "https://example.com/story" in found
+        assert "http://example.com/story" in found
+
+
+class TestNoSecondRowPerScheme:
+    def test_http_row_is_reused_for_the_https_discovery(self):
+        """The exact production shape: http seen first, https seen later."""
+        session = _Session(rows=[_Existing("http://www.example.com/story")])
+        upsert_candidate_link(session, "https://www.example.com/story", source="s")
+        assert session.added == [], "a second row per scheme is the bug"
+
+    def test_the_surviving_row_is_upgraded_to_https(self):
+        session = _Session(rows=[_Existing("http://www.example.com/story")])
+        link = upsert_candidate_link(
+            session, "https://www.example.com/story", source="s"
+        )
+        assert link.url == "https://www.example.com/story"
+
+    def test_https_is_not_downgraded_by_a_later_http_sighting(self):
+        session = _Session(rows=[_Existing("https://www.example.com/story")])
+        link = upsert_candidate_link(
+            session, "http://www.example.com/story", source="s"
+        )
+        assert link.url == "https://www.example.com/story"
+
+    def test_a_genuinely_new_url_still_inserts(self):
+        session = _Session()
+        upsert_candidate_link(session, "https://www.example.com/fresh", source="s")
+        assert len(session.added) == 1

--- a/tests/models/test_safe_session_execute_surfaces_failures.py
+++ b/tests/models/test_safe_session_execute_surfaces_failures.py
@@ -1,0 +1,70 @@
+"""safe_session_execute retries only what is retryable.
+
+It caught bare Exception and `pass`ed, falling through to the string-based
+handler for ANY failure of a SQLAlchemy Core statement. The fallback re-executes,
+so a genuine error did still surface -- but only after running the statement a
+second time, which for a non-idempotent write is a second attempt nobody asked
+for, against a connection whose transaction the first failure may already have
+aborted.
+
+Scope note, because the temptation is to claim more: this was investigated while
+chasing 176 candidate_links marked 'extracted' with no article row (142 with no
+article anywhere). This swallow is NOT established as the cause -- the fallback
+re-raises, so the caller was not silently told the write succeeded. It is fixed
+here as a real defect on its own terms; the orphaned rows still need their own
+root cause, and the caller-side rowcount guard is what protects against them.
+
+Only ArgumentError may fall through -- that is the signal for the legacy
+parameter styles the fallback exists to retry.
+"""
+
+import pytest
+from sqlalchemy.exc import ArgumentError
+from sqlalchemy.sql import text
+
+from src.models.database import safe_session_execute
+
+
+class _Session:
+    def __init__(self, error=None):
+        self.error = error
+        self.calls = 0
+
+    def execute(self, sql, params=None):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return "executed"
+
+
+class TestFailuresSurface:
+    def test_database_error_propagates(self):
+        """A failing statement must reach the caller (true before and after)."""
+        boom = RuntimeError("duplicate key violates uq_articles_url")
+        session = _Session(error=boom)
+        with pytest.raises(RuntimeError, match="uq_articles_url"):
+            safe_session_execute(session, text("INSERT INTO articles ..."), {"id": 1})
+
+    def test_it_does_not_silently_retry_a_real_failure(self):
+        """THE regression: a non-retryable failure must not be re-executed.
+
+        This is the assertion that fails on the previous implementation.
+        """
+        session = _Session(error=RuntimeError("nope"))
+        with pytest.raises(RuntimeError):
+            safe_session_execute(session, text("INSERT INTO x ..."), {"id": 1})
+        assert session.calls == 1, "a non-ArgumentError must not be retried"
+
+    def test_argument_error_still_falls_through(self):
+        """The fallback's actual purpose is preserved."""
+        session = _Session(error=ArgumentError("legacy param style"))
+        # Falls through to string handling; that path re-executes and this stub
+        # raises again, so the ArgumentError is what escapes -- the point is that
+        # it was ATTEMPTED a second time rather than surfacing immediately.
+        with pytest.raises(ArgumentError):
+            safe_session_execute(session, text("SELECT 1"), {"a": 1})
+        assert session.calls == 2, "ArgumentError must trigger the retry"
+
+    def test_success_returns_the_result(self):
+        session = _Session()
+        assert safe_session_execute(session, text("SELECT 1"), {"a": 1}) == "executed"

--- a/tests/utils/test_content_cleaning_telemetry.py
+++ b/tests/utils/test_content_cleaning_telemetry.py
@@ -911,3 +911,62 @@ class TestPersistentPatternsSourceIdKeying:
             telemetry.get_persistent_patterns(domain="other.com", source_id="SRC-2")
             == []
         )
+
+
+class TestSqlIsDialectNeutral:
+    """The SQL here runs on SQLite in tests and Postgres in production.
+
+    The persistent-pattern UPDATE used `MAX(confidence_score, ?)` -- SQLite's
+    two-argument scalar max. Postgres has no such function; max() there is a
+    one-argument aggregate, so the statement failed every time with:
+
+        42883: function max(double precision, unknown) does not exist
+
+    No test caught it because the suite runs on SQLite, where that SQL is
+    valid. It only showed up in production logs, and not as itself: the failed
+    statement aborts the transaction, so every later write on that connection
+    died with "InterfaceError: in failed transaction block". Ten of each per
+    45 minutes, with the real cause buried underneath.
+
+    So this asserts on the SQL text rather than on behaviour -- behaviour on
+    SQLite cannot distinguish the two dialects, which is exactly the blind spot.
+    """
+
+    def _module_sql(self) -> str:
+        """Module source with comments removed.
+
+        The prose above necessarily quotes the offending SQL, and a naive scan
+        of the raw source matches that quote rather than real code -- it fails
+        on the fixed module. Only executable text is scanned.
+        """
+        import inspect
+        import re
+
+        import src.utils.content_cleaning_telemetry as mod
+
+        src = inspect.getsource(mod)
+        return "\n".join(
+            re.sub(r"#.*$", "", line)
+            for line in src.splitlines()
+            if not line.strip().startswith("#")
+        )
+
+    def test_no_two_argument_max(self):
+        """max(a, b) is SQLite-only. Postgres needs GREATEST, which SQLite
+        lacks -- so neither belongs here; compare in Python instead."""
+        import re
+
+        assert not re.search(r"\bMAX\s*\([^)]*,", self._module_sql(), re.I), (
+            "two-argument MAX() is not valid Postgres; compute the comparison "
+            "in Python so the SQL works on both dialects"
+        )
+
+    def test_no_two_argument_min(self):
+        """Same trap, same fix."""
+        import re
+
+        assert not re.search(r"\bMIN\s*\([^)]*,", self._module_sql(), re.I)
+
+    def test_greatest_is_not_used_either(self):
+        """GREATEST would fix Postgres and break SQLite."""
+        assert "GREATEST(" not in self._module_sql().upper()


### PR DESCRIPTION
Six defects found by reading production data after the Selenium outage was repaired. They are one shape: **information is computed correctly and then destroyed before the code that needs it reads it.**

## `content` is now the immutable canonical

The schema said raw in `content`, cleaned in `text` (`f400000d`). The code violated it in both directions.

- The content cleaner wrote its output **back into `content`**, making it a cleaned derivative. The two columns converged — **151 of 183 rows byte-identical** in one export — and the raw capture stopped being recoverable from the row. It now writes only `text`, and reads `COALESCE(text, content)` so passes **compose**: reading `content` each time would re-clean the raw capture and silently discard what earlier passes removed.
- `ARTICLE_UPDATE_SQL` carried `content = :content` bound to the value it had just `SELECT`ed. Dropping it is a no-op today and makes immutability structural rather than dependent on every caller passing it back unchanged.
- The wall/furniture branches blanked `content["content"]` **before INSERT**, so the canonical never reached the database — those rows show `content=0` *and* `text=0`. "Body dropped" is now an explicit `body_dropped` flag. The flag is required, not cosmetic: with the canonical preserved, the `cleaned_text` fallback would otherwise restore the very wall the gate just rejected.

**No statement updates `articles.content` after insert.** A test asserts it, so the rule can't erode.

## Classification reads the canonical; sufficiency reads the cleaned text

The gate asked `stripped_content` whether a page was a wall — text `strip_boilerplate` had just removed the wall phrases from. `looks_like_paywall` documents that trap in its own docstring and the gate did it anyway.

**Detection was never missing.** Sedalia's prompt matches `"otherwise, click here to view your options for subscribing"`, which has been in `PAYWALL_MARKERS` all along. It was asked of the wrong text. Over one run, **298 of 316 `not_article` rows carried a real headline** — real journalism filed as "never was an article."

`not_article` keeps doing its real job for video, galleries and PDF shells. Nothing here widens it.

## Wire is terminal

The shape gate ran unconditionally and could overwrite an affirmative wire classification — rows carrying `wire=["The Associated Press"]` and `wire=["Washington Post"]` were rewritten to `not_article`. A walled wire story is still a wire story; its provenance does not depend on getting the body.

## Selenium: proxied all along, but invisible and unrouted

Three separate things, only one of which was a real egress problem:

| | before | now |
|---|---|---|
| Bypassing the proxy? | **No** — always via Squid | unchanged |
| Recorded in telemetry? | **No** — `proxy_used=0` | recorded |
| Using the router? | **No** — static home-only | routed per connection |

`set_proxy_metrics` was only called in `_fetch_page_html`, so Selenium- and unblock-captured extractions reported `proxy_used=0`. **All 47 rows missing proxy data in a 250-row sample were captured by those two paths; all 203 `http_fetch` rows had it** — a perfect split, which is what an instrumentation gap looks like.

Routing had to move **into the relay**: Chrome fixes `--proxy-server` at launch and drivers are reused across domains (`SELENIUM_DRIVER_REUSE_LIMIT=3`), so a per-domain choice made at driver creation would be carried to the next domain. The relay is the only component that sees each request's target host. Browser traffic was otherwise exempt from #413's health failover — the router logged `home_squid backed off for dosmundos.com (62 failures)` while Chrome kept sending there.

## Two-arg `MAX()` was aborting Postgres transactions

`confidence_score = MAX(confidence_score, ?)` is SQLite's scalar max. Postgres `max()` is a one-argument aggregate, so this failed **every time** with `42883`. The cost wasn't confined to that table: a failed statement aborts the transaction, so every later write on the connection died with `InterfaceError: in failed transaction block` — **10 + 10 errors per 45 minutes** in the processor, cause buried under the cascade. `persistent_boilerplate_patterns` has never updated on Postgres.

`GREATEST()` would fix Postgres and break SQLite, which this module also targets, so the comparison moved to Python.

## http/https duplicates

`upsert_candidate_link` deduplicates on a scheme- and www-agnostic path, then rebuilt the URLs to search for **from that stripped path** — while storage keeps `www.`. It searched `https://example.com/x` against a row stored as `https://www.example.com/x` and **could never match**. Every scheme variant inserted another row.

One publisher: **471 candidate_links against 300 articles**; 176 links marked `extracted` with no article of their own, 142 of those with the article under the other scheme's link. Nothing was lost — but a link asserting an article it does not have is indistinguishable from loss when querying by `candidate_link_id`, which is how it was first reported.

Lookup now covers all four stored forms; **https wins** for the surviving row and is never downgraded by a later http sighting.

Separately, `ARTICLE_INSERT_SQL` ends in `ON CONFLICT DO NOTHING`, so an insert can legitimately write nothing while the next statement marked the link `extracted` anyway. The status now only updates when a row was actually written.

## Verification

- Full suite green via the pre-push hook (lint, mypy, tests, 80% coverage gate) — no `--no-verify`.
- Every fix has tests that **fail on the pre-fix code**: 8/9 for the capture paths, 3/7 for the dedup (including the `www.` case that is the defect), 3/4 for the paywall gate, 1/4 for `safe_session_execute`.
- Tests pin the **rule**, not the symptoms — classification reads canonical, sufficiency reads cleaned, canonical assigned once, no statement may UPDATE it — because the next cleaning rule added is what breaks this again.

## Scope notes

- **Existing rows are past.** Where the cleaner already overwrote `content`, it holds cleaned text. Correct going forward; historical rows aren't recoverable from the DB, and the 30-day GCS raw HTML only covers recent ones.
- **Existing http/https pairs persist** — this prevents new ones. Merging them is a data migration. `uq_articles_url` still treats the schemes as distinct.
- **The 298 mislabelled `not_article` rows** can now be re-filed by backfill.
- `safe_session_execute` was narrowed to `except ArgumentError`, but it is **not** established as a cause of anything here — the fallback re-raises, so callers were never falsely told a write succeeded. Fixed on its own terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)