### PR TITLE
fix(discovery): fail over to the second Squid when an IP is blocked; add VTCNI dataset

### DIFF
--- a/scripts/load_vtcni_sources.py
+++ b/scripts/load_vtcni_sources.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Load the VT Community News (VTCNI) sources CSV into datasets/sources/dataset_sources.
+
+Same shape and the same reasoning as ``load_washington_sources.py`` -- raw SQL
+rather than the ORM, and no candidate-link enqueue, because the CSV carries
+homepages and discovery is what finds the stories.
+
+Two things are specific to this dataset:
+
+``name`` is provisional for most rows. The list arrived as bare URLs with no
+publication names, so ``name_source`` records where each name came from:
+``og:site_name``/``application-name``/``twitter:site``/``title-segment``/
+``logo-alt`` mean a real masthead was read off the page, while
+``domain-fallback`` means nobody has confirmed it and the value is just the
+domain title-cased ("Fordhamobserver"). Those are placeholders to be corrected
+from what discovery captures, not names to publish. The column is carried into
+source metadata so a later pass can find them without re-deriving.
+
+Re-running is the supported way to fix them: rows match on ``sources.host_norm``,
+so correcting names in the CSV and re-running updates this dataset in place.
+
+**A source already owned by another dataset is linked, never rewritten.** Five
+of these hosts are also Missouri sources with hand-curated names, cities,
+counties and owners (``themaneater.com`` -> "The Maneater", Columbia, Boone).
+This CSV carries no geography at all and a provisional name for most rows, so
+letting it UPDATE those rows -- which is what the Washington loader this was
+copied from does -- would replace "The Maneater" with "Themaneater" and blank
+the rest. It has nothing to contribute to a curated row, so it does not try;
+it only adds the dataset link. Even for rows this dataset does own, empty CSV
+values are never written over existing ones, and a confirmed name is never
+replaced by a provisional one.
+
+Two entries were removed from the raw list before it became this CSV:
+``medium.com`` and ``youtube.com``, which are platform roots rather than
+publications -- loading them as sources would aim discovery at those entire
+sites. The 26 remaining platform-hosted rows (``*.wordpress.com``,
+``*.weebly.com``, ``*.wixsite.com``) are real student newsrooms and are kept.
+
+The CSV itself is not in git -- ``.gitignore`` excludes ``*.csv`` with a short
+allowlist, and the Washington sources CSV is untracked for the same reason. It
+lives at ``sources/vtcni_sources.csv``, built from the VTCNI "productive sites"
+URL list (bare URLs, no names) plus the name-detection described above.
+
+Run inside a pod per the repo's DB access protocol::
+
+    kubectl cp scripts/load_vtcni_sources.py production/<cli-pod>:/app/load_vtcni_sources.py
+    kubectl cp sources/vtcni_sources.csv production/<cli-pod>:/app/vtcni_sources.csv
+    kubectl exec -n production <cli-pod> -- python /app/load_vtcni_sources.py \
+        --csv /app/vtcni_sources.csv [--commit]
+
+Then discovery runs against it through the normal production path::
+
+    python -m src.cli discover-urls --dataset "VT Community News" --force-all
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from src.models.database import DatabaseManager  # noqa: E402
+
+# `--dataset` on discover-urls matches datasets.label, not the slug.
+DATASET_SLUG = "VT-Community-News"
+DATASET_LABEL = "VT Community News"
+DATASET_NAME = "VT Community News Initiative Sources"
+DATASET_DESCRIPTION = (
+    "Student-produced and university-affiliated community news outlets tracked "
+    "by the VT Community News Initiative: the 'productive' site list, i.e. "
+    "outlets observed to be publishing."
+)
+
+# Anything else in this column means a masthead was read off the live page.
+PLACEHOLDER_NAME_SOURCE = "domain-fallback"
+
+
+def _source_fields(row: dict, host: str, host_norm: str) -> dict:
+    """Map a CSV row onto the sources columns.
+
+    ``name_source`` and ``name_is_provisional`` ride along in metadata so the
+    follow-up pass can select exactly the rows whose names still need
+    confirming, without re-deriving which ones those were.
+    """
+    name_source = row.get("name_source", "") or ""
+    return {
+        "host": host,
+        "host_norm": host_norm,
+        "canonical_name": row["name"],
+        "city": row.get("city", ""),
+        "county": row.get("county", ""),
+        "owner": row.get("owner", ""),
+        "type": row.get("media_type", "unknown"),
+        "metadata": json.dumps(
+            {
+                "address1": row.get("address1", ""),
+                "address2": row.get("address2", ""),
+                "state": row.get("State", ""),
+                "zip": str(row.get("zip", "") or ""),
+                "frequency": row.get("frequency", ""),
+                "media_type": row.get("media_type", ""),
+                "cohort": row.get("cohort", ""),
+                "source": row.get("source", ""),
+                "name_source": name_source,
+                "name_is_provisional": name_source == PLACEHOLDER_NAME_SOURCE,
+            }
+        ),
+    }
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, help="Path to the sources CSV")
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually write. Without this the script reports what it would do.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    with open(args.csv, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    if not rows:
+        print("ERROR: CSV is empty", file=sys.stderr)
+        return 1
+
+    provisional = sum(
+        1 for r in rows if r.get("name_source") == PLACEHOLDER_NAME_SOURCE
+    )
+    print(f"{len(rows)} rows; {provisional} carry a provisional (domain-derived) name")
+
+    db = DatabaseManager()
+    created_sources = 0
+    linked_sources = 0
+    existing_sources = 0
+    skipped_updates = 0
+
+    with db.get_session() as session:
+        dataset_id = session.execute(
+            text("SELECT id FROM datasets WHERE slug = :slug"),
+            {"slug": DATASET_SLUG},
+        ).scalar_one_or_none()
+
+        if dataset_id:
+            print(f"Dataset {DATASET_SLUG} already exists ({dataset_id})")
+        else:
+            dataset_id = str(uuid.uuid4())
+            print(f"CREATE dataset {DATASET_SLUG} ({dataset_id})")
+            if args.commit:
+                session.execute(
+                    # ingested_at is NOT NULL in production and has no server
+                    # default there, despite what the ORM model implies.
+                    text("""
+                        INSERT INTO datasets
+                            (id, slug, label, name, description, ingested_at,
+                             ingested_by, metadata, is_public, cron_enabled)
+                        VALUES
+                            (:id, :slug, :label, :name, :description, NOW(),
+                             :ingested_by, CAST(:metadata AS JSON), :is_public,
+                             :cron_enabled)
+                        """),
+                    {
+                        "id": dataset_id,
+                        "slug": DATASET_SLUG,
+                        "label": DATASET_LABEL,
+                        "name": DATASET_NAME,
+                        "description": DATASET_DESCRIPTION,
+                        "ingested_by": "load_vtcni_sources",
+                        "metadata": json.dumps(
+                            {
+                                "source_file": args.csv,
+                                "total_rows": len(rows),
+                                "provisional_names": provisional,
+                            }
+                        ),
+                        "is_public": False,
+                        "cron_enabled": False,
+                    },
+                )
+
+        for row in rows:
+            host = row["url_news"].split("//", 1)[1].strip("/")
+            host_norm = host.lower()
+
+            fields = _source_fields(row, host, host_norm)
+
+            existing = session.execute(
+                text("""
+                    SELECT s.id,
+                           s.canonical_name,
+                           EXISTS (
+                               SELECT 1 FROM dataset_sources ds
+                               WHERE ds.source_id = s.id
+                                 AND ds.dataset_id <> :dataset_id
+                           ) AS owned_elsewhere
+                    FROM sources s
+                    WHERE s.host_norm = :h
+                    """),
+                {"h": host_norm, "dataset_id": dataset_id},
+            ).one_or_none()
+
+            source_id = existing[0] if existing else None
+            provisional_row = row.get("name_source") == PLACEHOLDER_NAME_SOURCE
+            flag = "?" if provisional_row else " "
+
+            if source_id:
+                existing_sources += 1
+                current_name, owned_elsewhere = existing[1], existing[2]
+
+                if owned_elsewhere:
+                    # Another dataset curated this row. Link it in; touch nothing.
+                    skipped_updates += 1
+                    print(
+                        f"  LINK   {flag} {host_norm:<38} "
+                        f"keeping {current_name!r} (owned by another dataset)"
+                    )
+                elif provisional_row and current_name:
+                    skipped_updates += 1
+                    print(
+                        f"  LINK   {flag} {host_norm:<38} "
+                        f"keeping {current_name!r} (ours is provisional)"
+                    )
+                else:
+                    print(f"  UPDATE {flag} {host_norm:<38} {row['name']}")
+                    if args.commit:
+                        # COALESCE(NULLIF(...)) so a blank CSV cell leaves the
+                        # stored value alone rather than erasing it.
+                        session.execute(
+                            text("""
+                                UPDATE sources
+                                SET canonical_name = :canonical_name,
+                                    city = COALESCE(NULLIF(:city, ''), city),
+                                    county = COALESCE(NULLIF(:county, ''), county),
+                                    owner = COALESCE(NULLIF(:owner, ''), owner),
+                                    type = COALESCE(NULLIF(:type, ''), type),
+                                    metadata = CAST(:metadata AS JSON)
+                                WHERE id = :id
+                                """),
+                            {**fields, "id": source_id},
+                        )
+            else:
+                source_id = str(uuid.uuid4())
+                created_sources += 1
+                print(f"  CREATE {flag} {host_norm:<38} {row['name']}")
+                if args.commit:
+                    session.execute(
+                        text("""
+                            INSERT INTO sources
+                                (id, host, host_norm, canonical_name, city, county,
+                                 owner, type, metadata, status)
+                            VALUES
+                                (:id, :host, :host_norm, :canonical_name, :city,
+                                 :county, :owner, :type, CAST(:metadata AS JSON),
+                                 :status)
+                            """),
+                        {**fields, "id": source_id, "status": "active"},
+                    )
+
+            if not args.commit:
+                continue
+
+            mapped = session.execute(
+                text("""
+                    SELECT 1 FROM dataset_sources
+                    WHERE dataset_id = :d AND source_id = :s
+                    """),
+                {"d": dataset_id, "s": source_id},
+            ).scalar_one_or_none()
+            if not mapped:
+                linked_sources += 1
+                session.execute(
+                    text("""
+                        INSERT INTO dataset_sources
+                            (id, dataset_id, source_id, legacy_host_id, legacy_meta)
+                        VALUES
+                            (:id, :d, :s, :hid, CAST(:meta AS JSON))
+                        """),
+                    {
+                        "id": str(uuid.uuid4()),
+                        "d": dataset_id,
+                        "s": source_id,
+                        "hid": str(row["host_id"]),
+                        "meta": json.dumps({"original_csv_row": row}),
+                    },
+                )
+
+        if args.commit:
+            session.commit()
+
+    verb = "Wrote" if args.commit else "DRY RUN (pass --commit to write):"
+    # Report rows actually rewritten, not rows that merely already existed --
+    # the two differ by every row this script deliberately left alone.
+    print(
+        f"\n{verb} sources created={created_sources} "
+        f"updated={existing_sources - skipped_updates} "
+        f"left-alone={skipped_updates} linked={linked_sources}"
+    )
+    print(
+        f"'?' marks a provisional name ({provisional} rows) to fix after discovery; "
+        f"{skipped_updates} existing sources were linked without being rewritten"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/commands/analysis.py
+++ b/src/cli/commands/analysis.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from sqlalchemy import select
 
 from src.ml.article_classifier import ArticleClassifier
-from src.models import Article, ArticleLabel
+from src.models import Article, ArticleLabel, CandidateLink
 from src.models.database import DatabaseManager, safe_session_execute
 from src.services.classification_service import ArticleClassificationService
 
@@ -67,6 +67,7 @@ def _snapshot_labels(
     session,
     label_version: str,
     statuses: Sequence[str] | None,
+    dataset_id: str | None = None,
 ) -> dict[str, dict[str, str | None]]:
     stmt = select(
         Article.id,
@@ -78,6 +79,19 @@ def _snapshot_labels(
         (ArticleLabel.article_id == Article.id)
         & (ArticleLabel.label_version == label_version),
     )
+
+    # Scoped to the same dataset the run classifies, or the diff compares a
+    # one-dataset run against a corpus-wide snapshot. The dataset lives on the
+    # candidate link, not the article -- see _select_articles.
+    if dataset_id:
+        stmt = stmt.where(
+            select(CandidateLink.id)
+            .where(
+                CandidateLink.id == Article.candidate_link_id,
+                CandidateLink.dataset_id == dataset_id,
+            )
+            .exists()
+        )
 
     if statuses is None:
         stmt = stmt.where(Article.status.notin_(list(EXCLUDED_STATUSES)))
@@ -274,6 +288,13 @@ def add_analysis_parser(subparsers) -> None:
         ),
     )
     parser.add_argument(
+        "--dataset-id",
+        help=(
+            "Classify only articles belonging to this dataset id. Omit to "
+            "classify across every dataset."
+        ),
+    )
+    parser.add_argument(
         "--report-path",
         help=(
             "Optional CSV path for label-change report. If omitted, a "
@@ -300,6 +321,7 @@ def handle_analysis_command(args) -> int:
         args.model_path or os.getenv("MODEL_PATH") or "models"
     ).expanduser()
     collect_diff = bool(args.report_path)
+    dataset_id = (getattr(args, "dataset_id", None) or "").strip() or None
 
     try:
         classifier = ArticleClassifier(model_path=model_path)
@@ -317,6 +339,7 @@ def handle_analysis_command(args) -> int:
                 db.session,
                 label_version,
                 filtered_statuses,
+                dataset_id,
             )
 
         stats = service.apply_classification(
@@ -330,6 +353,7 @@ def handle_analysis_command(args) -> int:
             top_k=top_k,
             dry_run=args.dry_run,
             include_existing=args.force,
+            dataset_id=dataset_id,
         )
 
         print("\n=== Classification Summary ===")
@@ -360,6 +384,7 @@ def handle_analysis_command(args) -> int:
                     db.session,
                     label_version,
                     filtered_statuses,
+                    dataset_id,
                 )
                 changes = _compute_label_changes(
                     before_snapshot,

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -81,6 +81,7 @@ from src.utils.url_utils import normalize_url
 
 from ..models.database import DatabaseManager, safe_execute, safe_session_execute
 from .proxy_config import get_proxy_manager
+from .proxy_router import RouterProxy
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,22 @@ RSS_MISSING_THRESHOLD = 3
 # RSS_TRANSIENT_THRESHOLD failures occur within RSS_TRANSIENT_WINDOW_DAYS, mark missing.
 RSS_TRANSIENT_THRESHOLD = 5
 RSS_TRANSIENT_WINDOW_DAYS = 7
+
+# Statuses that mean "this egress is not welcome here", as opposed to "this
+# page is not here". A 403 from Cloudflare (error 1006 is literally "the owner
+# of this website has banned your IP address") or a 406 from mod_security is a
+# property of the address the request came from: the identical request from
+# the other Squid usually returns 200. Those are worth reporting to the proxy
+# router as a failure and retrying elsewhere.
+#
+# Deliberately excluded:
+#   404/410 -- the page is gone from every address; retrying is pure waste.
+#   503     -- normally an origin under strain. Retrying through a second
+#              proxy would add load to a server already failing, and it is
+#              not an address-level judgement.
+#   407     -- OUR proxy rejected OUR credentials. Switching proxies would
+#              mask a misconfiguration that should be loud.
+BLOCKED_STATUS_CODES = frozenset({403, 406, 429, 451})
 
 
 class RawFeedEntry(TypedDict, total=False):
@@ -502,9 +519,15 @@ class NewsDiscovery:
         # Try primary session first (cloudscraper or requests)
         try:
             response = self.session.get(url, timeout=timeout, proxies=router_proxies)
-            self._report_router_result(domain, router_proxy, success=True)
-            self._note_capture_diagnosis(url, getattr(response, "text", None))
-            return response
+            return self._settle_response(
+                url,
+                domain,
+                router_proxy,
+                router_proxies,
+                response,
+                timeout,
+                self.session,
+            )
         except requests.exceptions.SSLError as e:
             logger.warning(
                 "SSL error with primary session for %s, trying fallback: %s",
@@ -525,14 +548,122 @@ class NewsDiscovery:
             response = self._fallback_session.get(
                 url, timeout=timeout, proxies=router_proxies
             )
-            self._report_router_result(domain, router_proxy, success=True)
-            self._note_capture_diagnosis(url, getattr(response, "text", None))
-            return response
+            return self._settle_response(
+                url,
+                domain,
+                router_proxy,
+                router_proxies,
+                response,
+                timeout,
+                self._fallback_session,
+            )
         except requests.exceptions.RequestException as e:
             self._report_router_result(
                 domain, router_proxy, success=False, reason=str(e)[:200]
             )
             raise
+
+    def _settle_response(
+        self,
+        url: str,
+        domain: str,
+        router_proxy,
+        router_proxies: dict | None,
+        response: requests.Response,
+        timeout: int,
+        session,
+    ) -> requests.Response:
+        """Report the attempt to the router, retrying elsewhere if IP-blocked.
+
+        This used to be one unconditional ``success=True``. `requests` does not
+        raise on 4xx, so a Cloudflare 403 -- "the owner of this website has
+        banned your IP address" -- was reported to the router as a SUCCESS and
+        handed back as a normal response. Three things followed: the router
+        never backed the proxy off for that domain, so it never failed over;
+        its health data recorded the blocked proxy as healthy for exactly the
+        domains where it was banned; and discovery reported "no articles" for
+        sites that were merely being refused at one address.
+
+        Measured on 20 VTCNI sources that discovery had found nothing for:
+        re-running them through the second Squid alone produced 535 candidate
+        URLs from 11 of them. Nothing about those sites had changed.
+        """
+        if response.status_code not in BLOCKED_STATUS_CODES:
+            self._report_router_result(domain, router_proxy, success=True)
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        reason = f"HTTP {response.status_code}"
+        logger.warning(
+            "%s blocked at %s via %s -- treating as a proxy failure, not a fetch",
+            reason,
+            url,
+            getattr(router_proxy, "value", router_proxy),
+        )
+        self._report_router_result(domain, router_proxy, success=False, reason=reason)
+
+        alt_proxies, alt_proxy = self._alternate_proxies_for_domain(
+            router_proxy, router_proxies
+        )
+        if alt_proxies is None:
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        logger.info(
+            "Retrying %s via %s after %s",
+            url,
+            getattr(alt_proxy, "value", alt_proxy),
+            reason,
+        )
+        try:
+            retry = session.get(url, timeout=timeout, proxies=alt_proxies)
+        except requests.exceptions.RequestException as exc:
+            # The alternate failed too. Keep the original response rather than
+            # raising: the caller asked for a fetch, and one bad proxy should
+            # not turn a 403 into an exception it never had to handle before.
+            self._report_router_result(
+                domain, alt_proxy, success=False, reason=str(exc)[:200]
+            )
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        blocked_again = retry.status_code in BLOCKED_STATUS_CODES
+        self._report_router_result(
+            domain,
+            alt_proxy,
+            success=not blocked_again,
+            reason=f"HTTP {retry.status_code}" if blocked_again else None,
+        )
+        if blocked_again:
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        self._note_capture_diagnosis(url, getattr(retry, "text", None))
+        return retry
+
+    def _alternate_proxies_for_domain(self, current, current_proxies: dict | None):
+        """The other configured proxy, or (None, None) if there isn't one.
+
+        Compares the resolved proxy URLs rather than the RouterProxy names.
+        get_requests_proxies_for_domain() maps an unconfigured MIZZOU_SQUID
+        back onto home Squid, so two different names can resolve to one box --
+        retrying there would just re-ask the address that was already refused.
+        """
+        proxy_manager = getattr(self, "proxy_manager", None)
+        if proxy_manager is None or current is None:
+            return None, None
+
+        resolve = getattr(proxy_manager, "get_requests_proxies_for_router_proxy", None)
+        if resolve is None:  # older manager / test double
+            return None, None
+
+        for candidate in RouterProxy:
+            if candidate is current:
+                continue
+            proxies = resolve(candidate)
+            if proxies and proxies != current_proxies:
+                return proxies, candidate
+        return None, None
 
     def _note_capture_diagnosis(self, url: str, html: str | None) -> None:
         """Record WHY a capture might yield nothing, for this source.

--- a/src/crawler/proxy_config.py
+++ b/src/crawler/proxy_config.py
@@ -391,6 +391,31 @@ class ProxyManager:
 
         return _build_proxies_dict(provider), router_proxy, choice.method
 
+    def get_requests_proxies_for_router_proxy(
+        self, router_proxy: RouterProxy
+    ) -> Optional[dict]:
+        """Return the proxies dict for one specific proxy, or None.
+
+        Unlike get_requests_proxies_for_domain(), this asks for a *named*
+        proxy rather than letting the router choose -- callers use it to reach
+        the other Squid after the routed one turned out to be blocked for a
+        domain.
+
+        Returns None rather than falling back to home Squid when the requested
+        proxy isn't configured. The fallback is right for "just get me a
+        proxy" and wrong here: a caller retrying a blocked request needs to
+        know it would be retrying through the same box, so it can skip the
+        pointless second attempt.
+        """
+        provider_by_proxy = {
+            RouterProxy.HOME_SQUID: ProxyProvider.SQUID,
+            RouterProxy.MIZZOU_SQUID: ProxyProvider.MIZZOU_SQUID,
+        }
+        provider = self.configs.get(provider_by_proxy.get(router_proxy))
+        if provider is None or not provider.enabled:
+            return None
+        return _build_proxies_dict(provider)
+
     def report_domain_result(
         self,
         domain: str,

--- a/src/services/classification_service.py
+++ b/src/services/classification_service.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.ml.article_classifier import Prediction
-from src.models import Article, ArticleLabel
+from src.models import Article, ArticleLabel, CandidateLink
 from src.models.database import save_article_classification
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,7 @@ class ArticleClassificationService:
         include_existing: bool,
         excluded_statuses: Sequence[str] | None = None,
         excluded_article_ids: Sequence[str] | None = None,
+        dataset_id: str | None = None,
     ) -> list[Article]:
         stmt = select(Article)
 
@@ -66,6 +67,20 @@ class ArticleClassificationService:
 
         if excluded_statuses:
             stmt = stmt.where(Article.status.notin_(list(excluded_statuses)))
+
+        # Articles carry no dataset of their own; the dataset is a property of
+        # the candidate link they were discovered through. EXISTS rather than a
+        # join so the FOR UPDATE SKIP LOCKED below keeps locking articles only.
+        if dataset_id:
+            in_dataset = (
+                select(CandidateLink.id)
+                .where(
+                    CandidateLink.id == Article.candidate_link_id,
+                    CandidateLink.dataset_id == dataset_id,
+                )
+                .exists()
+            )
+            stmt = stmt.where(in_dataset)
 
         if not include_existing:
             label_exists = (
@@ -148,6 +163,7 @@ class ArticleClassificationService:
         top_k: int = 2,
         dry_run: bool = False,
         include_existing: bool = False,
+        dataset_id: str | None = None,
     ) -> ClassificationStats:
         """Classify eligible articles and persist results.
 
@@ -210,6 +226,7 @@ class ArticleClassificationService:
                 include_existing,
                 list(excluded_statuses),
                 excluded_ids,
+                dataset_id,
             )
 
             if not articles:

--- a/tests/cli/commands/test_analysis.py
+++ b/tests/cli/commands/test_analysis.py
@@ -77,6 +77,7 @@ def _default_args(**overrides) -> Namespace:
         top_k=2,
         dry_run=False,
         force=False,
+        dataset_id=None,
         report_path=None,
     )
     defaults.update(overrides)
