### PR TITLE
fix(extraction): act on the router's proxy decision instead of only reporting it

### DIFF
--- a/src/crawler/__init__.py
+++ b/src/crawler/__init__.py
@@ -2236,6 +2236,7 @@ class ContentExtractor:
                 reason=error_msg[:200],
                 service="newscrawler",
             )
+            self._forget_domain_session(domain)
 
         return {
             "url": url,
@@ -2249,6 +2250,135 @@ class ContentExtractor:
             "error": error_msg,
             "metadata": metadata or {},
         }
+
+    def _retry_unblock_via_alternate_proxy(
+        self,
+        url: str,
+        domain: Optional[str],
+        metrics: Optional["ExtractionMetrics"] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Re-run the unblock rung through the other Squid. None if there isn't one.
+
+        Never raises: a second ProxyChallengeError here means both addresses
+        were refused, which is the caller's existing "fall through to Selenium"
+        case, not a new failure mode to handle.
+        """
+        if domain is None:
+            return None
+
+        # Defensive reads: test doubles built via ContentExtractor.__new__()
+        # skip __init__ entirely, so neither attribute is guaranteed. A retry
+        # that cannot look up routing is simply not available -- it must not
+        # turn a challenge into an AttributeError and abort the extraction.
+        router_map = getattr(self, "domain_router_proxy", None)
+        proxy_manager = getattr(self, "proxy_manager", None)
+        if router_map is None or proxy_manager is None:
+            return None
+
+        current = router_map.get(domain)
+        if current is None:
+            # No recorded choice for this domain, so there is nothing to be the
+            # alternate *of*. Same reasoning as the unresolvable-URL case below:
+            # a retry we cannot show is going somewhere else is guesswork.
+            logger.info(
+                "No routed proxy recorded for %s; skipping alternate retry", domain
+            )
+            return None
+
+        try:
+            current_proxies = proxy_manager.get_requests_proxies_for_router_proxy(
+                current
+            )
+            alt_proxies, alt_proxy = proxy_manager.get_alternate_proxies(
+                current, current_proxies
+            )
+        except Exception as exc:  # routing must never break extraction
+            logger.warning("alternate-proxy lookup failed for %s: %s", domain, exc)
+            return None
+
+        if current_proxies is None:
+            # Without the current proxy's URL there is nothing to compare the
+            # alternate against, so "different box" cannot be established --
+            # and retrying through the address that was just refused costs a
+            # request and teaches the router nothing.
+            logger.info(
+                "Current proxy for %s is unresolvable; skipping alternate retry",
+                domain,
+            )
+            return None
+
+        if not alt_proxies:
+            logger.info(
+                "No alternate proxy configured; %s stays refused at %s",
+                domain,
+                getattr(current, "value", current),
+            )
+            return None
+
+        logger.info(
+            "🔁 Retrying %s through %s after a challenge on %s",
+            url,
+            getattr(alt_proxy, "value", alt_proxy),
+            getattr(current, "value", current),
+        )
+        try:
+            result = self._extract_with_unblock_proxy(
+                url, None, metrics, domain=domain, proxy_override=alt_proxies
+            )
+        except ProxyChallengeError as exc:
+            logger.info("Alternate proxy also refused %s: %s", url, exc)
+            self._report_proxy_outcome(
+                domain, alt_proxy, success=False, reason=str(exc)
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 - retry is best-effort
+            logger.warning("Alternate-proxy retry errored for %s: %s", url, exc)
+            return None
+
+        if result and result.get("content"):
+            self._report_proxy_outcome(domain, alt_proxy, success=True)
+            # The alternate worked, so let the next request for this domain
+            # re-pick rather than reusing the session built for the refused box.
+            self._forget_domain_session(domain)
+        return result
+
+    def _report_proxy_outcome(
+        self, domain: str, router_proxy, success: bool, reason: Optional[str] = None
+    ) -> None:
+        """Tell the router how a specific proxy fared, without ever raising."""
+        try:
+            self.proxy_manager.report_domain_result(
+                domain,
+                router_proxy,
+                success=success,
+                reason=(reason or "")[:200] or None,
+                service="newscrawler",
+            )
+        except Exception as exc:  # pragma: no cover - telemetry must not fail a fetch
+            logger.debug("report_domain_result failed for %s: %s", domain, exc)
+
+    def _forget_domain_session(self, domain: str) -> None:
+        """Drop the cached session for a domain after its proxy was blocked.
+
+        The proxy is chosen once, when the domain's session is built, and then
+        baked into ``session.proxies``; every later request for that domain
+        reuses the cached session without asking the router again. So when a
+        challenge causes the router to back this proxy off for the domain, the
+        router has learned and extraction has not -- it keeps sending through
+        the refused address until an unrelated user-agent rotation happens to
+        rebuild the session.
+
+        Forgetting the session is what makes the router's decision take
+        effect: the next request for this domain builds a fresh session and
+        calls get_requests_proxies_for_domain() again, which now returns the
+        other Squid because the first one is backed off.
+        """
+        self.domain_sessions.pop(domain, None)
+        self.domain_router_proxy.pop(domain, None)
+        logger.info(
+            "🔁 Dropped cached session for %s so the next request re-picks a proxy",
+            domain,
+        )
 
     def clear_all_sessions(self):
         """Clear all domain sessions and reset rotation state."""
@@ -3119,18 +3249,40 @@ class ContentExtractor:
                 logger.warning(f"❌ Proxy challenge for {url}: {e}")
                 if metrics:
                     metrics.end_method("unblock_proxy", False, str(e), {})
-                if domain_requires_unblock:
+
+                # A challenge is a statement about the ADDRESS the request came
+                # from, not about the page. Try the other Squid before giving up
+                # on HTTP: the same URL routinely returns 200 from the second
+                # box. Doing this here matters because the challenge also puts
+                # the domain into CAPTCHA backoff, and that backoff then makes
+                # _run_selenium_extraction skip the browser -- so without this
+                # retry a single block costs the article twice, on the fetch and
+                # on the fallback that was supposed to rescue it.
+                retry_result = self._retry_unblock_via_alternate_proxy(
+                    url, domain, metrics
+                )
+                if retry_result and retry_result.get("content"):
+                    self._merge_extraction_results(
+                        result, retry_result, "unblock_proxy", missing_fields, metrics
+                    )
+                    logger.info(
+                        "✅ Unblock proxy succeeded for %s via the alternate proxy",
+                        url,
+                    )
+                    if metrics:
+                        metrics.end_method("unblock_proxy", True, None, retry_result)
+                elif domain_requires_unblock:
                     # Flagged domains treat a challenge as terminal and mark the
                     # article for retry — Selenium won't help where the site has
                     # already refused this route.
                     raise
-                # As a general rung this is advisory: the disguise was refused,
-                # which says nothing about whether a real browser would be. Fall
-                # through so Selenium still gets its turn, exactly as before this
-                # rung existed for unflagged domains.
-                logger.info(
-                    "tls_client capture refused for %s; continuing to Selenium", url
-                )
+                else:
+                    # As a general rung this is advisory: the disguise was
+                    # refused, which says nothing about whether a real browser
+                    # would be. Fall through so Selenium still gets its turn.
+                    logger.info(
+                        "tls_client capture refused for %s; continuing to Selenium", url
+                    )
 
             except Exception as e:
                 logger.error(f"❌ Unblock proxy extraction failed for {url}: {e}")
@@ -4201,6 +4353,7 @@ class ContentExtractor:
         browser_actions: Optional[list] = None,
         metrics: Optional[ExtractionMetrics] = None,
         domain: Optional[str] = None,
+        proxy_override: Optional[dict] = None,
     ) -> Dict[str, Any]:
         """Extract content using Squid proxy for strong bot protection.
 
@@ -4231,7 +4384,12 @@ class ContentExtractor:
             # something unconfigured, so this can never end up direct.
             router_proxies = None
             router_proxy = None
-            if domain is not None:
+            if proxy_override:
+                # A caller retrying after a challenge already knows which box
+                # to use; asking the router again would just return the one
+                # that was refused, since backoff is not instantaneous.
+                router_proxies = proxy_override
+            elif domain is not None:
                 try:
                     router_proxies, router_proxy, _method = (
                         self.proxy_manager.get_requests_proxies_for_domain(

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -81,7 +81,6 @@ from src.utils.url_utils import normalize_url
 
 from ..models.database import DatabaseManager, safe_execute, safe_session_execute
 from .proxy_config import get_proxy_manager
-from .proxy_router import RouterProxy
 
 logger = logging.getLogger(__name__)
 
@@ -644,26 +643,19 @@ class NewsDiscovery:
     def _alternate_proxies_for_domain(self, current, current_proxies: dict | None):
         """The other configured proxy, or (None, None) if there isn't one.
 
-        Compares the resolved proxy URLs rather than the RouterProxy names.
-        get_requests_proxies_for_domain() maps an unconfigured MIZZOU_SQUID
-        back onto home Squid, so two different names can resolve to one box --
-        retrying there would just re-ask the address that was already refused.
+        Delegates to ProxyManager.get_alternate_proxies so discovery and
+        extraction answer "is there somewhere else to try?" identically; the
+        URL-vs-name comparison that matters is documented there.
         """
         proxy_manager = getattr(self, "proxy_manager", None)
         if proxy_manager is None or current is None:
             return None, None
 
-        resolve = getattr(proxy_manager, "get_requests_proxies_for_router_proxy", None)
+        resolve = getattr(proxy_manager, "get_alternate_proxies", None)
         if resolve is None:  # older manager / test double
             return None, None
 
-        for candidate in RouterProxy:
-            if candidate is current:
-                continue
-            proxies = resolve(candidate)
-            if proxies and proxies != current_proxies:
-                return proxies, candidate
-        return None, None
+        return resolve(current, current_proxies)
 
     def _note_capture_diagnosis(self, url: str, html: str | None) -> None:
         """Record WHY a capture might yield nothing, for this source.

--- a/src/crawler/proxy_config.py
+++ b/src/crawler/proxy_config.py
@@ -416,6 +416,30 @@ class ProxyManager:
             return None
         return _build_proxies_dict(provider)
 
+    def get_alternate_proxies(
+        self, current: Optional[RouterProxy], current_proxies: Optional[dict]
+    ) -> tuple[Optional[dict], Optional[RouterProxy]]:
+        """The other configured proxy, or (None, None) if there isn't one.
+
+        Compares the resolved proxy URLs rather than the RouterProxy names.
+        get_requests_proxies_for_domain() maps an unconfigured MIZZOU_SQUID
+        back onto home Squid, so two different names can resolve to the same
+        box -- retrying there would re-ask the address that just refused us,
+        which costs a request and teaches the router nothing.
+
+        Shared by discovery's fetch path and extraction's unblock rung so both
+        answer "is there somewhere else to try?" the same way.
+        """
+        if current is None:
+            return None, None
+        for candidate in RouterProxy:
+            if candidate is current:
+                continue
+            proxies = self.get_requests_proxies_for_router_proxy(candidate)
+            if proxies and proxies != current_proxies:
+                return proxies, candidate
+        return None, None
+
     def report_domain_result(
         self,
         domain: str,

--- a/tests/crawler/test_blocked_status_fails_over.py
+++ b/tests/crawler/test_blocked_status_fails_over.py
@@ -23,6 +23,7 @@ import pytest
 import requests
 
 from src.crawler.discovery import BLOCKED_STATUS_CODES, NewsDiscovery
+from src.crawler.proxy_config import ProxyManager
 from src.crawler.proxy_router import RouterProxy
 
 HOME = {"http": "http://home:3128", "https": "http://home:3128"}
@@ -51,6 +52,15 @@ class _Session:
 
 
 class _ProxyManager:
+    """Stubs only the config lookup; the selection logic is the real one.
+
+    get_alternate_proxies is bound straight off ProxyManager so these tests
+    exercise production's "is the other proxy actually different?" rule rather
+    than a reimplementation of it that could drift.
+    """
+
+    get_alternate_proxies = ProxyManager.get_alternate_proxies
+
     def __init__(self, resolvable=None):
         # RouterProxy -> proxies dict
         self._resolvable = resolvable or {

--- a/tests/crawler/test_extraction_proxy_failover.py
+++ b/tests/crawler/test_extraction_proxy_failover.py
@@ -1,0 +1,237 @@
+"""Extraction must act on the router's decision, not just report to it.
+
+Two defects observed on the VTCNI extraction run, 2026-08-12.
+
+**The proxy was chosen once per domain and then cached.** The router is
+consulted only when a domain's session is built, and the choice is baked into
+``session.proxies``; every later request reuses that session. So when a
+challenge made the router back the proxy off for that domain, the router had
+learned and extraction had not -- it kept egressing through the refused address
+until an unrelated user-agent rotation happened to rebuild the session.
+
+**A challenge fell straight through to Selenium.** The same failure also puts
+the domain into CAPTCHA backoff, and that backoff makes the Selenium rung skip
+the browser. So one block cost the article twice: the HTTP fetch and the
+fallback meant to rescue it. Measured in the run's own log: Selenium was
+*skipped* 16 times against 14 actual attempts.
+
+A challenge is a statement about the address a request came from, not about the
+page -- the same URL routinely returns 200 from the second Squid.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Optional
+
+from src.crawler import ContentExtractor, ProxyChallengeError
+from src.crawler.proxy_config import ProxyManager
+from src.crawler.proxy_router import RouterProxy
+
+HOME = {"http": "http://home:3128", "https": "http://home:3128"}
+MIZZOU = {"http": "http://mizzou:3128", "https": "http://mizzou:3128"}
+DOMAIN = "example.com"
+URL = "https://example.com/story"
+
+
+class _ProxyManager:
+    """Stubs config lookup; the alternate-selection logic is production's."""
+
+    get_alternate_proxies = ProxyManager.get_alternate_proxies
+
+    def __init__(self, resolvable=None):
+        self._resolvable = (
+            resolvable
+            if resolvable is not None
+            else {RouterProxy.HOME_SQUID: HOME, RouterProxy.MIZZOU_SQUID: MIZZOU}
+        )
+        self.reported: list[tuple] = []
+        self.failures = 0
+
+    def get_requests_proxies_for_router_proxy(self, router_proxy):
+        return self._resolvable.get(router_proxy)
+
+    def get_requests_proxies_for_domain(self, domain, service="newscrawler"):
+        return HOME, RouterProxy.HOME_SQUID, "http"
+
+    def report_domain_result(self, domain, router_proxy, success, reason=None, **kw):
+        self.reported.append((router_proxy, success, reason))
+
+    def record_failure(self):
+        self.failures += 1
+
+
+def _extractor(manager: Optional[_ProxyManager] = None) -> ContentExtractor:
+    e = ContentExtractor.__new__(ContentExtractor)
+    e.proxy_manager = manager or _ProxyManager()
+    e.domain_sessions = {}
+    e.domain_router_proxy = {}
+    e.domain_user_agents = {}
+    e.request_counts = {}
+    e.last_request_times = {}
+    return e
+
+
+class TestBlockedProxyDropsTheCachedSession:
+    def test_session_is_forgotten_so_the_router_gets_asked_again(self):
+        e = _extractor()
+        e.domain_sessions[DOMAIN] = object()
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+
+        e._create_error_result(URL, "Cloudflare 403 bot protection")
+
+        assert DOMAIN not in e.domain_sessions
+        assert DOMAIN not in e.domain_router_proxy
+
+    def test_the_failure_is_still_reported_to_the_router(self):
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+
+        e._create_error_result(URL, "captcha challenge")
+
+        assert manager.reported[-1][0] is RouterProxy.HOME_SQUID
+        assert manager.reported[-1][1] is False
+
+    def test_an_ordinary_error_leaves_the_session_alone(self):
+        """Only proxy-shaped failures should cost a warm session."""
+        e = _extractor()
+        sentinel = object()
+        e.domain_sessions[DOMAIN] = sentinel
+
+        e._create_error_result(URL, "parse error: no article body found")
+
+        assert e.domain_sessions[DOMAIN] is sentinel
+
+
+class TestRetryThroughTheAlternateProxy:
+    def test_retry_uses_the_other_squid(self):
+        e = _extractor()
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        seen: dict[str, Any] = {}
+
+        def fake_unblock(
+            url, actions=None, metrics=None, domain=None, proxy_override=None
+        ):
+            seen["override"] = proxy_override
+            return {"content": "real body"}
+
+        e._extract_with_unblock_proxy = fake_unblock
+
+        result = e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None)
+
+        assert seen["override"] == MIZZOU
+        assert result["content"] == "real body"
+
+    def test_success_is_credited_to_the_proxy_that_worked(self):
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        e._extract_with_unblock_proxy = lambda *a, **k: {"content": "body"}
+
+        e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None)
+
+        assert (RouterProxy.MIZZOU_SQUID, True, None) in manager.reported
+
+    def test_a_second_challenge_returns_none_rather_than_raising(self):
+        """Both addresses refused is the caller's fall-through-to-Selenium
+        case, not a new exception for it to handle."""
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+
+        def refuse(*a, **k):
+            raise ProxyChallengeError("challenge_page")
+
+        e._extract_with_unblock_proxy = refuse
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert manager.reported[-1][:2] == (RouterProxy.MIZZOU_SQUID, False)
+
+    def test_no_retry_when_the_alternate_is_the_same_box(self):
+        """An unconfigured MIZZOU_SQUID resolves back onto home Squid."""
+        manager = _ProxyManager(
+            {RouterProxy.HOME_SQUID: HOME, RouterProxy.MIZZOU_SQUID: HOME}
+        )
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        called = []
+        e._extract_with_unblock_proxy = lambda *a, **k: called.append(1)
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert called == []
+
+    def test_no_retry_when_the_current_proxy_cannot_be_resolved(self):
+        """Without the current proxy's URL, "somewhere else" is unprovable --
+        so spending a request on it would be guesswork."""
+        manager = _ProxyManager({RouterProxy.MIZZOU_SQUID: MIZZOU})
+        e = _extractor(manager)
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        called = []
+        e._extract_with_unblock_proxy = lambda *a, **k: called.append(1)
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert called == []
+
+    def test_no_domain_means_no_retry(self):
+        e = _extractor()
+        assert e._retry_unblock_via_alternate_proxy(URL, None, None) is None
+
+    def test_a_successful_retry_also_drops_the_stale_session(self):
+        e = _extractor()
+        e.domain_router_proxy[DOMAIN] = RouterProxy.HOME_SQUID
+        e.domain_sessions[DOMAIN] = object()
+        e._extract_with_unblock_proxy = lambda *a, **k: {"content": "body"}
+
+        e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None)
+
+        assert DOMAIN not in e.domain_sessions
+
+
+class TestOverrideBypassesTheRouter:
+    def test_router_is_not_consulted_when_an_override_is_given(self, monkeypatch):
+        """Asking the router again would return the refused box, since backoff
+        is not instantaneous."""
+        manager = _ProxyManager()
+        asked = []
+        manager.get_requests_proxies_for_domain = lambda d, service=None: (
+            asked.append(d) or (HOME, RouterProxy.HOME_SQUID, "http")
+        )
+        e = _extractor(manager)
+
+        # The request itself cannot succeed (no network in tests); all this
+        # asserts is that routing was skipped before it was attempted.
+        with contextlib.suppress(Exception):
+            e._extract_with_unblock_proxy(
+                URL, None, None, domain=DOMAIN, proxy_override=MIZZOU
+            )
+
+        assert asked == []
+
+
+class TestNoRecordedProxy:
+    def test_domain_with_no_routed_proxy_skips_the_retry(self):
+        """domain_router_proxy has no entry until a session is built, so the
+        current proxy can be None -- there is nothing to be the alternate of."""
+        manager = _ProxyManager()
+        e = _extractor(manager)
+        called = []
+        e._extract_with_unblock_proxy = lambda *a, **k: called.append(1)
+
+        assert e._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None
+        assert called == []
+
+
+class TestRetryIsNeverFatal:
+    def test_extractor_without_routing_state_returns_none(self):
+        """The regression the pre-push hook caught.
+
+        Test doubles (and any ContentExtractor built via __new__) have neither
+        domain_router_proxy nor proxy_manager. Reading them unguarded turned a
+        stubbed ProxyChallengeError into an AttributeError and aborted the
+        whole extraction, breaking the flagged/unflagged challenge contract in
+        test_tls_capture_rung.
+        """
+        bare = ContentExtractor.__new__(ContentExtractor)
+
+        assert bare._retry_unblock_via_alternate_proxy(URL, DOMAIN, None) is None


