### PR TITLE
fix(extraction): act on the router's proxy decision instead of only reporting it

### DIFF
--- a/scripts/load_vtcni_sources.py
+++ b/scripts/load_vtcni_sources.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Load the VT Community News (VTCNI) sources CSV into datasets/sources/dataset_sources.
+
+Same shape and the same reasoning as ``load_washington_sources.py`` -- raw SQL
+rather than the ORM, and no candidate-link enqueue, because the CSV carries
+homepages and discovery is what finds the stories.
+
+Two things are specific to this dataset:
+
+``name`` is provisional for most rows. The list arrived as bare URLs with no
+publication names, so ``name_source`` records where each name came from:
+``og:site_name``/``application-name``/``twitter:site``/``title-segment``/
+``logo-alt`` mean a real masthead was read off the page, while
+``domain-fallback`` means nobody has confirmed it and the value is just the
+domain title-cased ("Fordhamobserver"). Those are placeholders to be corrected
+from what discovery captures, not names to publish. The column is carried into
+source metadata so a later pass can find them without re-deriving.
+
+Re-running is the supported way to fix them: rows match on ``sources.host_norm``,
+so correcting names in the CSV and re-running updates this dataset in place.
+
+**A source already owned by another dataset is linked, never rewritten.** Five
+of these hosts are also Missouri sources with hand-curated names, cities,
+counties and owners (``themaneater.com`` -> "The Maneater", Columbia, Boone).
+This CSV carries no geography at all and a provisional name for most rows, so
+letting it UPDATE those rows -- which is what the Washington loader this was
+copied from does -- would replace "The Maneater" with "Themaneater" and blank
+the rest. It has nothing to contribute to a curated row, so it does not try;
+it only adds the dataset link. Even for rows this dataset does own, empty CSV
+values are never written over existing ones, and a confirmed name is never
+replaced by a provisional one.
+
+Two entries were removed from the raw list before it became this CSV:
+``medium.com`` and ``youtube.com``, which are platform roots rather than
+publications -- loading them as sources would aim discovery at those entire
+sites. The 26 remaining platform-hosted rows (``*.wordpress.com``,
+``*.weebly.com``, ``*.wixsite.com``) are real student newsrooms and are kept.
+
+The CSV itself is not in git -- ``.gitignore`` excludes ``*.csv`` with a short
+allowlist, and the Washington sources CSV is untracked for the same reason. It
+lives at ``sources/vtcni_sources.csv``, built from the VTCNI "productive sites"
+URL list (bare URLs, no names) plus the name-detection described above.
+
+Run inside a pod per the repo's DB access protocol::
+
+    kubectl cp scripts/load_vtcni_sources.py production/<cli-pod>:/app/load_vtcni_sources.py
+    kubectl cp sources/vtcni_sources.csv production/<cli-pod>:/app/vtcni_sources.csv
+    kubectl exec -n production <cli-pod> -- python /app/load_vtcni_sources.py \
+        --csv /app/vtcni_sources.csv [--commit]
+
+Then discovery runs against it through the normal production path::
+
+    python -m src.cli discover-urls --dataset "VT Community News" --force-all
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from src.models.database import DatabaseManager  # noqa: E402
+
+# `--dataset` on discover-urls matches datasets.label, not the slug.
+DATASET_SLUG = "VT-Community-News"
+DATASET_LABEL = "VT Community News"
+DATASET_NAME = "VT Community News Initiative Sources"
+DATASET_DESCRIPTION = (
+    "Student-produced and university-affiliated community news outlets tracked "
+    "by the VT Community News Initiative: the 'productive' site list, i.e. "
+    "outlets observed to be publishing."
+)
+
+# Anything else in this column means a masthead was read off the live page.
+PLACEHOLDER_NAME_SOURCE = "domain-fallback"
+
+
+def _source_fields(row: dict, host: str, host_norm: str) -> dict:
+    """Map a CSV row onto the sources columns.
+
+    ``name_source`` and ``name_is_provisional`` ride along in metadata so the
+    follow-up pass can select exactly the rows whose names still need
+    confirming, without re-deriving which ones those were.
+    """
+    name_source = row.get("name_source", "") or ""
+    return {
+        "host": host,
+        "host_norm": host_norm,
+        "canonical_name": row["name"],
+        "city": row.get("city", ""),
+        "county": row.get("county", ""),
+        "owner": row.get("owner", ""),
+        "type": row.get("media_type", "unknown"),
+        "metadata": json.dumps(
+            {
+                "address1": row.get("address1", ""),
+                "address2": row.get("address2", ""),
+                "state": row.get("State", ""),
+                "zip": str(row.get("zip", "") or ""),
+                "frequency": row.get("frequency", ""),
+                "media_type": row.get("media_type", ""),
+                "cohort": row.get("cohort", ""),
+                "source": row.get("source", ""),
+                "name_source": name_source,
+                "name_is_provisional": name_source == PLACEHOLDER_NAME_SOURCE,
+            }
+        ),
+    }
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, help="Path to the sources CSV")
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually write. Without this the script reports what it would do.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    with open(args.csv, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    if not rows:
+        print("ERROR: CSV is empty", file=sys.stderr)
+        return 1
+
+    provisional = sum(
+        1 for r in rows if r.get("name_source") == PLACEHOLDER_NAME_SOURCE
+    )
+    print(f"{len(rows)} rows; {provisional} carry a provisional (domain-derived) name")
+
+    db = DatabaseManager()
+    created_sources = 0
+    linked_sources = 0
+    existing_sources = 0
+    skipped_updates = 0
+
+    with db.get_session() as session:
+        dataset_id = session.execute(
+            text("SELECT id FROM datasets WHERE slug = :slug"),
+            {"slug": DATASET_SLUG},
+        ).scalar_one_or_none()
+
+        if dataset_id:
+            print(f"Dataset {DATASET_SLUG} already exists ({dataset_id})")
+        else:
+            dataset_id = str(uuid.uuid4())
+            print(f"CREATE dataset {DATASET_SLUG} ({dataset_id})")
+            if args.commit:
+                session.execute(
+                    # ingested_at is NOT NULL in production and has no server
+                    # default there, despite what the ORM model implies.
+                    text("""
+                        INSERT INTO datasets
+                            (id, slug, label, name, description, ingested_at,
+                             ingested_by, metadata, is_public, cron_enabled)
+                        VALUES
+                            (:id, :slug, :label, :name, :description, NOW(),
+                             :ingested_by, CAST(:metadata AS JSON), :is_public,
+                             :cron_enabled)
+                        """),
+                    {
+                        "id": dataset_id,
+                        "slug": DATASET_SLUG,
+                        "label": DATASET_LABEL,
+                        "name": DATASET_NAME,
+                        "description": DATASET_DESCRIPTION,
+                        "ingested_by": "load_vtcni_sources",
+                        "metadata": json.dumps(
+                            {
+                                "source_file": args.csv,
+                                "total_rows": len(rows),
+                                "provisional_names": provisional,
+                            }
+                        ),
+                        "is_public": False,
+                        "cron_enabled": False,
+                    },
+                )
+
+        for row in rows:
+            host = row["url_news"].split("//", 1)[1].strip("/")
+            host_norm = host.lower()
+
+            fields = _source_fields(row, host, host_norm)
+
+            existing = session.execute(
+                text("""
+                    SELECT s.id,
+                           s.canonical_name,
+                           EXISTS (
+                               SELECT 1 FROM dataset_sources ds
+                               WHERE ds.source_id = s.id
+                                 AND ds.dataset_id <> :dataset_id
+                           ) AS owned_elsewhere
+                    FROM sources s
+                    WHERE s.host_norm = :h
+                    """),
+                {"h": host_norm, "dataset_id": dataset_id},
+            ).one_or_none()
+
+            source_id = existing[0] if existing else None
+            provisional_row = row.get("name_source") == PLACEHOLDER_NAME_SOURCE
+            flag = "?" if provisional_row else " "
+
+            if source_id:
+                existing_sources += 1
+                current_name, owned_elsewhere = existing[1], existing[2]
+
+                if owned_elsewhere:
+                    # Another dataset curated this row. Link it in; touch nothing.
+                    skipped_updates += 1
+                    print(
+                        f"  LINK   {flag} {host_norm:<38} "
+                        f"keeping {current_name!r} (owned by another dataset)"
+                    )
+                elif provisional_row and current_name:
+                    skipped_updates += 1
+                    print(
+                        f"  LINK   {flag} {host_norm:<38} "
+                        f"keeping {current_name!r} (ours is provisional)"
+                    )
+                else:
+                    print(f"  UPDATE {flag} {host_norm:<38} {row['name']}")
+                    if args.commit:
+                        # COALESCE(NULLIF(...)) so a blank CSV cell leaves the
+                        # stored value alone rather than erasing it.
+                        session.execute(
+                            text("""
+                                UPDATE sources
+                                SET canonical_name = :canonical_name,
+                                    city = COALESCE(NULLIF(:city, ''), city),
+                                    county = COALESCE(NULLIF(:county, ''), county),
+                                    owner = COALESCE(NULLIF(:owner, ''), owner),
+                                    type = COALESCE(NULLIF(:type, ''), type),
+                                    metadata = CAST(:metadata AS JSON)
+                                WHERE id = :id
+                                """),
+                            {**fields, "id": source_id},
+                        )
+            else:
+                source_id = str(uuid.uuid4())
+                created_sources += 1
+                print(f"  CREATE {flag} {host_norm:<38} {row['name']}")
+                if args.commit:
+                    session.execute(
+                        text("""
+                            INSERT INTO sources
+                                (id, host, host_norm, canonical_name, city, county,
+                                 owner, type, metadata, status)
+                            VALUES
+                                (:id, :host, :host_norm, :canonical_name, :city,
+                                 :county, :owner, :type, CAST(:metadata AS JSON),
+                                 :status)
+                            """),
+                        {**fields, "id": source_id, "status": "active"},
+                    )
+
+            if not args.commit:
+                continue
+
+            mapped = session.execute(
+                text("""
+                    SELECT 1 FROM dataset_sources
+                    WHERE dataset_id = :d AND source_id = :s
+                    """),
+                {"d": dataset_id, "s": source_id},
+            ).scalar_one_or_none()
+            if not mapped:
+                linked_sources += 1
+                session.execute(
+                    text("""
+                        INSERT INTO dataset_sources
+                            (id, dataset_id, source_id, legacy_host_id, legacy_meta)
+                        VALUES
+                            (:id, :d, :s, :hid, CAST(:meta AS JSON))
+                        """),
+                    {
+                        "id": str(uuid.uuid4()),
+                        "d": dataset_id,
+                        "s": source_id,
+                        "hid": str(row["host_id"]),
+                        "meta": json.dumps({"original_csv_row": row}),
+                    },
+                )
+
+        if args.commit:
+            session.commit()
+
+    verb = "Wrote" if args.commit else "DRY RUN (pass --commit to write):"
+    # Report rows actually rewritten, not rows that merely already existed --
+    # the two differ by every row this script deliberately left alone.
+    print(
+        f"\n{verb} sources created={created_sources} "
+        f"updated={existing_sources - skipped_updates} "
+        f"left-alone={skipped_updates} linked={linked_sources}"
+    )
+    print(
+        f"'?' marks a provisional name ({provisional} rows) to fix after discovery; "
+        f"{skipped_updates} existing sources were linked without being rewritten"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/commands/analysis.py
+++ b/src/cli/commands/analysis.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from sqlalchemy import select
 
 from src.ml.article_classifier import ArticleClassifier
-from src.models import Article, ArticleLabel
+from src.models import Article, ArticleLabel, CandidateLink
 from src.models.database import DatabaseManager, safe_session_execute
 from src.services.classification_service import ArticleClassificationService
 
@@ -67,6 +67,7 @@ def _snapshot_labels(
     session,
     label_version: str,
     statuses: Sequence[str] | None,
+    dataset_id: str | None = None,
 ) -> dict[str, dict[str, str | None]]:
     stmt = select(
         Article.id,
@@ -78,6 +79,19 @@ def _snapshot_labels(
         (ArticleLabel.article_id == Article.id)
         & (ArticleLabel.label_version == label_version),
     )
+
+    # Scoped to the same dataset the run classifies, or the diff compares a
+    # one-dataset run against a corpus-wide snapshot. The dataset lives on the
+    # candidate link, not the article -- see _select_articles.
+    if dataset_id:
+        stmt = stmt.where(
+            select(CandidateLink.id)
+            .where(
+                CandidateLink.id == Article.candidate_link_id,
+                CandidateLink.dataset_id == dataset_id,
+            )
+            .exists()
+        )
 
     if statuses is None:
         stmt = stmt.where(Article.status.notin_(list(EXCLUDED_STATUSES)))
@@ -274,6 +288,13 @@ def add_analysis_parser(subparsers) -> None:
         ),
     )
     parser.add_argument(
+        "--dataset-id",
+        help=(
+            "Classify only articles belonging to this dataset id. Omit to "
+            "classify across every dataset."
+        ),
+    )
+    parser.add_argument(
         "--report-path",
         help=(
             "Optional CSV path for label-change report. If omitted, a "
@@ -300,6 +321,7 @@ def handle_analysis_command(args) -> int:
         args.model_path or os.getenv("MODEL_PATH") or "models"
     ).expanduser()
     collect_diff = bool(args.report_path)
+    dataset_id = (getattr(args, "dataset_id", None) or "").strip() or None
 
     try:
         classifier = ArticleClassifier(model_path=model_path)
@@ -317,6 +339,7 @@ def handle_analysis_command(args) -> int:
                 db.session,
                 label_version,
                 filtered_statuses,
+                dataset_id,
             )
 
         stats = service.apply_classification(
@@ -330,6 +353,7 @@ def handle_analysis_command(args) -> int:
             top_k=top_k,
             dry_run=args.dry_run,
             include_existing=args.force,
+            dataset_id=dataset_id,
         )
 
         print("\n=== Classification Summary ===")
@@ -360,6 +384,7 @@ def handle_analysis_command(args) -> int:
                     db.session,
                     label_version,
                     filtered_statuses,
+                    dataset_id,
                 )
                 changes = _compute_label_changes(
                     before_snapshot,

--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -2236,6 +2236,7 @@ class ContentExtractor:
                 reason=error_msg[:200],
                 service="newscrawler",
             )
