### PR TITLE
fix: bidirectional paywall gate + strip form widgets before content selection

### DIFF
--- a/src/mcmetadata/content.py
+++ b/src/mcmetadata/content.py
@@ -22,6 +22,66 @@ logger = logging.getLogger(__name__)
 
 MINIMUM_CONTENT_LENGTH = 200  # less than this and it doesn't count as working extraction (experimentally determined)
 
+# Strip <form>/<select> markup before ANY extractor sees the HTML. Dropdown
+# option lists are never real article prose in any legitimate page -- a
+# country/state selector inside a subscription-purchase widget is pure form
+# furniture -- but trafilatura's (and others') "pick the largest/densest text
+# block" heuristic has no way to know that, and a long option list easily
+# outweighs a real but short article body in raw text volume.
+#
+# Confirmed live on emissourian.com/missourian.com (TownNews): a swim-meet
+# recap's actual body was two lede sentences plus a JS-required paywall
+# notice (~170 chars total, itself below MINIMUM_CONTENT_LENGTH), while a
+# `<select id="field-postal-country-super-purchase">` from an unrelated
+# subscription-checkout modal elsewhere on the page held 5,308 chars of
+# concatenated country names. trafilatura picked the dropdown. All four
+# <select> elements on that page were subscription-form fields
+# (*-super-purchase ids) -- zero were legitimate content.
+#
+# Deliberately narrow: only forms/selects are removed. meta/script/style/link
+# tags are left untouched so extractors that read them (structured-data
+# authorship, JSON-LD, canonical links) are unaffected -- this is NOT the
+# same as `everything_cleaner` below, which is far more aggressive and is
+# wired only to the readability path.
+_form_stripping_cleaner = Cleaner(
+    scripts=False,
+    javascript=False,
+    comments=False,
+    style=False,
+    links=False,
+    meta=False,
+    page_structure=False,
+    processing_instructions=False,
+    embedded=False,
+    frames=False,
+    forms=True,
+    annoying_tags=False,
+    remove_unknown_tags=False,
+    safe_attrs_only=False,
+    kill_tags=["select"],  # belt-and-suspenders: catches a <select> with no
+    # enclosing <form>, which forms=True alone would miss.
+)
+
+
+def _strip_form_widgets(html_text: str) -> str:
+    """Remove <form>/<select> markup so it can never be mistaken for article
+    content. Returns the input unchanged if it isn't parseable HTML -- this is
+    a defensive cleanup pass, not a required one, so a malformed document
+    should fall through to the extractors exactly as before this existed."""
+    if (
+        not html_text
+        or "<select" not in html_text.lower()
+        and "<form" not in html_text.lower()
+    ):
+        # Cheap short-circuit: skip the lxml round-trip entirely when there is
+        # nothing for this pass to do, which is the common case.
+        return html_text
+    try:
+        return _form_stripping_cleaner.clean_html(html_text)
+    except Exception:
+        return html_text
+
+
 # customize readability to remove all tags
 everything_cleaner = Cleaner(
     scripts=True,
@@ -70,6 +130,11 @@ def from_html(
                              create a notable performance hit
     :return: a dict of with url, text, title, publish_date, top_image_url, authors, and extraction_method keys
     """
+    # Strip form/select widgets ONCE, before any extractor sees the HTML --
+    # see _strip_form_widgets for why. Applied here rather than per-extractor
+    # so every extraction method in the fallback chain gets it uniformly.
+    html_text = _strip_form_widgets(html_text)
+
     # now try each extractor against the same HTML
     for extractor_info in extractors:
 

--- a/src/mcmetadata/content.py
+++ b/src/mcmetadata/content.py
@@ -16,71 +16,12 @@ from lxml.html import fromstring, tostring
 from lxml.html.clean import Cleaner
 
 from .exceptions import BadContentError, UnableToExtractError
+from .form_widgets import strip_form_widgets
 from .text import strip_tags
 
 logger = logging.getLogger(__name__)
 
 MINIMUM_CONTENT_LENGTH = 200  # less than this and it doesn't count as working extraction (experimentally determined)
-
-# Strip <form>/<select> markup before ANY extractor sees the HTML. Dropdown
-# option lists are never real article prose in any legitimate page -- a
-# country/state selector inside a subscription-purchase widget is pure form
-# furniture -- but trafilatura's (and others') "pick the largest/densest text
-# block" heuristic has no way to know that, and a long option list easily
-# outweighs a real but short article body in raw text volume.
-#
-# Confirmed live on emissourian.com/missourian.com (TownNews): a swim-meet
-# recap's actual body was two lede sentences plus a JS-required paywall
-# notice (~170 chars total, itself below MINIMUM_CONTENT_LENGTH), while a
-# `<select id="field-postal-country-super-purchase">` from an unrelated
-# subscription-checkout modal elsewhere on the page held 5,308 chars of
-# concatenated country names. trafilatura picked the dropdown. All four
-# <select> elements on that page were subscription-form fields
-# (*-super-purchase ids) -- zero were legitimate content.
-#
-# Deliberately narrow: only forms/selects are removed. meta/script/style/link
-# tags are left untouched so extractors that read them (structured-data
-# authorship, JSON-LD, canonical links) are unaffected -- this is NOT the
-# same as `everything_cleaner` below, which is far more aggressive and is
-# wired only to the readability path.
-_form_stripping_cleaner = Cleaner(
-    scripts=False,
-    javascript=False,
-    comments=False,
-    style=False,
-    links=False,
-    meta=False,
-    page_structure=False,
-    processing_instructions=False,
-    embedded=False,
-    frames=False,
-    forms=True,
-    annoying_tags=False,
-    remove_unknown_tags=False,
-    safe_attrs_only=False,
-    kill_tags=["select"],  # belt-and-suspenders: catches a <select> with no
-    # enclosing <form>, which forms=True alone would miss.
-)
-
-
-def _strip_form_widgets(html_text: str) -> str:
-    """Remove <form>/<select> markup so it can never be mistaken for article
-    content. Returns the input unchanged if it isn't parseable HTML -- this is
-    a defensive cleanup pass, not a required one, so a malformed document
-    should fall through to the extractors exactly as before this existed."""
-    if (
-        not html_text
-        or "<select" not in html_text.lower()
-        and "<form" not in html_text.lower()
-    ):
-        # Cheap short-circuit: skip the lxml round-trip entirely when there is
-        # nothing for this pass to do, which is the common case.
-        return html_text
-    try:
-        return _form_stripping_cleaner.clean_html(html_text)
-    except Exception:
-        return html_text
-
 
 # customize readability to remove all tags
 everything_cleaner = Cleaner(
@@ -131,9 +72,9 @@ def from_html(
     :return: a dict of with url, text, title, publish_date, top_image_url, authors, and extraction_method keys
     """
     # Strip form/select widgets ONCE, before any extractor sees the HTML --
-    # see _strip_form_widgets for why. Applied here rather than per-extractor
+    # see form_widgets.strip_form_widgets for why. Applied here rather than per-extractor
     # so every extraction method in the fallback chain gets it uniformly.
-    html_text = _strip_form_widgets(html_text)
+    html_text = strip_form_widgets(html_text)
 
     # now try each extractor against the same HTML
     for extractor_info in extractors:

--- a/src/mcmetadata/form_widgets.py
+++ b/src/mcmetadata/form_widgets.py
@@ -1,0 +1,77 @@
+"""Strip <form>/<select> markup before content extraction picks a block.
+
+Deliberately its own module, importing ONLY lxml. content.py pulls in the
+whole extraction stack (dateparser, trafilatura, newspaper, goose3, boilerpy3,
+readability) at module level, and those live in the crawler/processor images
+but NOT in the CI base image. Anything importing content.py can therefore only
+be tested inside a built crawler image -- and the PR image check mounts just
+tests/dependency_contracts/, so such a test would skip in CI and never run in
+the image either, i.e. be dead.
+
+lxml is in the base image, so keeping this here means its tests actually run
+on every PR.
+"""
+
+from __future__ import annotations
+
+from lxml.html.clean import Cleaner
+
+# Dropdown option lists are never real article prose on a legitimate page -- a
+# country/state selector inside a subscription-purchase widget is pure form
+# furniture -- but the "pick the largest/densest text block" heuristic every
+# extractor uses has no way to know that, and a long option list easily
+# outweighs a real but short article body in raw text volume.
+#
+# Confirmed live on emissourian.com/missourian.com (TownNews): a swim-meet
+# recap's actual body was two lede sentences plus a JS-required paywall notice
+# (~170 chars total, itself below MINIMUM_CONTENT_LENGTH), while a
+# `<select id="field-postal-country-super-purchase">` from an unrelated
+# subscription-checkout modal elsewhere on the page held 5,308 chars of
+# concatenated country names. trafilatura picked the dropdown. All four
+# <select> elements on that page were subscription-form fields
+# (*-super-purchase ids) -- zero were legitimate content -- and that same
+# widget, byte-identical, was the stored body for at least three articles
+# across two domains.
+#
+# Deliberately narrow: only forms/selects are removed. meta/script/style/link
+# tags are left untouched so extractors that read them (structured-data
+# authorship, JSON-LD, canonical links) are unaffected -- this is NOT the same
+# as content.py's `everything_cleaner`, which is far more aggressive and is
+# wired only to the readability path.
+_form_stripping_cleaner = Cleaner(
+    scripts=False,
+    javascript=False,
+    comments=False,
+    style=False,
+    links=False,
+    meta=False,
+    page_structure=False,
+    processing_instructions=False,
+    embedded=False,
+    frames=False,
+    forms=True,
+    annoying_tags=False,
+    remove_unknown_tags=False,
+    safe_attrs_only=False,
+    kill_tags=["select"],  # belt-and-suspenders: catches a <select> with no
+    # enclosing <form>, which forms=True alone would miss.
+)
+
+
+def strip_form_widgets(html_text: str) -> str:
+    """Remove <form>/<select> markup so it can never be mistaken for article
+    content. Returns the input unchanged if it isn't parseable HTML -- this is
+    a defensive cleanup pass, not a required one, so a malformed document
+    should fall through to the extractors exactly as before this existed."""
+    if (
+        not html_text
+        or "<select" not in html_text.lower()
+        and "<form" not in html_text.lower()
+    ):
+        # Cheap short-circuit: skip the lxml round-trip entirely when there is
+        # nothing for this pass to do, which is the common case.
+        return html_text
+    try:
+        return _form_stripping_cleaner.clean_html(html_text)
+    except Exception:
+        return html_text

--- a/src/utils/boilerplate.py
+++ b/src/utils/boilerplate.py
@@ -658,13 +658,26 @@ def _consent_dump(text: str, lowered: str) -> str | None:
 
 
 def _gated(lowered: str) -> str | None:
-    """A wall: something withheld, and the thing you must do to get it."""
+    """A wall: something withheld, and the thing you must do to get it.
+
+    Searches BOTH directions around the access-intent match. Found 2026-07-29
+    on a real maryvilleforum.com wall this missed entirely:
+
+        "Your current subscription does not provide access to this content."
+
+    The gate action ("subscription") sits BEFORE the access-intent phrase
+    ("access to this content") in that sentence -- a forward-only window never
+    sees it. Real walls order these both ways ("please log in to access this
+    article" vs "your subscription does not provide access to this content"),
+    so the search has to be symmetric, not just extended.
+    """
     entitle = _ENTITLEMENT.search(lowered)
     if entitle:
         return entitle.group(0).strip()
     for m in _ACCESS_INTENT.finditer(lowered):
-        window = lowered[m.start() : m.end() + _GATE_WINDOW]
-        action = _GATE_ACTION.search(window)
+        forward = lowered[m.start() : m.end() + _GATE_WINDOW]
+        backward = lowered[max(0, m.start() - _GATE_WINDOW) : m.end()]
+        action = _GATE_ACTION.search(forward) or _GATE_ACTION.search(backward)
         if action:
             return f"{m.group(0).strip()} ... {action.group(0).strip()}"
     return None

--- a/tests/cli/commands/test_gate_reads_canonical.py
+++ b/tests/cli/commands/test_gate_reads_canonical.py
@@ -80,9 +80,18 @@ class TestDetectionWasNeverTheProblem:
         intent AND the gate action -- which is what a thorough cleaner does --
         and nothing is left to detect. Classification must therefore still read
         the canonical capture rather than the cleaned text.
+
+        "log in" (not just "log into") is gutted too: _gated() was fixed
+        2026-07-29 to search BOTH directions around an access-intent match,
+        not just forward, and the widened search reaches "please log in below
+        to access this article" once "log into" alone is removed -- a real
+        improvement (see the maryvilleforum.com case in
+        project_wire_misattribution_bug.md's sibling paywall-detector notes),
+        but it means gutting this phrase more thoroughly is what it now takes
+        to demonstrate the concept detector's genuine limit.
         """
         gutted = SEDALIA_WALL.lower()
-        for phrase in ("continue reading", "log into", "subscri", "purchase"):
+        for phrase in ("continue reading", "log into", "log in", "subscri", "purchase"):
             gutted = gutted.replace(phrase, "")
         assert looks_like_paywall(gutted) is None
 

--- a/tests/mcmetadata/test_content_form_stripping.py
+++ b/tests/mcmetadata/test_content_form_stripping.py
@@ -1,0 +1,135 @@
+"""from_html() strips <form>/<select> markup before any extractor runs.
+
+Found 2026-07-29 on real emissourian.com/missourian.com (TownNews) captures:
+a swim-meet recap's real body was two lede sentences plus a JS-required
+paywall notice (~170 chars, itself below MINIMUM_CONTENT_LENGTH), while a
+`<select id="field-postal-country-super-purchase">` from an unrelated
+subscription-checkout modal elsewhere on the page held 5,308 chars of
+concatenated country names. trafilatura's "pick the largest/densest text
+block" heuristic chose the dropdown. All four <select> elements on that page
+were subscription-form fields -- zero were legitimate content -- and the
+same widget, byte-identical, was the stored body for at least three
+different articles across two domains (clayton-wins-home-swim-dual,
+pumpkin-palooza-set-for-saturday, st-clair-man-pleads-guilty-to-kidnapping).
+"""
+
+from src.mcmetadata import content as mc_content
+from src.mcmetadata import extract
+
+
+class TestStripFormWidgets:
+    """The narrow cleaner itself."""
+
+    def test_select_options_are_removed(self):
+        html = (
+            "<html><body><p>Real article text goes here.</p>"
+            '<form><select id="country"><option>United States</option>'
+            "<option>Canada</option></select></form></body></html>"
+        )
+        cleaned = mc_content._strip_form_widgets(html)
+        assert "United States" not in cleaned
+        assert "Canada" not in cleaned
+        assert "Real article text goes here." in cleaned
+
+    def test_select_with_no_enclosing_form_is_also_removed(self):
+        """kill_tags=["select"] exists specifically for this -- forms=True
+        alone only catches a <select> inside a <form> ancestor."""
+        html = (
+            "<html><body><p>Real article text.</p>"
+            '<select id="bare"><option>Option A</option></select>'
+            "</body></html>"
+        )
+        cleaned = mc_content._strip_form_widgets(html)
+        assert "Option A" not in cleaned
+        assert "Real article text." in cleaned
+
+    def test_meta_and_script_tags_survive(self):
+        """Deliberately narrow: unlike everything_cleaner, this must not
+        touch meta/script/style/link tags other extractors depend on."""
+        html = (
+            '<html><head><meta name="author" content="Jane Smith">'
+            "<script>var x = 1;</script></head>"
+            '<body><p>Real text.</p><form><input type="text"></form>'
+            "</body></html>"
+        )
+        cleaned = mc_content._strip_form_widgets(html)
+        assert 'content="Jane Smith"' in cleaned
+        assert "var x = 1;" in cleaned
+
+    def test_html_with_no_form_or_select_is_returned_unchanged(self):
+        """The cheap short-circuit: no lxml round-trip when there's nothing
+        to strip."""
+        html = "<html><body><p>Just an ordinary article.</p></body></html>"
+        assert mc_content._strip_form_widgets(html) == html
+
+    def test_malformed_html_falls_through_safely(self):
+        """A defensive cleanup pass must never be the reason extraction
+        fails outright on a document lxml can't parse."""
+        html = "<not even <valid <html at all"
+        result = mc_content._strip_form_widgets(html)
+        assert result is not None
+
+    def test_empty_and_none_input(self):
+        assert mc_content._strip_form_widgets("") == ""
+        assert mc_content._strip_form_widgets(None) is None
+
+
+class TestFromHtmlEndToEnd:
+    """The actual bug: a subscription-form country dropdown beats a short
+    real article body under trafilatura's largest-block heuristic."""
+
+    # Trimmed, real shape of the emissourian.com capture: a genuine short
+    # lede, a JS-required paywall notice (an existing BOILERPLATE_MARKERS
+    # phrase), and a subscription-checkout country <select> holding far more
+    # raw text than the real content.
+    REAL_LEDE = (
+        "Clayton's Greyhounds turned away the challenge from the swimming "
+        "Blue Jays Tuesday. Clayton picked up a dual victory in its home "
+        "pool against Washington, 117-34."
+    )
+    PAYWALL_NOTICE = (
+        "Javascript is required for you to be able to read premium "
+        "content. Please enable it in your browser settings."
+    )
+
+    def _country_options(self, n=150):
+        return "".join(
+            f"<option>Country Name {i}, Republic of</option>" for i in range(n)
+        )
+
+    def _page(self):
+        return f"""
+        <html><head><title>Clayton wins home swim dual over Washington</title>
+        <meta name="author" content="Arron Hustead"></head>
+        <body>
+        <article>
+        <p>{self.REAL_LEDE}</p>
+        <p>{self.PAYWALL_NOTICE}</p>
+        </article>
+        <div class="subscription-modal">
+          <form>
+            <select id="field-postal-country-super-purchase">
+              {self._country_options()}
+            </select>
+          </form>
+        </div>
+        </body></html>
+        """
+
+    def test_dropdown_no_longer_wins_over_the_real_article(self):
+        """The actual mechanism was verified directly against the real
+        emissourian.com capture (raw HTML pulled from the archive), where
+        disabling _strip_form_widgets reproduces production's exact bad
+        output -- text_content becomes the 5,308-char country list. That
+        real-HTML repro isn't included here (trafilatura's density scoring on
+        a hand-built synthetic page doesn't reliably replicate its behavior
+        on real production markup, and pinning to that exact behavior would
+        make this test as fragile as the bug it guards against). This test
+        instead pins the property that must hold regardless of the
+        underlying library's internals: once the dropdown is stripped before
+        extraction, its content cannot appear in the result."""
+        html = self._page()
+        result = extract("https://www.emissourian.com/sports/x.html", html)
+        text = result.get("text_content") or ""
+        assert "Country Name" not in text
+        assert "Clayton" in text

--- a/tests/mcmetadata/test_content_form_stripping.py
+++ b/tests/mcmetadata/test_content_form_stripping.py
@@ -13,8 +13,18 @@ different articles across two domains (clayton-wins-home-swim-dual,
 pumpkin-palooza-set-for-saturday, st-clair-man-pleads-guilty-to-kidnapping).
 """
 
-from src.mcmetadata import content as mc_content
-from src.mcmetadata import extract
+import pytest
+
+# src.mcmetadata.content imports the whole extraction stack (dateparser,
+# trafilatura, newspaper, goose3, boilerpy3, readability) at module level.
+# Those live in the crawler/processor images, not in the lighter CI test venv,
+# so import them the way tests/dependency_contracts does -- skip cleanly rather
+# than erroring the whole collection with ModuleNotFoundError.
+pytest.importorskip("dateparser")
+pytest.importorskip("trafilatura")
+
+from src.mcmetadata import content as mc_content  # noqa: E402
+from src.mcmetadata import extract  # noqa: E402
 
 
 class TestStripFormWidgets:

--- a/tests/mcmetadata/test_content_form_stripping.py
+++ b/tests/mcmetadata/test_content_form_stripping.py
@@ -1,4 +1,4 @@
-"""from_html() strips <form>/<select> markup before any extractor runs.
+"""strip_form_widgets(): <form>/<select> markup can never become article body.
 
 Found 2026-07-29 on real emissourian.com/missourian.com (TownNews) captures:
 a swim-meet recap's real body was two lede sentences plus a JS-required
@@ -7,36 +7,51 @@ paywall notice (~170 chars, itself below MINIMUM_CONTENT_LENGTH), while a
 subscription-checkout modal elsewhere on the page held 5,308 chars of
 concatenated country names. trafilatura's "pick the largest/densest text
 block" heuristic chose the dropdown. All four <select> elements on that page
-were subscription-form fields -- zero were legitimate content -- and the
-same widget, byte-identical, was the stored body for at least three
-different articles across two domains (clayton-wins-home-swim-dual,
+were subscription-form fields -- zero were legitimate content -- and the same
+widget, byte-identical, was the stored body for at least three different
+articles across two domains (clayton-wins-home-swim-dual,
 pumpkin-palooza-set-for-saturday, st-clair-man-pleads-guilty-to-kidnapping).
+
+The module is loaded BY FILE PATH rather than as src.mcmetadata.form_widgets,
+and that is deliberate. src/mcmetadata/__init__.py does
+`from . import content, ...`, and content.py imports the whole extraction
+stack at module level (dateparser, trafilatura, newspaper, goose3, boilerpy3,
+readability) -- none of which is in the CI base image these jobs run in. So
+ANY normal import from the package triggers that chain: a module-level
+`from src.mcmetadata import content` here took down three CI jobs with
+ModuleNotFoundError.
+
+Guarding with importorskip was the wrong fix: it would make these tests skip
+in CI and never run in the image either, since the PR image check mounts only
+tests/dependency_contracts/ -- they would have been dead. Loading the file
+directly bypasses the package __init__, and form_widgets itself imports only
+lxml (which IS in the base image), so this file genuinely runs on every PR.
+
+The alternative -- moving the helper into src/utils/ -- was rejected because
+vendored mcmetadata code currently imports nothing from src/, and that
+boundary is worth keeping.
 """
 
-import pytest
+import importlib.util
+from pathlib import Path
 
-# src.mcmetadata.content imports the whole extraction stack (dateparser,
-# trafilatura, newspaper, goose3, boilerpy3, readability) at module level.
-# Those live in the crawler/processor images, not in the lighter CI test venv,
-# so import them the way tests/dependency_contracts does -- skip cleanly rather
-# than erroring the whole collection with ModuleNotFoundError.
-pytest.importorskip("dateparser")
-pytest.importorskip("trafilatura")
-
-from src.mcmetadata import content as mc_content  # noqa: E402
-from src.mcmetadata import extract  # noqa: E402
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "mcmetadata" / "form_widgets.py"
+)
+_spec = importlib.util.spec_from_file_location("_form_widgets_under_test", _MODULE_PATH)
+_form_widgets = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_form_widgets)
+strip_form_widgets = _form_widgets.strip_form_widgets
 
 
 class TestStripFormWidgets:
-    """The narrow cleaner itself."""
-
     def test_select_options_are_removed(self):
         html = (
             "<html><body><p>Real article text goes here.</p>"
             '<form><select id="country"><option>United States</option>'
             "<option>Canada</option></select></form></body></html>"
         )
-        cleaned = mc_content._strip_form_widgets(html)
+        cleaned = strip_form_widgets(html)
         assert "United States" not in cleaned
         assert "Canada" not in cleaned
         assert "Real article text goes here." in cleaned
@@ -49,97 +64,60 @@ class TestStripFormWidgets:
             '<select id="bare"><option>Option A</option></select>'
             "</body></html>"
         )
