### PR TITLE
fix(cleaning): let the furniture detector shape the stored body, not just the status

### DIFF
--- a/src/cli/commands/extraction.py
+++ b/src/cli/commands/extraction.py
@@ -33,7 +33,12 @@ from src.models.database import (
 # crawler image, which carries no ML dependencies.
 from src.pipeline.text_cleaning import decode_rot47_segments
 from src.services.wire_detection import resolve_api_token
-from src.utils.boilerplate import looks_like_furniture, looks_like_paywall
+from src.utils.boilerplate import (
+    PAYWALL,
+    excise_furniture_lines,
+    looks_like_furniture,
+    looks_like_paywall,
+)
 
 # Lazy import: entity_extraction only needed for entity-extraction command
 # Importing at top level causes ModuleNotFoundError in crawler image (no rapidfuzz)
@@ -1845,6 +1850,49 @@ def _process_batch(
                         decoded_text = ""
                         stripped_content = ""
 
+                    # SECOND CLEANING PASS, chained onto the first.
+                    #
+                    # The pattern cleaner above removes what it has LEARNED for
+                    # this source (persistent_boilerplate_patterns). That is
+                    # per-source and needs a pattern to already exist, so on a
+                    # host it has not learned yet it removes nothing: measured
+                    # 2026-07-28 over a 3-hour production run, 120 cleaning
+                    # sessions ran and recorded ZERO removed segments.
+                    #
+                    # strip_furniture is the vendor-independent half -- it needs
+                    # no prior knowledge of the site. Without this the semantic
+                    # detector only ever GATED (decided paywall vs not_article)
+                    # and never shaped the body that gets stored, so a capture
+                    # whose host had no learned pattern was saved with its
+                    # furniture intact.
+                    #
+                    # CHAINED, never substituted: this runs ON the pattern
+                    # cleaner's output, so both passes' removals survive and
+                    # neither overwrites the other. Each stage only ever removes
+                    # more, and `content` is untouched by both.
+                    # excise_furniture_lines, NOT strip_furniture: the latter
+                    # is the detection-side function and is too destructive to
+                    # edit a stored body with. Measured over the 161 bodies this
+                    # pipeline stored on 2026-07-28, it rewrote 149 of them by
+                    # collapsing newlines and it deleted a maconhomepress.com
+                    # honor roll as a "menu run". The write path removes only
+                    # what vocabulary and concepts positively identify, and
+                    # leaves every other byte alone.
+                    furniture_kinds: frozenset[str] = frozenset()
+                    if stripped_content:
+                        deboned, furniture_kinds = excise_furniture_lines(
+                            stripped_content
+                        )
+                        if deboned != stripped_content:
+                            logger.info(
+                                "Furniture pass removed %d chars (%s) that no "
+                                "learned pattern covered: %s",
+                                len(stripped_content) - len(deboned),
+                                ",".join(sorted(furniture_kinds)) or "-",
+                                url,
+                            )
+                            stripped_content = deboned
+
                     # CLASSIFICATION -- read the canonical, not the cleaned
                     # text. The marker list already covers these walls: the
                     # Sedalia prompt matches "otherwise, click here to view
@@ -1858,6 +1906,15 @@ def _process_batch(
                     has_paywall_patterns = (
                         gate_says_paywall
                         or paywall_marker is not None
+                        # The KIND the furniture pass found selects the status.
+                        # This is the point of returning a kind at all: a wall
+                        # it excised means content exists and is withheld
+                        # (retryable with credentials), while a cookie table or
+                        # nav bar it excised means the opposite. Without this
+                        # the pass would silently empty a walled body and the
+                        # gate would call the result not_article -- the exact
+                        # mislabel this work exists to stop.
+                        or PAYWALL in furniture_kinds
                         or any(
                             pattern in cleaning_metadata.get("patterns_matched", [])
                             for pattern in ["subscription", "paywall"]

--- a/src/utils/boilerplate.py
+++ b/src/utils/boilerplate.py
@@ -727,6 +727,82 @@ def classify_furniture(text: str | None) -> Furniture | None:
     return None
 
 
+# A furniture line longer than this is edited sentence-by-sentence rather than
+# dropped whole, because at that length it is likely to be an extractor's
+# unbroken run of banner-plus-story rather than a banner alone. Set from the
+# stltoday captures, whose consent notices run ~300 chars while the mixed
+# banner-and-story lines run 1,500-2,200.
+MAX_WHOLE_LINE_DROP = 400
+
+
+def excise_furniture_lines(body: str | None) -> tuple[str, frozenset[str]]:
+    """Drop whole LINES that are furniture, leaving everything else byte-exact.
+
+    The write-path variant, and deliberately much more conservative than
+    strip_furniture(). It differs in exactly two ways, both of which were
+    forced by measuring strip_furniture against 161 real stored bodies:
+
+    1. **Layout is preserved.** strip_furniture rejoins with " ", which
+       collapses every newline in the body. On those 161 bodies that alone
+       rewrote 149 of them -- 90% -- for no editorial gain. Storing a
+       reformatted body is a destructive edit even when no words are lost.
+
+    2. **No menu-run removal.** _drop_menu_runs is a RUN heuristic tuned for
+       nav bars, and on stored bodies it eats agate: it removed a
+       maconhomepress.com honor roll ("Class 1 Macey Harrington Team GPA: 3.55
+       Jordan Harrington Jessalyn Parks ...") as though it were a menu. This
+       module's own thresholds already name that risk -- "the known false
+       positive is agate: sports scores, election returns, real estate
+       transfers, legitimate local copy carrying almost no function words".
+       Detecting furniture can afford that; editing a stored article cannot.
+
+    So this removes only what VOCABULARY and CONCEPTS positively identify --
+    consent notices, walls, comment policies, nav chrome -- and never anything
+    judged on shape alone. Returns the kept text and the kinds removed, so the
+    caller can let the kind pick the status.
+    """
+    if not body or not body.strip():
+        return "", frozenset()
+    kept_lines: list[str] = []
+    kinds: set[str] = set()
+    for line in body.splitlines():
+        if not line.strip():
+            kept_lines.append(line)
+            continue
+        found = classify_furniture(line)
+        if found is None or found.kind not in _SEGMENT_REMOVABLE:
+            kept_lines.append(line)
+            continue
+        if len(line) <= MAX_WHOLE_LINE_DROP:
+            kinds.add(found.kind)
+            continue
+        # A LONG line judged furniture is not necessarily furniture all the way
+        # through -- extractors that emit no paragraph breaks put the banner and
+        # the story on one line. Dropping it whole is the all-or-nothing bug in
+        # miniature: one stltoday.com capture carries its consent notice and
+        # "ST. LOUIS COUNTY -- A worker hired to paint the KSDK television
+        # transmission tower helped save a man who climbed it" in a single
+        # 2,177-char line, and dropping the line lost the story.
+        #
+        # So go a level finer INSIDE the line and keep what survives. The line
+        # boundary itself is preserved either way, so layout never changes.
+        inner = [s for s in segments(line) if _keeps(s, kinds)]
+        if inner:
+            kept_lines.append(" ".join(inner))
+        else:
+            kinds.add(found.kind)
+    return "\n".join(kept_lines).strip(), frozenset(kinds)
+
+
+def _keeps(segment: str, kinds: set[str]) -> bool:
+    """Whether a sentence survives, recording the kind when it does not."""
+    found = classify_furniture(segment)
+    if found is not None and found.kind in _SEGMENT_REMOVABLE:
+        kinds.add(found.kind)
+        return False
+    return True
+
+
 # Minimum characters of unbroken clean text to be believed as body copy inside a
 # block already condemned as a disclosure table.
 #

--- a/tests/test_write_path_furniture_excision.py
+++ b/tests/test_write_path_furniture_excision.py
@@ -1,0 +1,131 @@
+"""The furniture detector must shape the STORED body, not only gate on it.
+
+Until 2026-07-28 boilerplate.py was consulted only to decide a status. The text
+that got stored came solely from content_cleaner_balanced's per-source learned
+patterns, so on a host with no learned pattern nothing was removed at all --
+measured over a 3-hour production run, 120 cleaning sessions recorded ZERO
+removed segments while bodies still carried consent notices.
+
+Wiring the detector into the write path is easy to get wrong in two specific
+ways, and both were caught by measuring against real stored bodies rather than
+by reasoning. Each has a test here.
+
+1. strip_furniture() is the DETECTION-side function and is too destructive to
+   edit a stored article with. Over the 161 bodies this pipeline stored on
+   2026-07-28 it rewrote 149 of them by collapsing newlines, and it deleted a
+   maconhomepress.com honor roll as a "menu run" -- the agate false positive
+   this module's own thresholds already warn about.
+
+2. Dropping whole furniture LINES loses stories, because extractors that emit
+   no paragraph breaks put the banner and the article on one line.
+"""
+
+from src.utils.boilerplate import (
+    CONSENT,
+    MAX_WHOLE_LINE_DROP,
+    excise_furniture_lines,
+    strip_furniture,
+)
+
+# Shape of the real stltoday.com capture: consent notice and story on ONE line.
+BANNER = (
+    "This website utilizes technologies such as cookies to enable essential "
+    "site functionality, as well as for analytics, personalization, and "
+    "targeted advertising. To learn more, view the following link: Privacy Policy"
+)
+STORY = (
+    "ST. LOUIS COUNTY - A worker hired to paint the KSDK television "
+    "transmission tower helped save a man who climbed it Wednesday afternoon "
+    "without authorization. Rescuers in a basket were raised up to reach him. "
+    "The man was taken to a hospital and is expected to recover, police said."
+)
+
+# The maconhomepress.com honor roll, copied in the shape the extractor really
+# emits it: one name per line. That shape is the whole point -- a run of short
+# capitalised fragments with no sentence punctuation is indistinguishable from a
+# nav bar by structure alone, which is exactly why the run heuristic eats it.
+AGATE = "\n".join(
+    [
+        "Class 1",
+        "Macey Harrington",
+        "Team GPA: 3.55",
+        "Jordan Harrington",
+        "Jessalyn Parks",
+        "Alana Fesler",
+        "Lanie Witt",
+        "Jaycee Christensen",
+        "Kenny Vaught",
+        "Haley Bachman",
+        "Sophia Brower",
+        "Jessica Compton",
+        "Presleigh Williams",
+    ]
+)
+
+
+class TestLayoutIsPreserved:
+    """A reformatted body is a destructive edit even when no words are lost."""
+
+    def test_newlines_survive(self):
+        body = "First paragraph here.\n\nSecond paragraph here.\n\nThird one."
+        kept, _ = excise_furniture_lines(body)
+        assert kept.count("\n") == body.strip().count("\n")
+
+    def test_a_clean_body_is_returned_byte_identical(self):
+        body = "The council voted Tuesday.\nThe measure passed five to two."
+        assert excise_furniture_lines(body)[0] == body
+
+    def test_strip_furniture_would_not_have_been_safe_here(self):
+        """Why the write path needs its own function.
+
+        Pins the actual difference rather than trusting the docstring: the
+        detection-side helper collapses the line structure.
+        """
+        body = "First paragraph here.\n\nSecond paragraph here."
+        assert "\n" not in strip_furniture(body).text
+        assert "\n" in excise_furniture_lines(body)[0]
+
+
+class TestAgateSurvives:
+    """Legitimate local copy that reads like a list is not furniture."""
+
+    def test_an_honor_roll_is_not_removed(self):
+        kept, _ = excise_furniture_lines("Honor roll:\n" + AGATE)
+        assert "Macey Harrington" in kept
+        assert "Presleigh Williams" in kept
+
+    def test_the_detection_helper_does_remove_it(self):
+        """The reason the write path may not use menu-run removal.
+
+        Documents the real divergence: this is fine for deciding "is this
+        block furniture" and wrong for editing a stored article.
+        """
+        assert "Macey Harrington" not in strip_furniture(AGATE).text
+
+
+class TestMixedLinesAreEditedNotDropped:
+    def test_a_banner_and_a_story_on_one_line_keeps_the_story(self):
+        kept, kinds = excise_furniture_lines(BANNER + " " + STORY)
+        assert "A worker hired to paint" in kept
+        assert "utilizes technologies such as cookies" not in kept
+        assert CONSENT in kinds
+
+    def test_a_short_banner_alone_is_dropped_whole(self):
+        kept, kinds = excise_furniture_lines(BANNER)
+        assert kept == ""
+        assert CONSENT in kinds
+
+    def test_the_threshold_separates_those_two_cases(self):
+        """A banner alone is short; a banner glued to a story is not."""
+        assert len(BANNER) < MAX_WHOLE_LINE_DROP
+        assert len(BANNER + " " + STORY) > MAX_WHOLE_LINE_DROP
+
+
+class TestTheKindReachesTheCaller:
+    """The status depends on it, so it must survive excision."""
+
+    def test_consent_is_reported(self):
+        assert CONSENT in excise_furniture_lines(BANNER)[1]
+
+    def test_a_clean_body_reports_nothing(self):
+        assert excise_furniture_lines(STORY)[1] == frozenset()


### PR DESCRIPTION
## The gap

The semantic detector only ever **gated**. It decided `paywall` vs `not_article` and never touched the text that gets saved — `text` came solely from `content_cleaner_balanced`'s per-source learned patterns, and `strip_furniture` was called in exactly one place: the crawler's mcmetadata consent guard.

That per-source cleaner needs a pattern to *already exist*, so on a host it hasn't learned it removes nothing. Measured over a 3-hour production run on 2026-07-28:

| table | rows in 3h |
|---|---|
| `content_cleaning_sessions` | **120** |
| `content_cleaning_segments` | **0** |

Every session ran, found nothing, recorded nothing — while stltoday.com bodies sat in the corpus with their consent notices intact. The vendor-independent half of the detector was never given the chance to help.

## What changed

A second pass on the write path, **chained** onto the pattern cleaner rather than replacing it: each stage only removes more, neither overwrites the other, and `content` is untouched by both. The **kind** the pass finds selects the status — the point of returning a kind at all. Without that, the pass would silently empty a walled body and the gate would file it `not_article`.

## Why it does NOT reuse `strip_furniture`

That's the detection-side function, and it is too destructive to edit a stored article with. Measured against the **161 bodies this pipeline actually stored** on 2026-07-28, it would have:

- **rewritten 149 of them (90%)** by collapsing every newline — a destructive edit even though no words are lost
- **deleted a maconhomepress.com honor roll** — `Class 1 / Macey Harrington / Team GPA: 3.55 / Jordan Harrington / …` — as a *"menu run"*. One name per line is structurally identical to a nav bar, and this module's own thresholds already warn that agate (sports scores, election returns, real estate transfers) is the known false positive.

So `excise_furniture_lines` removes only what **vocabulary and concepts** positively identify, never anything judged on shape alone, and preserves layout.

## The mixed-line trap

A first cut dropped whole furniture *lines* and lost a story. Extractors that emit no paragraph breaks put the banner and the article on **one line** — a stltoday.com capture carries its consent notice and *"ST. LOUIS COUNTY — A worker hired to paint the KSDK television transmission tower helped save a man who climbed it"* in a single 2,177-char line. Lines over `MAX_WHOLE_LINE_DROP` are now edited sentence-by-sentence instead of dropped, so the banner goes and the story stays.

## Verified on real data, not fixtures

| check | result |
|---|---|
| 4 stltoday consent bodies | all cleaned, **none emptied** |
| KSDK-tower story | **preserved**, its banner removed |
| 176 labelled stories | 0 changed, 0 emptied |
| 161 live stored bodies | 0 changed, 0 emptied |
| maconhomepress honor roll | **intact** |

Both near-misses above are pinned by tests, including the agate fixture in the one-name-per-line shape the extractor really emits — the shape that reproduces the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)