### PR DESCRIPTION
Found while extracting the VTCNI dataset. A challenge page from one Squid cost the article **twice**, and the second Squid was never tried — despite the router correctly deciding it should be.

Replaces #452, which was unmergeable: that branch kept commits already squash-merged as #450, so its history diverged from main. Same code, rebuilt cleanly on current main.

## Defect 1 — the router's decision never took effect

The proxy is chosen once per domain, when that domain's session is built, and baked into `session.proxies`. Every later request reuses the cached session without asking the router again.

So when a challenge made the router back that proxy off for the domain, **the router had learned and extraction had not** — it kept egressing through the refused address until an unrelated user-agent rotation happened to rebuild the session.

`_forget_domain_session()` now drops the cached session on a proxy-shaped failure, so the next request re-picks and gets the other box.

## Defect 2 — a challenge disabled the fallback meant to survive it

`ProxyChallengeError` fell straight through to Selenium. But the same failure puts the domain into CAPTCHA backoff, and that backoff makes the Selenium rung **skip the browser**.

From the run's own log, Selenium was *skipped* 16 times against 14 actual attempts:

```
Challenge page detected for loyolamaroon.com: proxy blocked
proxy_router: home_squid backed off for loyolamaroon.com
Attempting Selenium ... for missing fields
Skipping Selenium for loyolamaroon.com - domain is in CAPTCHA backoff period
Could not extract fields ... with any method
```