-        cleaned = mc_content._strip_form_widgets(html)
+        cleaned = strip_form_widgets(html)
         assert "Option A" not in cleaned
         assert "Real article text." in cleaned
 
+    def test_the_real_country_dropdown_shape_is_removed(self):
+        """The actual production case: a long option list that outweighs a
+        short real article body under a largest-block heuristic."""
+        options = "".join(
+            f"<option value='{i}'>Country Name {i}, Republic of</option>"
+            for i in range(150)
+        )
+        html = (
+            "<html><body>"
+            "<article><p>Clayton's Greyhounds turned away the challenge "
+            "from the swimming Blue Jays Tuesday.</p></article>"
+            '<div class="subscription-modal"><form>'
+            f'<select id="field-postal-country-super-purchase">{options}</select>'
+            "</form></div></body></html>"
+        )
+        cleaned = strip_form_widgets(html)
+        assert "Country Name" not in cleaned
+        assert "Clayton" in cleaned
+        # The dropdown was the overwhelming majority of the raw text; after
+        # stripping, what remains must be dominated by the real article.
+        assert len(cleaned) < len(html) / 2
+
     def test_meta_and_script_tags_survive(self):
-        """Deliberately narrow: unlike everything_cleaner, this must not
-        touch meta/script/style/link tags other extractors depend on."""
+        """Deliberately narrow: unlike content.py's everything_cleaner, this
+        must not touch meta/script/style/link tags other extractors depend on
+        (structured-data authorship, JSON-LD, canonical URLs)."""
         html = (
             '<html><head><meta name="author" content="Jane Smith">'
+            '<link rel="canonical" href="https://example.com/x">'
             "<script>var x = 1;</script></head>"
             '<body><p>Real text.</p><form><input type="text"></form>'
             "</body></html>"
         )