+            self._forget_domain_session(domain)
 
         return {
             "url": url,
@@ -2249,6 +2250,135 @@ class ContentExtractor:
             "error": error_msg,
             "metadata": metadata or {},
         }
+
+    def _retry_unblock_via_alternate_proxy(
+        self,
+        url: str,
+        domain: Optional[str],
+        metrics: Optional["ExtractionMetrics"] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Re-run the unblock rung through the other Squid. None if there isn't one.
+
+        Never raises: a second ProxyChallengeError here means both addresses
+        were refused, which is the caller's existing "fall through to Selenium"
+        case, not a new failure mode to handle.
+        """
+        if domain is None:
+            return None
+
+        # Defensive reads: test doubles built via ContentExtractor.__new__()
+        # skip __init__ entirely, so neither attribute is guaranteed. A retry
+        # that cannot look up routing is simply not available -- it must not
+        # turn a challenge into an AttributeError and abort the extraction.
+        router_map = getattr(self, "domain_router_proxy", None)
+        proxy_manager = getattr(self, "proxy_manager", None)
+        if router_map is None or proxy_manager is None:
+            return None
+
+        current = router_map.get(domain)
+        if current is None:
+            # No recorded choice for this domain, so there is nothing to be the
+            # alternate *of*. Same reasoning as the unresolvable-URL case below:
+            # a retry we cannot show is going somewhere else is guesswork.
+            logger.info(
+                "No routed proxy recorded for %s; skipping alternate retry", domain
+            )
+            return None
+
+        try:
+            current_proxies = proxy_manager.get_requests_proxies_for_router_proxy(
+                current
+            )
+            alt_proxies, alt_proxy = proxy_manager.get_alternate_proxies(
+                current, current_proxies
+            )
+        except Exception as exc:  # routing must never break extraction
+            logger.warning("alternate-proxy lookup failed for %s: %s", domain, exc)
+            return None
+
+        if current_proxies is None:
+            # Without the current proxy's URL there is nothing to compare the
+            # alternate against, so "different box" cannot be established --
+            # and retrying through the address that was just refused costs a
+            # request and teaches the router nothing.
+            logger.info(
+                "Current proxy for %s is unresolvable; skipping alternate retry",
+                domain,
+            )
+            return None
+
+        if not alt_proxies:
+            logger.info(
+                "No alternate proxy configured; %s stays refused at %s",
+                domain,
+                getattr(current, "value", current),
+            )
+            return None
+
+        logger.info(
+            "🔁 Retrying %s through %s after a challenge on %s",
+            url,
+            getattr(alt_proxy, "value", alt_proxy),
+            getattr(current, "value", current),
+        )
+        try:
+            result = self._extract_with_unblock_proxy(
+                url, None, metrics, domain=domain, proxy_override=alt_proxies
+            )
+        except ProxyChallengeError as exc:
+            logger.info("Alternate proxy also refused %s: %s", url, exc)
+            self._report_proxy_outcome(
+                domain, alt_proxy, success=False, reason=str(exc)
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 - retry is best-effort
+            logger.warning("Alternate-proxy retry errored for %s: %s", url, exc)
+            return None
+
+        if result and result.get("content"):
+            self._report_proxy_outcome(domain, alt_proxy, success=True)
+            # The alternate worked, so let the next request for this domain
+            # re-pick rather than reusing the session built for the refused box.
+            self._forget_domain_session(domain)
+        return result
+
+    def _report_proxy_outcome(
+        self, domain: str, router_proxy, success: bool, reason: Optional[str] = None
+    ) -> None:
+        """Tell the router how a specific proxy fared, without ever raising."""
+        try:
+            self.proxy_manager.report_domain_result(
+                domain,
+                router_proxy,
+                success=success,
+                reason=(reason or "")[:200] or None,
+                service="newscrawler",
+            )
+        except Exception as exc:  # pragma: no cover - telemetry must not fail a fetch
+            logger.debug("report_domain_result failed for %s: %s", domain, exc)
+
+    def _forget_domain_session(self, domain: str) -> None:
+        """Drop the cached session for a domain after its proxy was blocked.
+
+        The proxy is chosen once, when the domain's session is built, and then
+        baked into ``session.proxies``; every later request for that domain
+        reuses the cached session without asking the router again. So when a
+        challenge causes the router to back this proxy off for the domain, the
+        router has learned and extraction has not -- it keeps sending through
+        the refused address until an unrelated user-agent rotation happens to
+        rebuild the session.
+
+        Forgetting the session is what makes the router's decision take
+        effect: the next request for this domain builds a fresh session and
+        calls get_requests_proxies_for_domain() again, which now returns the
+        other Squid because the first one is backed off.
+        """
+        self.domain_sessions.pop(domain, None)
+        self.domain_router_proxy.pop(domain, None)
+        logger.info(
+            "🔁 Dropped cached session for %s so the next request re-picks a proxy",
+            domain,
+        )
 
     def clear_all_sessions(self):
         """Clear all domain sessions and reset rotation state."""
@@ -3119,18 +3249,40 @@ class ContentExtractor:
                 logger.warning(f"❌ Proxy challenge for {url}: {e}")
                 if metrics:
                     metrics.end_method("unblock_proxy", False, str(e), {})
-                if domain_requires_unblock:
+
+                # A challenge is a statement about the ADDRESS the request came
+                # from, not about the page. Try the other Squid before giving up
+                # on HTTP: the same URL routinely returns 200 from the second
+                # box. Doing this here matters because the challenge also puts
+                # the domain into CAPTCHA backoff, and that backoff then makes
+                # _run_selenium_extraction skip the browser -- so without this
+                # retry a single block costs the article twice, on the fetch and
+                # on the fallback that was supposed to rescue it.
+                retry_result = self._retry_unblock_via_alternate_proxy(
+                    url, domain, metrics
+                )
+                if retry_result and retry_result.get("content"):
+                    self._merge_extraction_results(
+                        result, retry_result, "unblock_proxy", missing_fields, metrics
+                    )
+                    logger.info(
+                        "✅ Unblock proxy succeeded for %s via the alternate proxy",
+                        url,
+                    )
+                    if metrics:
+                        metrics.end_method("unblock_proxy", True, None, retry_result)
+                elif domain_requires_unblock:
                     # Flagged domains treat a challenge as terminal and mark the
                     # article for retry — Selenium won't help where the site has
                     # already refused this route.
                     raise
-                # As a general rung this is advisory: the disguise was refused,
-                # which says nothing about whether a real browser would be. Fall
-                # through so Selenium still gets its turn, exactly as before this
-                # rung existed for unflagged domains.
-                logger.info(
-                    "tls_client capture refused for %s; continuing to Selenium", url
-                )
+                else:
+                    # As a general rung this is advisory: the disguise was
+                    # refused, which says nothing about whether a real browser
+                    # would be. Fall through so Selenium still gets its turn.
+                    logger.info(
+                        "tls_client capture refused for %s; continuing to Selenium", url
+                    )
 
             except Exception as e:
                 logger.error(f"❌ Unblock proxy extraction failed for {url}: {e}")
@@ -4201,6 +4353,7 @@ class ContentExtractor:
         browser_actions: Optional[list] = None,
         metrics: Optional[ExtractionMetrics] = None,
         domain: Optional[str] = None,
+        proxy_override: Optional[dict] = None,
     ) -> Dict[str, Any]:
         """Extract content using Squid proxy for strong bot protection.
 
@@ -4231,7 +4384,12 @@ class ContentExtractor:
             # something unconfigured, so this can never end up direct.
             router_proxies = None
             router_proxy = None
-            if domain is not None:
+            if proxy_override:
+                # A caller retrying after a challenge already knows which box
+                # to use; asking the router again would just return the one
+                # that was refused, since backoff is not instantaneous.
+                router_proxies = proxy_override
+            elif domain is not None:
                 try:
                     router_proxies, router_proxy, _method = (
                         self.proxy_manager.get_requests_proxies_for_domain(

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -81,6 +81,7 @@ from src.utils.url_utils import normalize_url
 
 from ..models.database import DatabaseManager, safe_execute, safe_session_execute
 from .proxy_config import get_proxy_manager
+from .proxy_router import RouterProxy
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,22 @@ RSS_MISSING_THRESHOLD = 3
 # RSS_TRANSIENT_THRESHOLD failures occur within RSS_TRANSIENT_WINDOW_DAYS, mark missing.
 RSS_TRANSIENT_THRESHOLD = 5
 RSS_TRANSIENT_WINDOW_DAYS = 7
+
+# Statuses that mean "this egress is not welcome here", as opposed to "this
+# page is not here". A 403 from Cloudflare (error 1006 is literally "the owner
+# of this website has banned your IP address") or a 406 from mod_security is a
+# property of the address the request came from: the identical request from
+# the other Squid usually returns 200. Those are worth reporting to the proxy
+# router as a failure and retrying elsewhere.
+#
+# Deliberately excluded:
+#   404/410 -- the page is gone from every address; retrying is pure waste.
+#   503     -- normally an origin under strain. Retrying through a second
+#              proxy would add load to a server already failing, and it is
+#              not an address-level judgement.
+#   407     -- OUR proxy rejected OUR credentials. Switching proxies would
+#              mask a misconfiguration that should be loud.
+BLOCKED_STATUS_CODES = frozenset({403, 406, 429, 451})
 
 
 class RawFeedEntry(TypedDict, total=False):
@@ -502,9 +519,15 @@ class NewsDiscovery:
         # Try primary session first (cloudscraper or requests)
         try:
             response = self.session.get(url, timeout=timeout, proxies=router_proxies)
-            self._report_router_result(domain, router_proxy, success=True)
-            self._note_capture_diagnosis(url, getattr(response, "text", None))
-            return response
+            return self._settle_response(
+                url,
+                domain,
+                router_proxy,
+                router_proxies,
+                response,
+                timeout,
+                self.session,
+            )
         except requests.exceptions.SSLError as e:
             logger.warning(
                 "SSL error with primary session for %s, trying fallback: %s",
@@ -525,14 +548,122 @@ class NewsDiscovery:
             response = self._fallback_session.get(
                 url, timeout=timeout, proxies=router_proxies
             )
-            self._report_router_result(domain, router_proxy, success=True)
-            self._note_capture_diagnosis(url, getattr(response, "text", None))
-            return response
+            return self._settle_response(
+                url,
+                domain,
+                router_proxy,
+                router_proxies,
+                response,
+                timeout,
+                self._fallback_session,
+            )
         except requests.exceptions.RequestException as e:
             self._report_router_result(
                 domain, router_proxy, success=False, reason=str(e)[:200]
             )
             raise
+
+    def _settle_response(
+        self,
+        url: str,
+        domain: str,
+        router_proxy,
+        router_proxies: dict | None,
+        response: requests.Response,
+        timeout: int,
+        session,
+    ) -> requests.Response:
+        """Report the attempt to the router, retrying elsewhere if IP-blocked.
+
+        This used to be one unconditional ``success=True``. `requests` does not
+        raise on 4xx, so a Cloudflare 403 -- "the owner of this website has
+        banned your IP address" -- was reported to the router as a SUCCESS and
+        handed back as a normal response. Three things followed: the router
+        never backed the proxy off for that domain, so it never failed over;
+        its health data recorded the blocked proxy as healthy for exactly the
+        domains where it was banned; and discovery reported "no articles" for
+        sites that were merely being refused at one address.
+
+        Measured on 20 VTCNI sources that discovery had found nothing for:
+        re-running them through the second Squid alone produced 535 candidate
+        URLs from 11 of them. Nothing about those sites had changed.
+        """
+        if response.status_code not in BLOCKED_STATUS_CODES:
+            self._report_router_result(domain, router_proxy, success=True)
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        reason = f"HTTP {response.status_code}"
+        logger.warning(
+            "%s blocked at %s via %s -- treating as a proxy failure, not a fetch",
+            reason,
+            url,
+            getattr(router_proxy, "value", router_proxy),
+        )
+        self._report_router_result(domain, router_proxy, success=False, reason=reason)
+
+        alt_proxies, alt_proxy = self._alternate_proxies_for_domain(
+            router_proxy, router_proxies
+        )
+        if alt_proxies is None:
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        logger.info(
+            "Retrying %s via %s after %s",
+            url,
+            getattr(alt_proxy, "value", alt_proxy),
+            reason,
+        )
+        try:
+            retry = session.get(url, timeout=timeout, proxies=alt_proxies)
+        except requests.exceptions.RequestException as exc:
+            # The alternate failed too. Keep the original response rather than
+            # raising: the caller asked for a fetch, and one bad proxy should
+            # not turn a 403 into an exception it never had to handle before.
+            self._report_router_result(
+                domain, alt_proxy, success=False, reason=str(exc)[:200]
+            )
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        blocked_again = retry.status_code in BLOCKED_STATUS_CODES
+        self._report_router_result(
+            domain,
+            alt_proxy,
+            success=not blocked_again,
+            reason=f"HTTP {retry.status_code}" if blocked_again else None,
+        )
+        if blocked_again:
+            self._note_capture_diagnosis(url, getattr(response, "text", None))
+            return response
+
+        self._note_capture_diagnosis(url, getattr(retry, "text", None))
+        return retry
+
+    def _alternate_proxies_for_domain(self, current, current_proxies: dict | None):
+        """The other configured proxy, or (None, None) if there isn't one.
+
+        Compares the resolved proxy URLs rather than the RouterProxy names.
+        get_requests_proxies_for_domain() maps an unconfigured MIZZOU_SQUID
+        back onto home Squid, so two different names can resolve to one box --
+        retrying there would just re-ask the address that was already refused.
+        """
+        proxy_manager = getattr(self, "proxy_manager", None)
+        if proxy_manager is None or current is None:
+            return None, None
+
+        resolve = getattr(proxy_manager, "get_requests_proxies_for_router_proxy", None)
+        if resolve is None:  # older manager / test double
+            return None, None
+
+        for candidate in RouterProxy:
+            if candidate is current:
+                continue
+            proxies = resolve(candidate)
+            if proxies and proxies != current_proxies:
+                return proxies, candidate
+        return None, None
 
     def _note_capture_diagnosis(self, url: str, html: str | None) -> None:
         """Record WHY a capture might yield nothing, for this source.

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -81,7 +81,6 @@ from src.utils.url_utils import normalize_url
 
 from ..models.database import DatabaseManager, safe_execute, safe_session_execute
 from .proxy_config import get_proxy_manager
-from .proxy_router import RouterProxy
 
 logger = logging.getLogger(__name__)
 
@@ -644,26 +643,19 @@ class NewsDiscovery:
     def _alternate_proxies_for_domain(self, current, current_proxies: dict | None):
         """The other configured proxy, or (None, None) if there isn't one.
 
-        Compares the resolved proxy URLs rather than the RouterProxy names.
-        get_requests_proxies_for_domain() maps an unconfigured MIZZOU_SQUID
-        back onto home Squid, so two different names can resolve to one box --
-        retrying there would just re-ask the address that was already refused.
+        Delegates to ProxyManager.get_alternate_proxies so discovery and
+        extraction answer "is there somewhere else to try?" identically; the
+        URL-vs-name comparison that matters is documented there.
         """
         proxy_manager = getattr(self, "proxy_manager", None)
         if proxy_manager is None or current is None:
             return None, None
 
-        resolve = getattr(proxy_manager, "get_requests_proxies_for_router_proxy", None)
+        resolve = getattr(proxy_manager, "get_alternate_proxies", None)
         if resolve is None:  # older manager / test double
             return None, None
 
-        for candidate in RouterProxy:
-            if candidate is current:
-                continue
-            proxies = resolve(candidate)
-            if proxies and proxies != current_proxies:
-                return proxies, candidate
-        return None, None
+        return resolve(current, current_proxies)
 
     def _note_capture_diagnosis(self, url: str, html: str | None) -> None:
         """Record WHY a capture might yield nothing, for this source.

--- a/src/crawler/proxy_config.py
+++ b/src/crawler/proxy_config.py
@@ -391,6 +391,31 @@ class ProxyManager:
 
         return _build_proxies_dict(provider), router_proxy, choice.method
 
+    def get_requests_proxies_for_router_proxy(
+        self, router_proxy: RouterProxy
+    ) -> Optional[dict]:
+        """Return the proxies dict for one specific proxy, or None.
+
+        Unlike get_requests_proxies_for_domain(), this asks for a *named*
+        proxy rather than letting the router choose -- callers use it to reach
+        the other Squid after the routed one turned out to be blocked for a
+        domain.
+
+        Returns None rather than falling back to home Squid when the requested
+        proxy isn't configured. The fallback is right for "just get me a
+        proxy" and wrong here: a caller retrying a blocked request needs to
+        know it would be retrying through the same box, so it can skip the
+        pointless second attempt.
+        """
+        provider_by_proxy = {
+            RouterProxy.HOME_SQUID: ProxyProvider.SQUID,
+            RouterProxy.MIZZOU_SQUID: ProxyProvider.MIZZOU_SQUID,
+        }
+        provider = self.configs.get(provider_by_proxy.get(router_proxy))
+        if provider is None or not provider.enabled:
+            return None
+        return _build_proxies_dict(provider)
+
     def report_domain_result(
         self,
         domain: str,

--- a/src/crawler/proxy_config.py
+++ b/src/crawler/proxy_config.py
@@ -416,6 +416,30 @@ class ProxyManager:
             return None
         return _build_proxies_dict(provider)
 
+    def get_alternate_proxies(
+        self, current: Optional[RouterProxy], current_proxies: Optional[dict]
+    ) -> tuple[Optional[dict], Optional[RouterProxy]]:
+        """The other configured proxy, or (None, None) if there isn't one.
+
+        Compares the resolved proxy URLs rather than the RouterProxy names.
+        get_requests_proxies_for_domain() maps an unconfigured MIZZOU_SQUID
+        back onto home Squid, so two different names can resolve to the same
+        box -- retrying there would re-ask the address that just refused us,
+        which costs a request and teaches the router nothing.
+
+        Shared by discovery's fetch path and extraction's unblock rung so both
+        answer "is there somewhere else to try?" the same way.
+        """
+        if current is None:
+            return None, None
+        for candidate in RouterProxy:
+            if candidate is current:
+                continue
+            proxies = self.get_requests_proxies_for_router_proxy(candidate)
+            if proxies and proxies != current_proxies:
+                return proxies, candidate
+        return None, None
+
     def report_domain_result(
         self,
         domain: str,

--- a/src/services/classification_service.py
+++ b/src/services/classification_service.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.ml.article_classifier import Prediction
-from src.models import Article, ArticleLabel
+from src.models import Article, ArticleLabel, CandidateLink
 from src.models.database import save_article_classification
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,7 @@ class ArticleClassificationService:
         include_existing: bool,
         excluded_statuses: Sequence[str] | None = None,
         excluded_article_ids: Sequence[str] | None = None,
+        dataset_id: str | None = None,
     ) -> list[Article]:
         stmt = select(Article)
 
@@ -66,6 +67,20 @@ class ArticleClassificationService:
 
         if excluded_statuses:
             stmt = stmt.where(Article.status.notin_(list(excluded_statuses)))
+
+        # Articles carry no dataset of their own; the dataset is a property of
+        # the candidate link they were discovered through. EXISTS rather than a
+        # join so the FOR UPDATE SKIP LOCKED below keeps locking articles only.
+        if dataset_id:
+            in_dataset = (
+                select(CandidateLink.id)
+                .where(
+                    CandidateLink.id == Article.candidate_link_id,
+                    CandidateLink.dataset_id == dataset_id,
+                )
+                .exists()
+            )
+            stmt = stmt.where(in_dataset)
 
         if not include_existing:
             label_exists = (
@@ -148,6 +163,7 @@ class ArticleClassificationService:
         top_k: int = 2,
         dry_run: bool = False,
         include_existing: bool = False,
+        dataset_id: str | None = None,
     ) -> ClassificationStats:
         """Classify eligible articles and persist results.
 
@@ -210,6 +226,7 @@ class ArticleClassificationService:
                 include_existing,
                 list(excluded_statuses),
                 excluded_ids,
+                dataset_id,
             )
 
             if not articles:

--- a/tests/cli/commands/test_analysis.py
+++ b/tests/cli/commands/test_analysis.py
@@ -77,6 +77,7 @@ def _default_args(**overrides) -> Namespace:
         top_k=2,
         dry_run=False,
         force=False,
+        dataset_id=None,
         report_path=None,
     )
     defaults.update(overrides)
@@ -144,7 +145,7 @@ def test_handle_analysis_dry_run_generates_report(
     }
     snapshot_calls: list[tuple[Any, ...]] = []
 
-    def fake_snapshot(session, label_version, statuses):
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
         snapshot_calls.append((session, label_version, statuses))
         return before_snapshot
 
@@ -202,7 +203,7 @@ def test_handle_analysis_persisted_report_generates_csv(
     snapshots = [before_snapshot, after_snapshot]
     snapshot_calls: list[tuple[Any, str, list[str] | None]] = []
 
-    def fake_snapshot(session, label_version, statuses):
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
         snapshot_calls.append((session, label_version, statuses))
         return snapshots[len(snapshot_calls) - 1]
 
@@ -500,7 +501,7 @@ def test_handle_analysis_no_label_changes_reports_skip(
     }
     snapshots = [snapshot, snapshot]
 
-    def fake_snapshot(session, label_version, statuses):
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
         return snapshots.pop(0)
 
     monkeypatch.setattr(analysis, "_snapshot_labels", fake_snapshot)
@@ -523,3 +524,56 @@ def test_handle_analysis_no_label_changes_reports_skip(
     assert exit_code == 0
     stdout = capsys.readouterr().out
     assert "No label changes detected" in stdout
+
+
+def test_dataset_id_reaches_the_service(db_stub, classifier_invocations, service_stub):
+    """--dataset-id must be forwarded, not merely accepted.
+
+    The first cut of this feature added the filter to the service and never
+    passed anything to it, so the flag parsed cleanly and classified the whole
+    corpus anyway.
+    """
+    args = _default_args(dataset_id="vtcni")
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert service_stub.calls.pop()["dataset_id"] == "vtcni"
+
+
+def test_omitted_dataset_id_stays_corpus_wide(
+    db_stub, classifier_invocations, service_stub
+):
+    args = _default_args()
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert service_stub.calls.pop()["dataset_id"] is None
+
+
+def test_blank_dataset_id_is_treated_as_omitted(
+    db_stub, classifier_invocations, service_stub
+):
+    """An empty --dataset-id must not narrow the run to zero articles."""
+    args = _default_args(dataset_id="   ")
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert service_stub.calls.pop()["dataset_id"] is None
+
+
+def test_snapshot_is_scoped_to_the_same_dataset(
+    db_stub, classifier_invocations, service_stub, monkeypatch, tmp_path
+):
+    """Otherwise the diff compares one dataset's run against the whole corpus."""
+    snapshot_calls: list[tuple] = []
+
+    def fake_snapshot(session, label_version, statuses, dataset_id=None):
+        snapshot_calls.append(dataset_id)
+        return {}
+
+    monkeypatch.setattr(analysis, "_snapshot_labels", fake_snapshot)
+
+    args = _default_args(
+        dataset_id="vtcni",
+        report_path=str(tmp_path / "changes.csv"),
+    )
+
+    assert analysis.handle_analysis_command(args) == 0
+    assert snapshot_calls == ["vtcni", "vtcni"]

--- a/tests/crawler/test_blocked_status_fails_over.py
+++ b/tests/crawler/test_blocked_status_fails_over.py
@@ -23,6 +23,7 @@ import pytest
 import requests
 
 from src.crawler.discovery import BLOCKED_STATUS_CODES, NewsDiscovery
+from src.crawler.proxy_config import ProxyManager
 from src.crawler.proxy_router import RouterProxy
 
 HOME = {"http": "http://home:3128", "https": "http://home:3128"}
@@ -51,6 +52,15 @@ class _Session:
 
 
 class _ProxyManager:
+    """Stubs only the config lookup; the selection logic is the real one.
+
+    get_alternate_proxies is bound straight off ProxyManager so these tests
+    exercise production's "is the other proxy actually different?" rule rather
+    than a reimplementation of it that could drift.
+    """
+
+    get_alternate_proxies = ProxyManager.get_alternate_proxies
+
     def __init__(self, resolvable=None):
         # RouterProxy -> proxies dict
         self._resolvable = resolvable or {

--- a/tests/crawler/test_blocked_status_fails_over.py
+++ b/tests/crawler/test_blocked_status_fails_over.py
@@ -1,0 +1,200 @@
+"""A 403 is a failure of the proxy, not a successful fetch.
+
+`requests` does not raise on 4xx, so `session.get()` returning a Cloudflare 403
+looked exactly like a 200 to the old code, which reported `success=True` to the
+proxy router unconditionally. The router therefore never backed the proxy off
+for that domain, never failed over to the second Squid, and recorded the banned
+address as healthy for precisely the domains where it was banned. Discovery
+reported "no articles found" for sites that were only being refused at one IP.
+
+Measured on 20 VTCNI sources that discovery had found nothing for: re-running
+them through the other Squid alone produced 535 candidate URLs from 11 of them.
+
+These tests assert on what the ROUTER IS TOLD, not just on the response handed
+back. Reporting the wrong thing to the router is the entire bug, and it is
+invisible from the return value -- which is why it survived in production.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import requests
+
+from src.crawler.discovery import BLOCKED_STATUS_CODES, NewsDiscovery
+from src.crawler.proxy_router import RouterProxy
+
+HOME = {"http": "http://home:3128", "https": "http://home:3128"}
+MIZZOU = {"http": "http://mizzou:3128", "https": "http://mizzou:3128"}
+
+
+class _Response:
+    def __init__(self, status_code: int, text: str = "<html></html>"):
+        self.status_code = status_code
+        self.text = text
+
+
+class _Session:
+    """Returns a queued response per call, recording the proxies used."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[dict | None] = []
+
+    def get(self, url, timeout=None, proxies=None):
+        self.calls.append(proxies)
+        result = self._responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class _ProxyManager:
+    def __init__(self, resolvable=None):
+        # RouterProxy -> proxies dict
+        self._resolvable = resolvable or {
+            RouterProxy.HOME_SQUID: HOME,
+            RouterProxy.MIZZOU_SQUID: MIZZOU,
+        }
+
+    def get_requests_proxies_for_router_proxy(self, router_proxy):
+        return self._resolvable.get(router_proxy)
+
+
+def _discovery(session, *, routed=RouterProxy.HOME_SQUID, manager=None):
+    """A NewsDiscovery with the network and router stubbed, no __init__."""
+    d = NewsDiscovery.__new__(NewsDiscovery)
+    d.session = session
+    d._fallback_session = session
+    d.timeout = 5
+    d.proxy_manager = manager or _ProxyManager()
+    d.reported: list[tuple] = []
+
+    d._router_proxies_for_domain = lambda domain: (HOME, routed)
+    d._report_router_result = lambda domain, proxy, success, reason=None: (
+        d.reported.append((proxy, success, reason))
+    )
+    d._note_capture_diagnosis = lambda url, html: None
+    return d
+
+
+class TestBlockedStatusIsReportedAsFailure:
+    @pytest.mark.parametrize("status", sorted(BLOCKED_STATUS_CODES))
+    def test_router_is_told_the_proxy_failed(self, status):
+        session = _Session([_Response(status), _Response(200)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        first_proxy, first_success, reason = d.reported[0]
+        assert first_proxy is RouterProxy.HOME_SQUID
+        assert first_success is False
+        assert str(status) in reason
+
+    def test_a_200_still_reports_success(self):
+        session = _Session([_Response(200)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert d.reported == [(RouterProxy.HOME_SQUID, True, None)]
+
+    def test_404_is_not_treated_as_a_block(self):
+        """The page is gone from every address -- retrying is pure waste."""
+        session = _Session([_Response(404)])
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 404
+        assert d.reported == [(RouterProxy.HOME_SQUID, True, None)]
+        assert len(session.calls) == 1
+
+    def test_503_is_not_treated_as_a_block(self):
+        """An origin under strain should not get a second proxy's load too."""
+        session = _Session([_Response(503)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert len(session.calls) == 1
+
+
+class TestRetryOnTheAlternateProxy:
+    def test_blocked_request_is_retried_through_the_other_squid(self):
+        session = _Session([_Response(403), _Response(200, "<html>real</html>")])
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert [c for c in session.calls] == [HOME, MIZZOU]
+        assert response.status_code == 200
+        assert response.text == "<html>real</html>"
+
+    def test_successful_retry_is_reported_against_the_proxy_that_worked(self):
+        session = _Session([_Response(403), _Response(200)])
+        d = _discovery(session)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert d.reported == [
+            (RouterProxy.HOME_SQUID, False, "HTTP 403"),
+            (RouterProxy.MIZZOU_SQUID, True, None),
+        ]
+
+    def test_both_blocked_reports_both_and_returns_the_original(self):
+        session = _Session([_Response(403), _Response(403)])
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 403
+        assert [r[1] for r in d.reported] == [False, False]
+
+    def test_alternate_transport_failure_does_not_raise(self):
+        """The caller asked for a fetch; a bad second proxy must not turn a
+        403 into an exception the old code never raised."""
+        session = _Session(
+            [_Response(403), requests.exceptions.ConnectionError("refused")]
+        )
+        d = _discovery(session)
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 403
+        assert d.reported[-1] == (RouterProxy.MIZZOU_SQUID, False, "refused")
+
+
+class TestNoPointlessRetry:
+    def test_no_retry_when_the_alternate_resolves_to_the_same_box(self):
+        """MIZZOU_SQUID falls back onto home Squid when unconfigured, so the
+        two names can resolve to one address -- retrying there would just
+        re-ask the IP that was already refused."""
+        manager = _ProxyManager({RouterProxy.MIZZOU_SQUID: HOME})
+        session = _Session([_Response(403)])
+        d = _discovery(session, manager=manager)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert len(session.calls) == 1
+        assert d.reported == [(RouterProxy.HOME_SQUID, False, "HTTP 403")]
+
+    def test_no_retry_when_no_alternate_is_configured(self):
+        manager = _ProxyManager({RouterProxy.HOME_SQUID: HOME})
+        session = _Session([_Response(403)])
+        d = _discovery(session, manager=manager)
+
+        d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert len(session.calls) == 1
+
+    def test_manager_without_the_resolver_degrades_quietly(self):
+        """Test doubles built via __new__ may predate the resolver."""
+        session = _Session([_Response(403)])
+        d = _discovery(session, manager=types.SimpleNamespace())
+
+        response = d._fetch_with_ssl_fallback("https://example.com/")
+
+        assert response.status_code == 403
+        assert len(session.calls) == 1

--- a/tests/crawler/test_extraction_proxy_failover.py
+++ b/tests/crawler/test_extraction_proxy_failover.py
@@ -1,0 +1,237 @@
+"""Extraction must act on the router's decision, not just report to it.
+
+Two defects observed on the VTCNI extraction run, 2026-08-12.
+
+**The proxy was chosen once per domain and then cached.** The router is
+consulted only when a domain's session is built, and the choice is baked into
+``session.proxies``; every later request reuses that session. So when a
+challenge made the router back the proxy off for that domain, the router had
+learned and extraction had not -- it kept egressing through the refused address
+until an unrelated user-agent rotation happened to rebuild the session.
+
+**A challenge fell straight through to Selenium.** The same failure also puts
+the domain into CAPTCHA backoff, and that backoff makes the Selenium rung skip
+the browser. So one block cost the article twice: the HTTP fetch and the
+fallback meant to rescue it. Measured in the run's own log: Selenium was
+*skipped* 16 times against 14 actual attempts.
+
+A challenge is a statement about the address a request came from, not about the
+page -- the same URL routinely returns 200 from the second Squid.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Optional
+
+from src.crawler import ContentExtractor, ProxyChallengeError
+from src.crawler.proxy_config import ProxyManager
+from src.crawler.proxy_router import RouterProxy
+
+HOME = {"http": "http://home:3128", "https": "http://home:3128"}
+MIZZOU = {"http": "http://mizzou:3128", "https": "http://mizzou:3128"}
+DOMAIN = "example.com"
+URL = "https://example.com/story"
+
+
+class _ProxyManager:
+    """Stubs config lookup; the alternate-selection logic is production's."""
+
+    get_alternate_proxies = ProxyManager.get_alternate_proxies
+
+    def __init__(self, resolvable=None):
+        self._resolvable = (
+            resolvable
+            if resolvable is not None
+            else {RouterProxy.HOME_SQUID: HOME, RouterProxy.MIZZOU_SQUID: MIZZOU}
+        )
+        self.reported: list[tuple] = []
+        self.failures = 0
+
+    def get_requests_proxies_for_router_proxy(self, router_proxy):
+        return self._resolvable.get(router_proxy)
+
+    def get_requests_proxies_for_domain(self, domain, service="newscrawler"):
+        return HOME, RouterProxy.HOME_SQUID, "http"
+
+    def report_domain_result(self, domain, router_proxy, success, reason=None, **kw):
+        self.reported.append((router_proxy, success, reason))
+
+    def record_failure(self):
+        self.failures += 1
+
+
+def _extractor(manager: Optional[_ProxyManager] = None) -> ContentExtractor:
+    e = ContentExtractor.__new__(ContentExtractor)
+    e.proxy_manager = manager or _ProxyManager()
+    e.domain_sessions = {}
+    e.domain_router_proxy = {}
+    e.domain_user_agents = {}
+    e.request_counts = {}
+    e.last_request_times = {}
+    return e
+
+
+class TestBlockedProxyDropsTheCachedSession:
+    def test_session_is_forgotten_so_the_router_gets_asked_again(self):
+        e = _extractor()
+        e.domain_sessions[DOMAIN] = object()
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+
+        e._create_error_result(URL, "Cloudflare 403 bot protection")
+
+        assert DOMAIN not in e.domain_sessions
+        assert DOMAIN not in e.domain_router_proxy
+
+    def test_the_failure_is_still_reported_to_the_router(self):
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+
+        e._create_error_result(URL, "captcha challenge")
+
+        assert manager.reported[-1][0] is RouterProxy.HOME_SQUID
+        assert manager.reported[-1][1] is False
+
+    def test_an_ordinary_error_leaves_the_session_alone(self):
+        """Only proxy-shaped failures should cost a warm session."""
+        e = _extractor()
+        sentinel = object()
+        e.domain_sessions[DOMAIN] = sentinel
+
+        e._create_error_result(URL, "parse error: no article body found")
+
+        assert e.domain_sessions[DOMAIN] is sentinel
+
+
+class TestRetryThroughTheAlternateProxy:
+    def test_retry_uses_the_other_squid(self):
+        e = _extractor()
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        seen: dict[str, Any] = {}
+
+        def fake_unblock(
+            url, actions=None, metrics=None, domain=None, proxy_override=None
+        ):
+            seen["override"] = proxy_override
+            return {"content": "real body"}
+
+        e._extract_with_unblock_proxy = fake_unblock
+
+        result = e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None)
+
+        assert seen["override"] == MIZZOU
+        assert result["content"] == "real body"
+
+    def test_success_is_credited_to_the_proxy_that_worked(self):
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        e._extract_with_unblock_proxy = lambda *a, **k: {"content": "body"}
+
+        e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None)
+
+        assert (RouterProxy.MIZZOU_SQUID, True, None) in manager.reported
+
+    def test_a_second_challenge_returns_none_rather_than_raising(self):
+        """Both addresses refused is the caller's fall-through-to-Selenium
+        case, not a new exception for it to handle."""
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+
+        def refuse(*a, **k):
+            raise ProxyChallengeError("challenge_page")
+
+        e._extract_with_unblock_proxy = refuse
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert manager.reported[-1][:2] == (RouterProxy.MIZZOU_SQUID, False)
+
+    def test_no_retry_when_the_alternate_is_the_same_box(self):
+        """An unconfigured MIZZOU_SQUID resolves back onto home Squid."""
+        manager = _ProxyManager(
+            {RouterProxy.HOME_SQUID: HOME, RouterProxy.MIZZOU_SQUID: HOME}
+        )
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        called = []
+        e._extract_with_unblock_proxy = lambda *a, **k: called.append(1)
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert called == []
+
+    def test_no_retry_when_the_current_proxy_cannot_be_resolved(self):
+        """Without the current proxy's URL, "somewhere else" is unprovable --
+        so spending a request on it would be guesswork."""
+        manager = _ProxyManager({RouterProxy.MIZZOU_SQUID: MIZZOU})
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        called = []
+        e._extract_with_unblock_proxy = lambda *a, **k: called.append(1)
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert called == []
+
+    def test_no_domain_means_no_retry(self):
+        e = _extractor()
+        assert e._retry_unblock_via_alternate_proxy(URL, None, None) is None
+
+    def test_a_successful_retry_also_drops_the_stale_session(self):
+        e = _extractor()
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        e.domain_sessions[DOMAIN] = object()
+        e._extract_with_unblock_proxy = lambda *a, **k: {"content": "body"}
+
+        e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None)
+
+        assert DOMAIN not in e.domain_sessions
+
+
+class TestOverrideBypassesTheRouter:
+    def test_router_is_not_consulted_when_an_override_is_given(self, monkeypatch):
+        """Asking the router again would return the refused box, since backoff
+        is not instantaneous."""
+        manager = _ProxyManager()
+        asked = []
+        manager.get_requests_proxies_for_domain = lambda d, service=None: (
+            asked.append(d) or (HOME, RouterProxy.HOME_SQUID, "http")
+        )
+        e = _extractor(manager)
+
+        # The request itself cannot succeed (no network in tests); all this
+        # asserts is that routing was skipped before it was attempted.
+        with contextlib.suppress(Exception):
+            e._extract_with_unblock_proxy(
+                URL, None, None, domain=DOMAIN, proxy_override=MIZZOU
+            )
+
+        assert asked == []
+
+
+class TestNoRecordedProxy:
+    def test_domain_with_no_routed_proxy_skips_the_retry(self):
+        """domain_router_proxy has no entry until a session is built, so the
+        current proxy can be None -- there is nothing to be the alternate of."""
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        called = []
+        e._extract_with_unblock_proxy = lambda *a, **k: called.append(1)
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert called == []
+
+
+class TestRetryIsNeverFatal:
+    def test_extractor_without_routing_state_returns_none(self):
+        """The regression the pre-push hook caught.
+
+        Test doubles (and any ContentExtractor built via __new__) have neither
+        domain_router_proxy nor proxy_manager. Reading them unguarded turned a
+        stubbed ProxyChallengeError into an AttributeError and aborted the
+        whole extraction, breaking the flagged/unflagged challenge contract in
+        test_tls_capture_rung.
+        """
+        bare = ContentExtractor.__new__(ContentExtractor)
+
+        assert bare._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None

--- a/tests/services/test_classification_dataset_scope.py
+++ b/tests/services/test_classification_dataset_scope.py
@@ -1,0 +1,105 @@
+"""Classification can be scoped to a single dataset.
+
+Added for the VTCNI load: a new dataset arrives with thousands of unlabelled
+articles, and we want to classify only those without re-walking every other
+dataset's backlog in the same run.
+
+The tests select against a real session rather than asserting on a compiled
+statement, because the failure mode this guards is a flag that is accepted and
+then silently ignored -- which a shape check on the SQL would not catch. The
+first draft of this filter read `Article.dataset_id`, a column that does not
+exist: articles carry no dataset, the candidate link they were discovered
+through does.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.models import Article, Base, CandidateLink
+from src.services.classification_service import ArticleClassificationService
+
+DATASET_A = "vtcni"
+DATASET_B = "mizzou-missouri"
+
+
+@pytest.fixture()
+def session() -> Generator[Session, None, None]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    try:
+        with SessionLocal() as db:
+            yield db
+            db.rollback()
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def _add_article(session: Session, article_id: str, dataset_id: str | None) -> None:
+    link_id = f"link-{article_id}"
+    session.add(
+        CandidateLink(
+            id=link_id,
+            url=f"https://example.com/{article_id}",
+            source="example.com",
+            dataset_id=dataset_id,
+        )
+    )
+    session.add(
+        Article(
+            id=article_id,
+            candidate_link_id=link_id,
+            url=f"https://example.com/{article_id}",
+            title="Commission approves measure",
+            text="The county commission voted 4-1 on Tuesday.",
+            status="cleaned",
+            created_at=datetime(2026, 8, 11),
+        )
+    )
+    session.commit()
+
+
+def _select(session: Session, dataset_id: str | None) -> list[str]:
+    service = ArticleClassificationService(session=session)
+    articles = service._select_articles(
+        ["cleaned"],
+        "default",
+        None,
+        False,
+        None,
+        None,
+        dataset_id,
+    )
+    return sorted(str(article.id) for article in articles)
+
+
+def test_dataset_id_restricts_selection_to_that_dataset(session: Session) -> None:
+    _add_article(session, "a1", DATASET_A)
+    _add_article(session, "b1", DATASET_B)
+
+    assert _select(session, DATASET_A) == ["a1"]
+    assert _select(session, DATASET_B) == ["b1"]
+
+
+def test_no_dataset_id_selects_across_every_dataset(session: Session) -> None:
+    """The default stays corpus-wide -- existing scheduled runs must not narrow."""
+    _add_article(session, "a1", DATASET_A)
+    _add_article(session, "b1", DATASET_B)
+    _add_article(session, "n1", None)
+
+    assert _select(session, None) == ["a1", "b1", "n1"]
+
+
+def test_dataset_scoping_excludes_articles_with_no_dataset(session: Session) -> None:
+    """A NULL dataset_id is not a wildcard: those rows belong to no dataset."""
+    _add_article(session, "a1", DATASET_A)
+    _add_article(session, "n1", None)
+
+    assert _select(session, DATASET_A) == ["a1"]

--- a/tests/services/test_classification_service_unit.py
+++ b/tests/services/test_classification_service_unit.py
@@ -119,6 +119,7 @@ def test_apply_classification_dry_run_collects_proposed_labels(monkeypatch):
         include_existing,
         excluded,
         excluded_ids=None,
+        dataset_id=None,
     ):
         nonlocal call_count
         if call_count:
@@ -371,6 +372,7 @@ def test_apply_classification_handles_none_statuses(monkeypatch):
         include_existing,
         excluded,
         excluded_ids=None,
+        dataset_id=None,
     ):
         captured.update(
             {


### PR DESCRIPTION
Found while extracting the VTCNI dataset. A challenge page from one Squid cost the article **twice**, and the second Squid was never tried — despite the router correctly deciding it should be.

## Defect 1 — the router's decision never took effect

The proxy is chosen once per domain, when that domain's session is built, and baked into `session.proxies`. Every later request reuses the cached session without asking the router again.

So when a challenge made the router back that proxy off for the domain, **the router had learned and extraction had not** — it kept egressing through the refused address until an unrelated user-agent rotation happened to rebuild the session.

`_forget_domain_session()` now drops the cached session on a proxy-shaped failure, so the next request re-picks and gets the other box.

## Defect 2 — a challenge disabled the fallback meant to survive it

`ProxyChallengeError` fell straight through to Selenium. But the same failure puts the domain into CAPTCHA backoff, and that backoff makes the Selenium rung **skip the browser**.

From the run's own log: Selenium was *skipped* 16 times against 14 actual attempts.

```
Challenge page detected for loyolamaroon.com: proxy blocked
proxy_router: home_squid backed off for loyolamaroon.com
Attempting Selenium ... for missing fields
Skipping Selenium for loyolamaroon.com - domain is in CAPTCHA backoff period
Could not extract fields ... with any method
```

`_retry_unblock_via_alternate_proxy()` now re-runs the unblock rung through the other Squid *before* falling through, with `_extract_with_unblock_proxy` gaining a `proxy_override` so the retry doesn't re-ask the router (backoff isn't instantaneous, so it would hand back the box that was just refused).

## Why this is the right framing

A challenge is a statement about the **address a request came from**, not about the page. Measured earlier the same day: 20 sources that discovery found nothing for produced **535 URLs from 11 of them** when routed through the second Squid alone.

## Shared logic

Both call sites and discovery now share `ProxyManager.get_alternate_proxies()`. It compares resolved proxy **URLs** rather than `RouterProxy` names — an unconfigured `MIZZOU_SQUID` maps back onto home Squid, so two names can resolve to one box — and declines when the current proxy can't be resolved, because then "a different box" is unprovable and the retry would be guesswork.

## Testing

- Tests assert the behaviour that was missing, not the return value
- Negative control: stubbing both new paths back out fails 5 of them, so they aren't passing vacuously
- Full suite: 3,028 passed

Two defects in this PR were caught by the pre-push hook rather than by me, both in error-handling paths of code whose entire purpose is error handling:

1. `domain_router_proxy.get()` returns `None`, passed into a `RouterProxy` parameter (mypy)
2. Reading `self.domain_router_proxy` unguarded — every `ContentExtractor` built via `__new__` lacks it, so a stubbed challenge raised `AttributeError` and aborted extraction, breaking the flagged/unflagged contract in `test_tls_capture_rung`

Both now use guarded reads, with a test pinning that a bare extractor returns `None` rather than exploding.

## Not yet verified

Extraction was stopped after 60 articles to make this fix. The rerun on the fixed path will produce the first measured success rate — I have none, and earlier figures I quoted were arithmetic on config values, not measurements.