`_retry_unblock_via_alternate_proxy()` now re-runs the unblock rung through the other Squid *before* falling through, with `_extract_with_unblock_proxy` gaining a `proxy_override` so the retry doesn't re-ask the router (backoff isn't instantaneous, so it would hand back the box that was just refused).

## Why this framing

A challenge is a statement about the **address a request came from**, not about the page. Measured the same day: 20 sources discovery found nothing for produced **535 URLs from 11 of them** when routed through the second Squid alone.

## Shared logic

Both call sites and discovery now share `ProxyManager.get_alternate_proxies()`. It compares resolved proxy **URLs** rather than `RouterProxy` names — an unconfigured `MIZZOU_SQUID` maps back onto home Squid, so two names can resolve to one box — and declines when the current proxy can't be resolved, since then "a different box" is unprovable and the retry would be guesswork.

## Testing

- Tests assert the behaviour that was missing, not the return value
- Negative control: stubbing both new paths back out fails 5 of them, so they aren't passing vacuously
- Full suite: 3,028 passed

The pre-push hook caught two defects in this work, both in error-handling paths of code whose entire purpose is error handling:

1. `domain_router_proxy.get()` returns `None`, passed into a `RouterProxy` parameter (mypy)
2. Reading `self.domain_router_proxy` unguarded — every `ContentExtractor` built via `__new__` lacks it, so a stubbed challenge raised `AttributeError` and aborted extraction, breaking the flagged/unflagged contract in `test_tls_capture_rung`

Both now use guarded reads, with a test pinning that a bare extractor returns `None` rather than exploding.

## Not yet verified

Extraction was stopped after 60 articles to make this fix; 1,907 sampled links remain. The rerun on the fixed path will produce the first measured success rate.