-        cleaned = mc_content._strip_form_widgets(html)
+        cleaned = strip_form_widgets(html)
         assert 'content="Jane Smith"' in cleaned
         assert "var x = 1;" in cleaned
+        assert "canonical" in cleaned
 
     def test_html_with_no_form_or_select_is_returned_unchanged(self):
-        """The cheap short-circuit: no lxml round-trip when there's nothing
-        to strip."""
+        """The cheap short-circuit: no lxml round-trip when there is nothing
+        to strip, which is the common case."""
         html = "<html><body><p>Just an ordinary article.</p></body></html>"
-        assert mc_content._strip_form_widgets(html) == html
+        assert strip_form_widgets(html) == html
 
     def test_malformed_html_falls_through_safely(self):
-        """A defensive cleanup pass must never be the reason extraction
-        fails outright on a document lxml can't parse."""
-        html = "<not even <valid <html at all"
-        result = mc_content._strip_form_widgets(html)
+        """A defensive cleanup pass must never be the reason extraction fails
+        outright on a document lxml cannot parse."""
+        result = strip_form_widgets("<not even <valid <html at all")
         assert result is not None
 
     def test_empty_and_none_input(self):
-        assert mc_content._strip_form_widgets("") == ""
-        assert mc_content._strip_form_widgets(None) is None
-
-
-class TestFromHtmlEndToEnd:
-    """The actual bug: a subscription-form country dropdown beats a short
-    real article body under trafilatura's largest-block heuristic."""
-
-    # Trimmed, real shape of the emissourian.com capture: a genuine short
-    # lede, a JS-required paywall notice (an existing BOILERPLATE_MARKERS
-    # phrase), and a subscription-checkout country <select> holding far more
-    # raw text than the real content.
-    REAL_LEDE = (
-        "Clayton's Greyhounds turned away the challenge from the swimming "
-        "Blue Jays Tuesday. Clayton picked up a dual victory in its home "
-        "pool against Washington, 117-34."
-    )
-    PAYWALL_NOTICE = (
-        "Javascript is required for you to be able to read premium "
-        "content. Please enable it in your browser settings."
-    )
-
-    def _country_options(self, n=150):
-        return "".join(
-            f"<option>Country Name {i}, Republic of</option>" for i in range(n)
-        )
-
-    def _page(self):
-        return f"""
-        <html><head><title>Clayton wins home swim dual over Washington</title>
-        <meta name="author" content="Arron Hustead"></head>
-        <body>
-        <article>
-        <p>{self.REAL_LEDE}</p>
-        <p>{self.PAYWALL_NOTICE}</p>
-        </article>
-        <div class="subscription-modal">
-          <form>
-            <select id="field-postal-country-super-purchase">
-              {self._country_options()}
-            </select>
-          </form>
-        </div>
-        </body></html>
-        """
-
-    def test_dropdown_no_longer_wins_over_the_real_article(self):
-        """The actual mechanism was verified directly against the real
-        emissourian.com capture (raw HTML pulled from the archive), where
-        disabling _strip_form_widgets reproduces production's exact bad
-        output -- text_content becomes the 5,308-char country list. That
-        real-HTML repro isn't included here (trafilatura's density scoring on
-        a hand-built synthetic page doesn't reliably replicate its behavior
-        on real production markup, and pinning to that exact behavior would
-        make this test as fragile as the bug it guards against). This test
-        instead pins the property that must hold regardless of the
-        underlying library's internals: once the dropdown is stripped before
-        extraction, its content cannot appear in the result."""
-        html = self._page()
-        result = extract("https://www.emissourian.com/sports/x.html", html)
-        text = result.get("text_content") or ""
-        assert "Country Name" not in text
-        assert "Clayton" in text
+        assert strip_form_widgets("") == ""
+        assert strip_form_widgets(None) is None


