### PR TITLE
fix: ROT47 marker-density validation + wire misattribution (cross-domain canonical)

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -273,6 +273,77 @@ _WIRE_SERVICE_DOMAINS = {
     "latimes.com": "Los Angeles Times",
 }
 
+# A canonical URL on a domain OTHER than the article's own is not automatically
+# syndication -- it can be the SAME publisher under a second name. Found
+# 2026-07-28: emissourian.com's canonical points to missourian.com with an
+# IDENTICAL slug, and the page's own TownNews CDN path is
+# bloximages.chicago2.vip.townnews.com/missourian.com/shared-content/... --
+# missourian.com is this paper's CMS site-key, not a wire source. Two
+# hyper-local prep-sports recaps were filed `wire` and excluded from CIN
+# classification because of it.
+#
+# Deliberately NOT raw substring containment. An early draft checked
+# `label in domain` and wrongly caught kansascity.com / kansas.com, which is
+# real syndication between two different newsrooms in different cities --
+# the "match" was coincidental (Kansas City happens to start with the word
+# "Kansas"). Real US city/state/country names collide with compound domain
+# names constantly, so this only allows an EXACT label match after removing
+# one of a short, explicit list of cosmetic affixes, or an identical
+# registrable domain (a subdomain variant of the same site).
+#
+# Validated against all 549 distinct (article_domain, wire_service) pairs
+# carrying status='wire' in production on 2026-07-28: suppresses exactly 5,
+# all confirmed same-site (emissourian.com/missourian.com, the
+# mdcp.nwaonline.com subdomain cluster, kmbc.com/storystudio.kmbc.com), and
+# preserves all 544 genuine cross-organization pairs, including
+# kansascity.com/kansas.com.
+_COSMETIC_DOMAIN_PREFIXES = ("e", "the", "my", "live", "new", "www")
+
+
+def _registrable_domain(domain: str) -> str:
+    parts = domain.split(".")
+    return ".".join(parts[-2:]) if len(parts) >= 2 else domain
+
+
+def _domain_base_label(domain: str) -> str:
+    parts = domain.split(".")
+    return parts[-2] if len(parts) >= 2 else domain
+
+
+def _is_same_site_domain_alias(article_domain: str, canonical_domain: str) -> bool:
+    """Whether two cross-domain URLs are plausibly the SAME publisher.
+
+    Two checks, both narrow on purpose:
+
+    1. Identical registrable domain -- a subdomain variant of one site
+       (mdcp.nwaonline.com vs nwaonline.com).
+    2. The two domains' base labels become EXACTLY equal once one of a short,
+       fixed set of cosmetic prefixes is stripped (emissourian -> missourian).
+       Never a substring/containment check -- see the module comment above
+       for why that specific looser version is unsafe here.
+    """
+    if _registrable_domain(article_domain) == _registrable_domain(canonical_domain):
+        return True
+
+    article_label = _domain_base_label(article_domain)
+    canonical_label = _domain_base_label(canonical_domain)
+    if article_label == canonical_label:
+        return True
+
+    def variants(label: str) -> set[str]:
+        out = {label}
+        for prefix in _COSMETIC_DOMAIN_PREFIXES:
+            if (
+                label.startswith(prefix)
+                and len(label) - len(prefix) >= 5
+                and label[len(prefix) :].isalpha()
+            ):
+                out.add(label[len(prefix) :])
+        return out
+
+    return bool(variants(article_label) & variants(canonical_label))
+
+
 # CMS-specific JavaScript data object patterns for content metadata extraction
 # These capture title, author, and other fields from CMS JavaScript objects
 
@@ -7144,9 +7215,13 @@ class ContentExtractor:
                             normalized = self._normalize_wire_service_name(wire_name)
                             if normalized and normalized not in wire_services:
                                 wire_services.append(normalized)
-                        else:
+                        elif not _is_same_site_domain_alias(
+                            article_domain, canonical_domain
+                        ):
                             # Unknown domain but cross-domain canonical indicates syndication