@@ -144,7 +145,7 @@ def test_handle_analysis_dry_run_generates_report(
     }
     snapshot_calls: list[tuple[Any, ...]] = []
 
-    def fake_snapshot(session, label_version, statuses):
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
         snapshot_calls.append((session, label_version, statuses))
         return before_snapshot
 
@@ -202,7 +203,7 @@ def test_handle_analysis_persisted_report_generates_csv(
     snapshots = [before_snapshot, after_snapshot]
     snapshot_calls: list[tuple[Any, str, list[str] | None]] = []
 
-    def fake_snapshot(session, label_version, statuses):
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
         snapshot_calls.append((session, label_version, statuses))
         return snapshots[len(snapshot_calls) - 1]
 
@@ -500,7 +501,7 @@ def test_handle_analysis_no_label_changes_reports_skip(
     }
     snapshots = [snapshot, snapshot]
 
-    def fake_snapshot(session, label_version, statuses):
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
         return snapshots.pop(0)
 
     monkeypatch.setattr(analysis, "_snapshot_labels", fake_snapshot)
@@ -523,3 +524,56 @@ def test_handle_analysis_no_label_changes_reports_skip(
     assert exit_code == 0
     stdout = capsys.readouterr().out
     assert "No label changes detected" in stdout
+
+
+def test_dataset_id_reaches_the_service(db_stub, classifier_invocations, service_stub):
+    """--dataset-id must be forwarded, not merely accepted.
+
+    The first cut of this feature added the filter to the service and never
+    passed anything to it, so the flag parsed cleanly and classified the whole
+    corpus anyway.
+    """
+    args = _default_args(dataset_id="vtcni")
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert service_stub.calls.pop()["dataset_id"] == "vtcni"
+
+
+def test_omitted_dataset_id_stays_corpus_wide(
+    db_stub, classifier_invocations, service_stub
+):
+    args = _default_args()
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert service_stub.calls.pop()["dataset_id"] is None
+
+
+def test_blank_dataset_id_is_treated_as_omitted(
+    db_stub, classifier_invocations, service_stub
+):
+    """An empty --dataset-id must not narrow the run to zero articles."""
+    args = _default_args(dataset_id="   ")
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert service_stub.calls.pop()["dataset_id"] is None
+
+
+def test_snapshot_is_scoped_to_the_same_dataset(
+    db_stub, classifier_invocations, service_stub, monkeypatch, tmp_path
+):
+    """Otherwise the diff compares one dataset's run against the whole corpus."""
+    snapshot_calls: list[tuple] = []
+
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
+        snapshot_calls.append(dataset_id)
+        return {}
+
+    monkeypatch.setattr(analysis, "_snapshot_labels", fake_snapshot)
+
+    args = _default_args(
+        dataset_id="vtcni",
+        report_path=str(tmp_path / "changes.csv"),
+    )
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert snapshot_calls == ["vtcni", "vtcni"]

--- a/tests/crawler/test_blocked_status_fails_over.py
+++ b/tests/crawler/test_blocked_status_fails_over.py
@@ -1,0 +1,200 @@
+"""A 403 is a failure of the proxy, not a successful fetch.
+
+`requests` does not raise on 4xx, so `session.get()` returning a Cloudflare 403
+looked exactly like a 200 to the old code, which reported `success=True` to the
+proxy router unconditionally. The router therefore never backed the proxy off
+for that domain, never failed over to the second Squid, and recorded the banned
+address as healthy for precisely the domains where it was banned. Discovery
+reported "no articles found" for sites that were only being refused at one IP.
+
+Measured on 20 VTCNI sources that discovery had found nothing for: re-running
+them through the other Squid alone produced 535 candidate URLs from 11 of them.
+
+These tests assert on what the ROUTER IS TOLD, not just on the response handed
+back. Reporting the wrong thing to the router is the entire bug, and it is
+invisible from the return value -- which is why it survived in production.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import requests
+
+from src.crawler.discovery import BLOCKED_STATUS_CODES, NewsDiscovery
+from src.crawler.proxy_router import RouterProxy
+
+HOME = {"http": "http://home:3128", "https": "http://home:3128"}
+MIZZOU = {"http": "http://mizzou:3128", "https": "http://mizzou:3128"}
+
+
+class _Response:
+    def __init__(self, status_code: int, text: str = "<html></html>"):
+        self.status_code = status_code
+        self.text = text
+
+
+class _Session:
+    """Returns a queued response per call, recording the proxies used."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[dict | None] = []
+
+    def get(self, url, timeout=None, proxies=None):
+        self.calls.append(proxies)
+        result = self._responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class _ProxyManager:
+    def __init__(self, resolvable=None):
+        # RouterProxy -> proxies dict
+        self._resolvable = resolvable or {
+            RouterProxy.HOME_SQUID: HOME,
+            RouterProxy.MIZZOU_SQUID: MIZZOU,
+        }
+
+    def get_requests_proxies_for_router_proxy(self, router_proxy):
+        return self._resolvable.get(router_proxy)
+
+
+def _discovery(session, *, routed=RouterProxy.HOME_SQUID, manager=None):
+    """A NewsDiscovery with the network and router stubbed, no __init__."""
+    d = NewsDiscovery.__new__(NewsDiscovery)
+    d.session = session
+    d._fallback_session = session
+    d.timeout = 5
+    d.proxy_manager = manager or _ProxyManager()
+    d.reported: list[tuple] = []
+
+    d._router_proxies_for_domain = lambda domain: (HOME, routed)
+    d._report_router_result = lambda domain, proxy, success, reason=None: (
+        d.reported.append((proxy, success, reason))
+    )
+    d._note_capture_diagnosis = lambda url, html: None
+    return d
+
+
+class TestBlockedStatusIsReportedAsFailure:
+    @pytest.mark.parametrize("status", sorted(BLOCKED_STATUS_CODES))
+    def test_router_is_told_the_proxy_failed(self, status):
+        session = _Session([_Response(status), _Response(200)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        first_proxy, first_success, reason = d.reported[0]
+        assert first_proxy is RouterProxy.HOME_SQUID
+        assert first_success is False
+        assert str(status) in reason
+
+    def test_a_200_still_reports_success(self):
+        session = _Session([_Response(200)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert d.reported == [(RouterProxy.HOME_SQUID, True, None)]
+
+    def test_404_is_not_treated_as_a_block(self):
+        """The page is gone from every address -- retrying is pure waste."""
+        session = _Session([_Response(404)])
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 404
+        assert d.reported == [(RouterProxy.HOME_SQUID, True, None)]
+        assert len(session.calls) == 1
+
+    def test_503_is_not_treated_as_a_block(self):
+        """An origin under strain should not get a second proxy's load too."""
+        session = _Session([_Response(503)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert len(session.calls) == 1
+
+
+class TestRetryOnTheAlternateProxy:
+    def test_blocked_request_is_retried_through_the_other_squid(self):
+        session = _Session([_Response(403), _Response(200, "<html>real</html>")])
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert [c for c in session.calls] == [HOME, MIZZOU]
+        assert response.status_code == 200
+        assert response.text == "<html>real</html>"
+
+    def test_successful_retry_is_reported_against_the_proxy_that_worked(self):
+        session = _Session([_Response(403), _Response(200)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert d.reported == [
+            (RouterProxy.HOME_SQUID, False, "HTTP 403"),
+            (RouterProxy.MIZZOU_SQUID, True, None),
+        ]
+
+    def test_both_blocked_reports_both_and_returns_the_original(self):
+        session = _Session([_Response(403), _Response(403)])
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 403
+        assert [r[1] for r in d.reported] == [False, False]
+
+    def test_alternate_transport_failure_does_not_raise(self):
+        """The caller asked for a fetch; a bad second proxy must not turn a
+        403 into an exception the old code never raised."""
+        session = _Session(
+            [_Response(403), requests.exceptions.ConnectionError("refused")]
+        )
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 403
+        assert d.reported[-1] == (RouterProxy.MIZZOU_SQUID, False, "refused")
+
+
+class TestNoPointlessRetry:
+    def test_no_retry_when_the_alternate_resolves_to_the_same_box(self):
+        """MIZZOU_SQUID falls back onto home Squid when unconfigured, so the
+        two names can resolve to one address -- retrying there would just
+        re-ask the IP that was already refused."""
+        manager = _ProxyManager({RouterProxy.MIZZOU_SQUID: HOME})
+        session = _Session([_Response(403)])
+        d = _discovery(session, manager=manager)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert len(session.calls) == 1
+        assert d.reported == [(RouterProxy.HOME_SQUID, False, "HTTP 403")]
+
+    def test_no_retry_when_no_alternate_is_configured(self):
+        manager = _ProxyManager({RouterProxy.HOME_SQUID: HOME})
+        session = _Session([_Response(403)])
+        d = _discovery(session, manager=manager)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert len(session.calls) == 1
+
+    def test_manager_without_the_resolver_degrades_quietly(self):
+        """Test doubles built via __new__ may predate the resolver."""
+        session = _Session([_Response(403)])
+        d = _discovery(session, manager=types.SimpleNamespace())
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 403
+        assert len(session.calls) == 1

--- a/tests/services/test_classification_dataset_scope.py
+++ b/tests/services/test_classification_dataset_scope.py
@@ -1,0 +1,105 @@
+"""Classification can be scoped to a single dataset.
+
+Added for the VTCNI load: a new dataset arrives with thousands of unlabelled
+articles, and we want to classify only those without re-walking every other
+dataset's backlog in the same run.
+
+The tests select against a real session rather than asserting on a compiled
+statement, because the failure mode this guards is a flag that is accepted and
+then silently ignored -- which a shape check on the SQL would not catch. The
+first draft of this filter read `Article.dataset_id`, a column that does not
+exist: articles carry no dataset, the candidate link they were discovered
+through does.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.models import Article, Base, CandidateLink
+from src.services.classification_service import ArticleClassificationService
+
+DATASET_A = "vtcni"
+DATASET_B = "mizzou-missouri"
+
+
+@pytest.fixture()
+def session() -> Generator[Session, None, None]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    try:
+        with SessionLocal() as db:
+            yield db
+            db.rollback()
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def _add_article(session: Session, article_id: str, dataset_id: str | None) -> None:
+    link_id = f"link-{article_id}"
+    session.add(
+        CandidateLink(
+            id=link_id,
+            url=f"https://example.com/{article_id}",
+            source="example.com",
+            dataset_id=dataset_id,
+        )
+    )
+    session.add(
+        Article(
+            id=article_id,
+            candidate_link_id=link_id,
+            url=f"https://example.com/{article_id}",
+            title="Commission approves measure",
+            text="The county commission voted 4-1 on Tuesday.",
+            status="cleaned",
+            created_at=datetime(2026, 8, 11),
+        )
+    )
+    session.commit()
+
+
+def _select(session: Session, dataset_id: str | None) -> list[str]:
+    service = ArticleClassificationService(session=session)
+    articles = service._select_articles(
+        ["cleaned"],
+        "default",
+        None,
+        False,
+        None,
+        None,
+        dataset_id,
+    )
+    return sorted(str(article.id) for article in articles)
+
+
+def test_dataset_id_restricts_selection_to_that_dataset(session: Session) -> None:
+    _add_article(session, "a1", DATASET_A)
+    _add_article(session, "b1", DATASET_B)
+
+    assert _select(session, DATASET_A) == ["a1"]
+    assert _select(session, DATASET_B) == ["b1"]
+
+
+def test_no_dataset_id_selects_across_every_dataset(session: Session) -> None:
+    """The default stays corpus-wide -- existing scheduled runs must not narrow."""
+    _add_article(session, "a1", DATASET_A)
+    _add_article(session, "b1", DATASET_B)
+    _add_article(session, "n1", None)
+
+    assert _select(session, None) == ["a1", "b1", "n1"]
+
+
+def test_dataset_scoping_excludes_articles_with_no_dataset(session: Session) -> None:
+    """A NULL dataset_id is not a wildcard: those rows belong to no dataset."""
+    _add_article(session, "a1", DATASET_A)
+    _add_article(session, "n1", None)
+
+    assert _select(session, DATASET_A) == ["a1"]

--- a/tests/services/test_classification_service_unit.py
+++ b/tests/services/test_classification_service_unit.py
@@ -119,6 +119,7 @@ def test_apply_classification_dry_run_collects_proposed_labels(monkeypatch):
         include_existing,
         excluded,
         excluded_ids=None,
+        dataset_id=None,
     ):
         nonlocal call_count
         if call_count:
@@ -371,6 +372,7 @@ def test_apply_classification_handles_none_statuses(monkeypatch):
         include_existing,
         excluded,
         excluded_ids=None,
+        dataset_id=None,
     ):
         captured.update(
             {


### PR DESCRIPTION
Two related pieces of work, found while loading the VT Community News (VTCNI) dataset.

## The bug that matters

`requests` does not raise on 4xx, so `session.get()` returning a Cloudflare 403 — error 1006, *"the owner of this website has banned your IP address"* — was indistinguishable from a 200 to `_fetch_with_ssl_fallback`, which reported `success=True` to the proxy router unconditionally.

Three things followed:

1. The router never backed the proxy off for that domain, so **it never failed over to the second Squid**.
2. Its health data recorded the banned address as *healthy* for exactly the domains where it was banned.
3. Discovery reported "no articles found" for sites that were only being refused at one IP.

### Measured cost

20 VTCNI sources that discovery had found nothing for, re-run through the Mizzou Squid alone:

| | router as-is | Mizzou-only |
|---|---|---|
| sources with content | 0/20 | **11/20** |
| candidate URLs | 0 | **535** |

Content success across that 50-source batch: **60% → 82%**. Nothing about those sites changed — only the address the request came from.

### The fix

`BLOCKED_STATUS_CODES = {403, 406, 429, 451}` — statuses that describe the *address a request came from*. On a block, report failure to the router and retry once through the other Squid.

Deliberately excluded: `404`/`410` (gone from every address), `503` (an origin under strain should not get a second proxy's load too), `407` (our own credentials failing — switching would mask a misconfiguration that should be loud).

The alternate proxy is resolved by comparing proxy **URLs** rather than `RouterProxy` names: `get_requests_proxies_for_domain()` maps an unconfigured `MIZZOU_SQUID` back onto home Squid, so two names can resolve to one box, and retrying there would just re-ask the address that already refused us.

## Classification dataset scoping

`--dataset-id` on the analysis command, so a new dataset's backlog can be classified without re-walking every other dataset's.

The filter is an EXISTS against `candidate_links`, not a column on `articles` — articles carry no dataset of their own, the candidate link they were discovered through does. An earlier draft read `Article.dataset_id`, which does not exist and would have raised `AttributeError` the first time the flag was used.

## VTCNI loader

Follows `load_washington_sources.py` but **will not rewrite a source another dataset already owns**. Five VTCNI hosts are also Missouri sources with hand-curated names and geography; this CSV has none and a provisional name for most rows, so an UPDATE would have replaced "The Maneater" with "Themaneater" and blanked Columbia/Boone.

## Testing

- 14 new tests asserting on **what the router is told**, not on the returned response — reporting the wrong thing to the router is the whole defect and it is invisible from the return value, which is how it survived in production
- Negative control run: the tests fail when the behavior is removed, so they are not passing vacuously
- Full suite: 3,015 passed, 0 failures
- Verified end to end in-cluster against the real proxy router, not locally

## Not yet verified

The 82% figure came from forcing the egress by hand. This branch should produce it automatically, and that is unproven until the processor image is built and the same 50 sources are re-run.