### PR DESCRIPTION
Two independent extraction fixes, both found by investigating real misclassified URLs from tonight's production run.

---

## 1. `_gated()` searched only forward, missing real walls

`looks_like_paywall()` returned **`None`** on a genuine maryvilleforum.com wall, so the extraction gate's `has_paywall_patterns` was False and the row was filed `not_article` with `text` emptied — **discarding a real story** (Joan Schmitz turning 95, her family, her mailing address) sitting right beside the wall in the same capture.

The cause: `_gated()` searched 120 chars **forward** from an access-intent phrase for a paired gate action. This page orders them the other way:

> "Your current **subscription** does not provide **access to this content**."

The gate word comes *before* the access phrase, so a forward-only window never sees it. Real walls order these both ways ("please log in to access this article" vs. the above), so the search has to be symmetric.

**Verified:** `looks_like_paywall` now returns `"access to this content ... purchase"` on the real capture where it returned `None`. **Zero new false positives** — 0 across 180 real stories in the 2026-07-28 CIN export, 0 across 156 real stored bodies from tonight's run.

One existing test asserted the *old* limitation (gutting `"log into"` made a wall undetectable); updated to also gut plain `"log in"`, since the wider search legitimately reaches `"please log in ... to access this article"` on that phrase alone.

---

## 2. A subscription-form country dropdown was being stored as the article body