-                            # (e.g., Hearst TV stations syndicating between each other)
+                            # (e.g., Hearst TV stations syndicating between each other).
+                            # The same-site check above rules out a domain alias for
+                            # the SAME publisher first -- see _is_same_site_domain_alias.
                             detection_methods.append("canonical_cross_domain")
                             raw_sources.append(canonical_domain)
                             evidence.append(

--- a/src/pipeline/text_cleaning.py
+++ b/src/pipeline/text_cleaning.py
@@ -144,6 +144,18 @@ def _decode_segment(segment: str) -> str | None:
     return cleaned
 
 
+def _marker_density(s: str) -> float:
+    """Share of *s* that is a ROT47-marker punctuation character.
+
+    ROT47 shifts common English letters into this exact punctuation set, so
+    genuine ciphertext is saturated with it and genuine English essentially
+    never is. Comparing this before and after decoding is what tells a real
+    decode apart from a paragraph that merely didn't need one — see the
+    validation note below.
+    """
+    return sum(1 for ch in s if ch in _ROT47_MARKERS) / len(s) if s else 0.0
+
+
 def _decode_rot47_by_markers(text: str) -> str | None:
     """Decode ROT47 text using paragraph markers (kAm/k^Am).
 
@@ -174,9 +186,25 @@ def _decode_rot47_by_markers(text: str) -> str | None:
         segment = match.group(0)
         decoded = _decode_rot47_text(segment)
 
-        # Basic validation: decoded should have reasonable letter ratio
-        letters = sum(1 for ch in decoded if ch.isalpha())
-        if len(decoded) > 0 and letters / len(decoded) >= 0.3:
+        # Validation is RELATIVE, not absolute: accept a decode when it
+        # measurably reduced ROT47-marker saturation relative to its own
+        # ciphertext, rather than requiring the decoded text alone to clear a
+        # fixed "looks like prose" bar.
+        #
+        # An absolute floor on decoded letter-ratio (this used to require
+        # >= 0.3) rejects a genuinely correct decode whenever the recovered
+        # text is naturally letter-sparse -- a box score is the case that
+        # exposed it: "NC - 0 - 14 - 0 - 10 = 24" decodes perfectly and scores
+        # 0.23, so the ciphertext was left in place mid-article while every
+        # surrounding prose paragraph decoded fine. Its RAW ciphertext scores
+        # even fewer letters by coincidence (ROT47 shifts digits and
+        # punctuation too), which is exactly why an absolute floor on the
+        # OUTPUT is the wrong measure and a relative one is not.
+        #
+        # Verified against every one of the 44 kAm/k^Am paragraphs in the
+        # production row that surfaced this (2026-07-28): marker density drops
+        # after decoding in all 44, including the 2 the old floor rejected.
+        if _marker_density(decoded) < _marker_density(segment):
             # Clean up HTML tags
             cleaned = _DECODED_TAG_RE.sub(" ", decoded)
             replacements.append((match.start(), match.end(), cleaned))

--- a/tests/crawler/test_same_site_domain_alias.py
+++ b/tests/crawler/test_same_site_domain_alias.py
@@ -1,0 +1,114 @@
+"""_is_same_site_domain_alias: tells a publisher's own domain alias apart
+from a real cross-organization wire relationship.
+
+Guards the canonical-cross-domain wire-detection fallback in
+src/crawler/__init__.py, which used to treat ANY domain mismatch on an
+unknown (non-`_WIRE_SERVICE_DOMAINS`) canonical as syndication. Found
+2026-07-28: emissourian.com's canonical points to missourian.com with an
+identical URL slug, and the page's own TownNews CDN path names
+missourian.com as this paper's CMS site-key -- not a wire source. Two
+hyper-local prep-sports recaps were filed `wire` and dropped out of CIN
+classification because of it.
+"""
+
+from src.crawler import _is_same_site_domain_alias
+
+
+class TestConfirmedSameSiteCases:
+    """Each of these was independently confirmed against the live page or
+    against production telemetry before being treated as a same-site alias --
+    see project_wire_misattribution_bug.md for how each was checked."""
+
+    def test_emissourian_missourian(self):
+        """Confirmed via live canonical tag + TownNews CDN site-key path."""
+        assert _is_same_site_domain_alias("emissourian.com", "missourian.com")
+
+    def test_nwaonline_subdomain_cluster(self):
+        """Identical registrable domain, different subdomains."""
+        assert _is_same_site_domain_alias("mdcp.nwaonline.com", "nwaonline.com")
+        assert _is_same_site_domain_alias("mdcp.nwaonline.com", "bvwv.nwaonline.com")
+        assert _is_same_site_domain_alias("mdcp.nwaonline.com", "hl.nwaonline.com")
+
+    def test_kmbc_storystudio_subdomain(self):
+        assert _is_same_site_domain_alias("kmbc.com", "storystudio.kmbc.com")
+
+    def test_symmetric(self):
+        """Order must not matter -- either side may be the 'article' domain."""
+        assert _is_same_site_domain_alias("missourian.com", "emissourian.com")
+
+
+class TestRealSyndicationMustSurvive:
+    """The reason this is NOT a substring check.
+
+    A first draft used `label in domain` and wrongly caught
+    kansascity.com/kansas.com -- genuinely different newsrooms (Kansas City
+    Star, Wichita Eagle) in different cities. Real US city/state/country
+    names collide with longer compound domain names constantly, so any
+    fix here has to not be fooled by that.
+    """
+
+    def test_kansascity_kansas_is_not_an_alias(self):
+        assert not _is_same_site_domain_alias("kansascity.com", "kansas.com")
+        assert not _is_same_site_domain_alias("kansas.com", "kansascity.com")
+
+    def test_unrelated_hearst_affiliates(self):
+        """kmbc.com/wcvb.com: the real case the fallback exists for."""
+        assert not _is_same_site_domain_alias("kmbc.com", "wcvb.com")
+
+    def test_completely_unrelated_domains(self):
+        assert not _is_same_site_domain_alias("stltoday.com", "reuters.com")
+
+    def test_short_geographic_words_do_not_collide(self):
+        """A handful of other plausible geographic-substring near-misses."""
+        assert not _is_same_site_domain_alias("newyorktimes.com", "newyork.com")
+        assert not _is_same_site_domain_alias("texastribune.org", "texas.gov")
+
+
+class TestValidatedAgainstAllProductionPairs:
+    """Regression guard for the exact numbers reported to the user.
+
+    All 549 distinct (article_domain, wire_service) pairs carrying
+    status='wire' in production on 2026-07-28, captured once as a fixture so
+    this test doesn't depend on a live DB connection. If this count ever
+    drifts, re-derive it from a fresh production query rather than editing
+    the expected numbers to make the test pass.
+    """
+
+    # A representative sample of the 544 pairs confirmed to survive --
+    # the full 549 were checked interactively against this exact function
+    # before it was wired in; re-listing all of them here would just be the
+    # production query restated as a fixture.
+    REAL_SYNDICATION_SAMPLE = [
+        ("kansascity.com", "kansas.com"),
+        ("kcur.org", "stlpr.org"),
+        ("krcgtv.com", "wjla.com"),
+        ("krcgtv.com", "thenationaldesk.com"),
+        ("abcstlouis.com", "foxbaltimore.com"),
+        ("abcstlouis.com", "wsbt.com"),
+        ("griffonnews.com", "columbiamissourian.com"),
+        ("kfvs12.com", "wifr.com"),
+        ("joplinglobe.com", "app.accessnewswire.com"),
+        ("bransontrilakesnews.com", "goodrx.com"),
+    ]
+
+    SAME_SITE_ALIASES = [
+        ("emissourian.com", "missourian.com"),
+        ("kmbc.com", "storystudio.kmbc.com"),
+        ("mdcp.nwaonline.com", "bvwv.nwaonline.com"),
+        ("mdcp.nwaonline.com", "hl.nwaonline.com"),
+        ("mdcp.nwaonline.com", "nwaonline.com"),
+    ]
+
+    def test_real_syndication_sample_all_survive(self):
+        for article_domain, wire_domain in self.REAL_SYNDICATION_SAMPLE:
+            assert not _is_same_site_domain_alias(article_domain, wire_domain), (
+                f"{article_domain} -> {wire_domain} is real syndication and "
+                "must not be suppressed"
+            )
+
+    def test_all_five_confirmed_aliases_are_caught(self):
+        for article_domain, wire_domain in self.SAME_SITE_ALIASES:
+            assert _is_same_site_domain_alias(article_domain, wire_domain), (
+                f"{article_domain} -> {wire_domain} is a confirmed same-site "
+                "alias and must be suppressed"
+            )

--- a/tests/crawler/test_structured_metadata_wire_detection.py
+++ b/tests/crawler/test_structured_metadata_wire_detection.py
@@ -148,6 +148,96 @@ class TestCanonicalUrlCrossDomainDetection:
         assert any("wcvb.com" in svc.lower() for svc in result["wire_services"])
 
 
+class TestCanonicalCrossDomainSameSiteAlias:
+    """An unknown-domain cross-domain canonical is not automatically wire.
+
+    Found 2026-07-28: emissourian.com's canonical points to missourian.com with
+    an IDENTICAL slug, and the page's own TownNews CDN path is
+    bloximages.chicago2.vip.townnews.com/missourian.com/shared-content/... --
+    missourian.com is this paper's own CMS site-key, not a wire source. Two
+    hyper-local prep-sports recaps (real reporting, no byline, box scores) were
+    filed `wire` because of it and dropped out of CIN classification entirely.
+
+    Validated against all 549 distinct (article_domain, wire_service) pairs
+    carrying status='wire' in production: suppresses exactly 5, all confirmed
+    same-site, and preserves all 544 genuine cross-organization pairs.
+    """
+
+    def test_emissourian_missourian_is_not_wire(self, extractor):
+        """The exact case that surfaced this."""
+        html = """
+        <html><head>
+        <link rel="canonical" href="https://www.missourian.com/sports/bulldogs-fall-to-north-county-in-thursday-tilt/article_8b5f4600.html"/>
+        </head><body></body></html>
+        """
+        result = extractor._detect_structured_metadata_wire_from_html(
+            html,
+            article_url="https://www.emissourian.com/sports/bulldogs-fall-to-north-county-in-thursday-tilt/article_8b5f4600.html",
+        )
+        assert result is None
+
+    def test_nwaonline_subdomain_variant_is_not_wire(self, extractor):
+        """Same registrable domain, different subdomain -- same publisher."""
+        html = """
+        <html><head>
+        <link rel="canonical" href="https://bvwv.nwaonline.com/news/2026/story"/>
+        </head><body></body></html>
+        """
+        result = extractor._detect_structured_metadata_wire_from_html(
+            html, article_url="https://mdcp.nwaonline.com/news/2026/story"
+        )
+        assert result is None
+
+    def test_kmbc_storystudio_subdomain_is_not_wire(self, extractor):
+        html = """
+        <html><head>
+        <link rel="canonical" href="https://storystudio.kmbc.com/feature/123"/>
+        </head><body></body></html>
+        """
+        result = extractor._detect_structured_metadata_wire_from_html(
+            html, article_url="https://www.kmbc.com/feature/123"
+        )
+        assert result is None
+
+    def test_kansascity_kansas_is_still_real_syndication(self, extractor):
+        """The case that killed a broader substring-based first draft.
+
+        kansascity.com and kansas.com are genuinely different newsrooms in
+        different cities -- the Kansas City Star and the Wichita Eagle. A raw
+        substring check (`"kansas" in "kansascity.com"`) wrongly caught this
+        as a same-site alias; it is real syndication and must stay detected.
+        """
+        html = """
+        <html><head>
+        <link rel="canonical" href="https://www.kansas.com/news/state/article123.html"/>
+        </head><body></body></html>
+        """
+        result = extractor._detect_structured_metadata_wire_from_html(
+            html, article_url="https://www.kansascity.com/news/state/article123.html"
+        )
+        assert result is not None
+        assert "canonical_cross_domain" in result["detected_by"]
+        assert any("kansas.com" in svc.lower() for svc in result["wire_services"])
+
+    def test_unrelated_cross_affiliate_syndication_still_detected(self, extractor):
+        """Guard against over-correcting: genuinely different domains stay wire.
+
+        Same fixture as test_canonical_cross_domain_unknown_service above --
+        kmbc.com and wcvb.com share no name or registrable domain at all, the
+        real Hearst-TV-affiliate case the original fallback was written for.
+        """
+        html = """
+        <html><head>
+        <link rel="canonical" href="https://www.wcvb.com/article/xyz/123"/>
+        </head><body></body></html>
+        """
+        result = extractor._detect_structured_metadata_wire_from_html(
+            html, article_url="https://www.kmbc.com/article/xyz/123"
+        )
+        assert result is not None
+        assert any("wcvb.com" in svc.lower() for svc in result["wire_services"])
+
+
 class TestJsonLdAuthorDetection:
     """Test detection via JSON-LD author field containing wire service names."""
 

--- a/tests/pipeline/test_text_cleaning.py
+++ b/tests/pipeline/test_text_cleaning.py
@@ -1,6 +1,7 @@
 from src.pipeline.text_cleaning import (
     _decode_segment,
     _looks_like_rot47_token,
+    _marker_density,
     _rot47,
     decode_rot47_segments,
 )
@@ -89,3 +90,87 @@ def test_decode_rot47_segments_no_kAm_markers():
     # Should return immediately without processing
     result = decode_rot47_segments(text)
     assert result == text
+
+
+class TestBoxScoreDecodesInsteadOfBeingRejected:
+    """A box score decodes correctly and used to be thrown away anyway.
+
+    Found 2026-07-28 on a real emissourian.com production row: every prose
+    paragraph decoded and displayed correctly, then the "Box Score" section
+    reverted to raw ciphertext. Not because it failed to decode -- because it
+    decoded PERFECTLY and a validation gate rejected it anyway.
+
+    The gate was `letters / len(decoded) >= 0.3`, an absolute floor on the
+    OUTPUT. A box score is mostly digits and dashes, so it fails that floor
+    even when the decode is exactly right:
+
+        ciphertext: kA 4=2DDlQAcQm}r \\ _ \\ `c \\ _ \\ `_ l ack^Am
+        decoded:    <p class="p4">NC - 0 - 14 - 0 - 10 = 24</p>
+        letters=10 len=43 ratio=0.23 -- below 0.3, rejected
+
+    Fixed by comparing marker density BEFORE and AFTER decoding instead: ROT47
+    saturates ciphertext with a specific punctuation set, and real English
+    (however letter-sparse) essentially never does. A genuine decode always
+    reduces that saturation; a box score's raw ciphertext still shows it even
+    though the box score's own letter count is low -- which is exactly why an
+    absolute floor on the output was the wrong measure.
+    """
+
+    RAW_BOX_SCORE = r"kA 4=2DDlQAcQm}r \ _ \ `c \ _ \ `_ l ack^Am"
+    RAW_SECOND_LINE = r"kA 4=2DDlQAcQm$%r \ _ \ `c \ _ \ _ l `ck^Am"
+    # A real prose paragraph from the same production row, so the "full
+    # article" test below exercises actual ciphertext throughout rather than
+    # a hand-typed stand-in -- an earlier draft used a fabricated paragraph
+    # that was already-plain English wearing a kAm/k^Am wrapper, which the
+    # relative check correctly refused to touch (it never was ciphertext),
+    # leaving a literal `k^Am` in the test's own expected output.
+    RAW_INTRO = (
+        "kA 4=2DDlQAcQm“(6’G6 8@E E@ 36 E@F896C[” $E] "
+        "r=2:C w625 r@249 %C2G:D y@9?D@? D2:5]k^Am"
+    )
+
+    def test_the_box_score_decodes_correctly_on_its_own(self):
+        """Pin the mechanism, not just the outcome: this IS a correct decode."""
+        from src.pipeline.text_cleaning import _decode_rot47_text
+
+        decoded = _decode_rot47_text(self.RAW_BOX_SCORE)
+        assert "NC - 0 - 14 - 0 - 10 = 24" in decoded
+
+    def test_the_old_absolute_floor_would_have_rejected_it(self):
+        """Document WHY this needed fixing, not just that it now works."""
+        from src.pipeline.text_cleaning import _decode_rot47_text
+
+        decoded = _decode_rot47_text(self.RAW_BOX_SCORE)
+        letters = sum(1 for ch in decoded if ch.isalpha())
+        ratio = letters / len(decoded)
+        assert ratio < 0.3, (
+            "if this ever rises above 0.3 the box score stopped being the "
+            "case that motivated the relative check -- re-derive from a "
+            "current low-letter-ratio production example instead"
+        )
+
+    def test_marker_density_drops_after_a_genuine_decode(self):
+        """The actual replacement rule."""
+        from src.pipeline.text_cleaning import _decode_rot47_text
+
+        decoded = _decode_rot47_text(self.RAW_BOX_SCORE)
+        assert _marker_density(decoded) < _marker_density(self.RAW_BOX_SCORE)
+
+    def test_a_full_article_with_a_box_score_decodes_completely(self):
+        """End to end: no ciphertext survives anywhere in a real article."""
+        article = f"{self.RAW_INTRO} {self.RAW_BOX_SCORE} {self.RAW_SECOND_LINE}"
+        result = decode_rot47_segments(article)
+        assert "kAm" not in result and "k^Am" not in result
+        assert "tougher" in result
+        assert "NC - 0 - 14 - 0 - 10 = 24" in result
+        assert "STC - 0 - 14 - 0 - 0 = 14" in result
+
+    def test_a_paragraph_that_genuinely_did_not_need_decoding_is_left_alone(self):
+        """The relative check must not fire on plain text with no ciphertext.
+
+        There is nothing to compare against a lower-density "after" if there
+        was never a "before" -- decode_rot47_segments short-circuits before
+        ever calling the marker-based decoder when no kAm/k^Am is present.
+        """
+        text = "The council met Tuesday and approved the budget unanimously."
+        assert decode_rot47_segments(text) == text


### PR DESCRIPTION
Two independent fixes, landed together per user direction.

---

## 1. ROT47: validate a decode by marker-density improvement, not an absolute floor

We already had a ROT47 decoder for TownNews/Lee Enterprises' encoded article text — it was not failing to decode anything. It was decoding correctly and then throwing the result away.

`_decode_rot47_by_markers` validated each decoded `kAm`/`k^Am` paragraph with `letters/len(decoded) >= 0.3` — an absolute floor on the **output**. A box score is mostly digits and dashes, so it fails that floor even when the decode is exactly right:

```
ciphertext: kA 4=2DDlQAcQm}r \ _ \ `c \ _ \ `_ l ack^Am
decoded:    <p class="p4">NC - 0 - 14 - 0 - 10 = 24</p>
letters=10 len=43 ratio=0.23 -- below 0.3, rejected
```

Confirmed on a real `emissourian.com` production row: every prose paragraph decoded correctly, and the "Box Score" section reverted to raw ciphertext mid-article — a validation gate discarding a correct decode, not a decode failure.

**Fix:** compare ROT47-marker density before and after decoding, instead of measuring the output alone. ROT47 shifts common English letters into a specific punctuation set (`@?:;[]=^$\|`), so genuine ciphertext is saturated with it and genuine English essentially never is — a real decode always reduces that saturation.

**Verified:** all 44 `kAm`/`k^Am` paragraphs in the row that surfaced this (marker density drops in all 44, including the 2 the old floor rejected); 1,975 real paragraphs across 66 production rows from every previously-affected host (0 garbage ever accepted, 1 disclosed minor regression — a one-word `[graph]` caption placeholder whose own decoded brackets are themselves marker characters).

---

## 2. Wire misattribution: a cross-domain canonical is not automatically syndication

Found investigating why two hyper-local `emissourian.com` prep-sports recaps (real reporting, box scores, no byline) were excluded from CIN classification entirely.

**Root cause:** `_detect_structured_metadata_wire_from_html`'s canonical-URL check falls through to an unrestricted `else` whenever a canonical points to an unknown domain (outside the 18-entry `_WIRE_SERVICE_DOMAINS` allowlist). Any mismatch was trusted as syndication using the bare canonical domain as the wire-service name.

**Confirmed on the live page:** `emissourian.com`'s canonical points to `missourian.com` with an **identical URL slug**, and the page's own TownNews CDN path is `bloximages.chicago2.vip.townnews.com/missourian.com/shared-content/...` — `missourian.com` is this paper's own CMS site-key, not a wire source.

**Fix:** `_is_same_site_domain_alias` — before trusting an unknown-domain canonical as syndication, check whether it's plausibly the *same publisher*: identical registrable domain (subdomain variant), or the two domains' base labels become exactly equal once one of a short, explicit cosmetic-prefix list (`e-`, `the-`, `my-`, `live-`, `new-`, `www-`) is stripped.

**Deliberately not raw substring containment.** A first draft wrongly caught `kansascity.com`/`kansas.com` — the Kansas City Star and the Wichita Eagle, genuinely different newsrooms, real syndication between them. Real US city/state/country names collide with compound domain names constantly.

**Validated against all 549 real `(article_domain, wire_service)` pairs** carrying `status='wire'` in production: suppresses exactly 5, all independently confirmed same-site; preserves all 544 genuine cross-organization pairs, including `kansascity.com`/`kansas.com` and the `kmbc.com`/`wcvb.com` Hearst-affiliate case an existing test already pins as the real syndication this fallback exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)