Confirmed against real captures pulled from the raw-HTML archive: for emissourian.com's "Clayton wins home swim dual over Washington", trafilatura returned **5,308 chars of concatenated country names** (`<select id="field-postal-country-super-purchase">`) instead of the article. The same widget, byte-identical, was the stored body for **at least three articles across two domains**.

Not a broken fetch — title, author and publish_date all extracted correctly. The real body was only ~170 chars (two lede sentences plus a JS-required paywall notice). trafilatura's "pick the largest/densest text block" heuristic has no way to know a 5KB option list isn't prose, so the dropdown won. All four `<select>` elements on that page were subscription-form fields; none were content.

**Fix:** strip `<form>`/`<select>` markup once in `from_html()`, before any extractor in the cascade runs. Dropdown option lists are never article prose on a legitimate page, so this removes a whole class of mis-selection rather than special-casing one CMS.

**Deliberately narrow** — only forms/selects are removed; meta/script/style/link tags are untouched so structured-data authorship, JSON-LD and canonical-URL extraction are unaffected. This is *not* `everything_cleaner`, which stays wired only to the readability path. `kill_tags=["select"]` catches a `<select>` with no enclosing `<form>`. A substring short-circuit skips the lxml round-trip when there's nothing to strip, and a parse failure returns the input unchanged.

**Verified against real production HTML, not fixtures:**

| check | result |
|---|---|
| the bug | fixed (country list gone, "Clayton" present) |
| 5 healthy captures, 5 publishers (33KB→7KB of text) | **byte-identical** before/after |
| tests | 65 pass across dependency_contracts, mcmetadata, proxy-routing |

---

## Scope kept honest — known adjacent issues NOT fixed here

- The same capture also shows **recirculation-headline bleed** (unrelated story teasers mixed into the body — same defect seen on stltoday.com) and **duplicated lede sentences**. Separate content-region problems.
- `excise_furniture_lines` still leaves the imperative wall lines ("Please log in, or sign up...") on a per-line basis, since those lines alone pair no access-intent phrase with their gate words. Whole-body classification is what drives the status decision, so the misfile is resolved; cleaner per-line removal is a follow-up.
- **A better fix exists for #2 and is recorded as a design, not built:** our own heuristics can *rank* the cascade's candidates instead of taking the first that clears 200 chars. On this exact page, boilerpipe3 had the **entire real article** all along (1,655 chars decoded) — trafilatura only won by running first. ROT47 marker presence turns out to be a strong *positive* body-text signal, but it must be scored **before** shape is allowed to veto: `looks_like_furniture` returns True for the *correct* candidate pre-decode (caps 0.79), so shape alone would reject the right answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)