### PR TITLE
Propose backfield enrichment as the final stage before export

### DIFF
--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -131,14 +131,29 @@ still reach `status='labeled'` despite the boilerplate work already done. One
 appeared in the 100-article sample:
 
 ```
-"Taylor Crouse" — 27,372 characters
-  "The provided text is not a news article; it is a list of website
-   cookie descriptions and technical settings."   — backfield's rationale
-  locations extracted: 0
+KQTV — "Taylor Crouse", 27,372 characters of cookie descriptions
+
+  our label       Civic information      confidence 0.429
+  our alternate   Economic Development   confidence 0.228
+  status          labeled  -> exportable to BigQuery
+  locations extracted by backfield: 0
   cost to process: $0.018, or 2.6x a typical article
+
+  backfield's rationale, unprompted:
+  "The provided text is not a news article; it is a list of website
+   cookie descriptions and technical settings."
 ```
 
-That article carries a CIN label and exports to BigQuery today.
+**This is a labelling defect, not a nuisance.** There is no story in that text,
+so there is nothing for a CIN label to describe. The classifier produced one
+anyway, at 0.43 confidence, and that low confidence stopped nothing: the article
+was promoted to `status='labeled'` and is exportable today. Two gaps meet here —
+no check that the text is a story, and no confidence floor on the promotion.
+
+Both belong **before CIN labelling**, not before enrichment. If junk never gets
+labelled it never reaches `status='labeled'`, never exports, and never costs an
+enrichment call. Placing the gate in this stage would catch it one step too late:
+the wrong label would already exist and would already have replicated.
 
 Two layers, cheapest first:
 
@@ -161,8 +176,9 @@ is long, so the true corpus rate is probably lower. The cost saving is real but
 small: the gate costs about $1.50 per 15,000 articles and saves a comparable
 amount. The reasons to do it are the other two:
 
-- **Corpus quality.** A cookie table should not carry a CIN label, contribute to
-  county coverage statistics, or reach BigQuery as a story.
+- **Label correctness.** A CIN label on text containing no story is wrong, and it
+  is currently indistinguishable in BigQuery from a label on a real article. It
+  contaminates coverage statistics and any analysis built on them.
 - **Regression detection.** The rejection rate is a monitor on the boilerplate
   stripping. A sudden rise means cleaning has broken upstream, and that is worth
   knowing on the day it happens rather than in a quarterly review.
@@ -170,6 +186,16 @@ amount. The reasons to do it are the other two:
 This overlaps existing statuses — `not_article` (1,051) and `paywall` (2,161)
 already exist — so the gate should feed the same vocabulary rather than invent a
 parallel one.
+
+### Two changes this implies outside this proposal
+
+Neither is enrichment work, and both should be considered on their own:
+
+1. **Run the content gate before CIN labelling.** It is described here because
+   this is where the evidence turned up, but its correct position is earlier.
+2. **Apply a confidence floor when promoting to `status='labeled'`.** A 0.43
+   primary label on 27KB of cookie text became exportable with nothing objecting.
+   Whatever the right threshold is, it is not "none".
 
 ```
 city_municipality        40      regional      17      statewide     12

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -58,7 +58,8 @@ yields `enrichment_skipped`, with the reason recorded:
 |---|---|
 | `profile_none` | The dataset asked for no enrichment |
 | `dataset_disabled` | Enrichment is off for this dataset entirely |
-| `operator_bypass` | Promoted by hand during an outage — see §9 |
+| `operator_bypass` | Released by hand during an outage — see §10 |
+| `failed_max_attempts` | Enrichment failed repeatedly; released so it still exports |
 
 Distinguishing these matters because two of them are policy and one is an
 incident. A month of `operator_bypass` articles is a gap in the data that someone
@@ -73,7 +74,7 @@ Three consequences worth being explicit about:
 - **Enrichment failure withholds export.** An article that errors stays at
   `labeled` and does not appear in BigQuery until it succeeds. This is the
   intended behaviour, and it makes the enrichment backlog an export backlog —
-  see §9.
+  see §10.
 - **The existing gate stays as the entry condition.** Nothing that fails wire
   checking or labelling becomes a candidate in the first place.
 
@@ -448,7 +449,59 @@ enrichment off.
 Recommended default for a new dataset: `content_gate` on, everything else off.
 Cheap, and it stops the known defect without committing to any spend.
 
-## 8. Data written
+## 8. Reprocessing: turning enrichment on later
+
+A dataset set to `none` today must be enrichable in a month by changing the
+profile, and the same must hold for articles that were bypassed during an outage
+or that failed. This is a first-class requirement, not a migration script.
+
+### Candidacy is a version comparison, not a status change
+
+**Do not re-queue by setting articles back to `labeled`.** They would stop
+matching the export criterion, and Datastream would withdraw them from BigQuery
+while they waited — briefly removing already-published rows because we decided to
+add a field to them.
+
+Instead the profile carries a version, each enrichment row records the version it
+was produced under, and candidacy is the comparison:
+
+```sql
+-- never processed
+status = 'labeled'
+-- or processed under an older profile than the dataset now asks for
+OR (status IN ('enriched', 'enrichment_skipped')
+    AND e.profile_version < d.profile_version)
+```
+
+Status is untouched throughout. An article stays exportable while it waits, while
+it is reprocessed, and afterwards. Enabling `people` on a dataset in October does
+not remove September's articles from BigQuery for an afternoon.
+
+### Only the delta is paid for
+
+The enrichment row records the steps actually applied. When a profile gains a
+step, the job runs **only the steps missing from that article**, not the profile
+from scratch. Turning on `people` for 15,000 already-enriched articles costs one
+call each, not ten.
+
+`operator_bypass` articles are the exception: nothing ran, so everything runs.
+
+### Cost of a change is knowable before it is made
+
+Because steps applied are recorded per article, the delta for a proposed profile
+change is a query, not a guess:
+
+```sql
+-- how many articles would a newly enabled step cost?
+SELECT count(*) FROM article_enrichment e
+JOIN articles a ON a.id = e.article_id
+WHERE NOT ('people' = ANY(e.steps_applied))
+```
+
+A profile change should report its estimated cost and article count before it is
+applied, for the same reason the job carries a spend ceiling.
+
+## 9. Data written
 
 New tables in the crawler database, all keyed on `article_id`. Datastream
 replicates them to BigQuery automatically — no export code, no schema
@@ -456,7 +509,7 @@ registration.
 
 | Table | Grain |
 |---|---|
-| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, **profile version, steps applied, `skip_reason` where relevant**, model and prompt versions, cost, `enriched_at` |
+| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, **`profile_version`, `steps_applied` (array, indexed), `skip_reason`**, model and prompt versions, cost, `enriched_at` |
 | `article_places` | One row per extracted location, with components, resolution method, and coordinates when resolved |
 | `article_people` | One row per person mention, with quotes |
 | `article_organizations` | One row per organization mention |
@@ -468,7 +521,7 @@ Idempotency comes from the candidate query: only `labeled` articles are picked
 up, so anything already `enriched` or `enrichment_skipped` is never re-billed. `enriched_at` records when, and the
 recorded model and prompt versions scope any future reprocessing.
 
-## 9. Failure handling
+## 10. Failure handling
 
 Because export now depends on this stage, its failure modes are export failure
 modes.
@@ -490,13 +543,18 @@ modes.
   oldest unenriched candidate, not a dashboard nobody opens. An OpenRouter outage,
   a rate-limit change or an expired key now stops the export feed, which was not
   true before.
+- **A permanently failing article must not be withheld forever.** After a bounded
+  number of attempts it takes `enrichment_skipped` with
+  `skip_reason='failed_max_attempts'`, so it exports and remains a candidate for
+  reprocessing under §8. Without this, one article backfield cannot parse is one
+  article BigQuery never sees, and nobody finds out.
 - **A bypass is required.** If enrichment is broken or too expensive to run,
   there must be a supported way to release `labeled` articles without enriching
   them. That path sets `enrichment_skipped` with
   `skip_reason='operator_bypass'`, never `enriched`, so an outage is later
   distinguishable from a policy decision and from real enrichment.
 
-## 10. Open decisions
+## 11. Open decisions
 
 **Backfield's CIN does not replace ours. Decided.** Our classifier stays
 authoritative. The `information_needs` preset is excluded from the production
@@ -541,7 +599,7 @@ the h3 finding in §2 starts to matter. Deferrable, expensive to retrofit.
 Some are legitimate — a Branson paper covering Springfield. Rule 2 would place
 them wrongly. Worth reading before the backfill.
 
-## 11. Suggested sequence
+## 12. Suggested sequence
 
 1. Tune the boilerplate heuristic and the content gate against known-bad
    articles, and measure the rejection rate on a fresh sample drawn without the

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -14,20 +14,39 @@ a vendor claim or an estimate where a measurement was possible.
 ## 1. Where it fits
 
 ```
-discover → extract → clean → wire check → CIN label → [ENRICH] → Datastream → BigQuery
-                                              ↓
-                                    status = 'labeled'
+discover → extract → clean → wire check → CIN label → ENRICH → Datastream → BigQuery
+                                              ↓                    ↓
+                                     status='labeled'      status='enriched'
+                                     (candidate)           (exportable)
 ```
 
-The stage runs on articles that already satisfy the export gate and have not yet
-been enriched:
+**The export criterion changes.** Today BigQuery takes
+`status='labeled' AND wire_check_status='complete'`. It will instead take
+`status='enriched'`, applied only after this stage completes successfully.
+
+Enrichment stops being an optional trailer on the pipeline and becomes the last
+required step. `labeled` becomes a candidate state, not an exportable one.
+
+The stage selects its work as:
 
 ```sql
-status = 'labeled' AND wire_check_status = 'complete' AND enriched_at IS NULL
+status = 'labeled' AND wire_check_status = 'complete'
 ```
 
-That gate is the existing one — `src/cli/commands/extraction.py` documents
-BigQuery as exporting `status='labeled' AND wire_check_status='complete'`.
+and on success sets `status = 'enriched'`.
+
+Three consequences worth being explicit about:
+
+- **Junk cannot export.** An article rejected by the content gate in §3 never
+  becomes `enriched`, so it never reaches BigQuery, whatever CIN label it was
+  given. The cookie-text defect closes by construction rather than by adding a
+  check earlier in the pipeline.
+- **Enrichment failure withholds export.** An article that errors stays at
+  `labeled` and does not appear in BigQuery until it succeeds. This is the
+  intended behaviour, and it makes the enrichment backlog an export backlog —
+  see §8.
+- **The existing gate stays as the entry condition.** Nothing that fails wire
+  checking or labelling becomes a candidate in the first place.
 
 **Scope is the `Mizzou-Missouri-State` dataset.** The other datasets in the
 database (VT Community News, WSU Washington State) are out of scope for this
@@ -64,8 +83,9 @@ The remaining ~82,000 historical articles are deliberately out of scope. They ca
 be added later without rework: `enriched_at` is the idempotency key, so widening
 the window is a query change, and nothing already enriched is re-billed.
 
-Enrichment adds no new qualification rule. If an article is fit to export, it is
-fit to enrich.
+Enrichment adds no new *entry* rule — everything that qualifies today becomes a
+candidate. What it adds is an exit rule: an article exports when it has been
+enriched, or not at all.
 
 ## 2. Why backfield runs as a library, not a platform
 
@@ -187,15 +207,17 @@ This overlaps existing statuses — `not_article` (1,051) and `paywall` (2,161)
 already exist — so the gate should feed the same vocabulary rather than invent a
 parallel one.
 
-### Two changes this implies outside this proposal
+### Where the gate belongs, given the new export criterion
 
-Neither is enrichment work, and both should be considered on their own:
+Inside this stage. Because export requires `enriched`, an article the gate
+rejects never exports regardless of the label it carries, so the defect is closed
+without touching the labelling step.
 
-1. **Run the content gate before CIN labelling.** It is described here because
-   this is where the evidence turned up, but its correct position is earlier.
-2. **Apply a confidence floor when promoting to `status='labeled'`.** A 0.43
-   primary label on 27KB of cookie text became exportable with nothing objecting.
-   Whatever the right threshold is, it is not "none".
+One related change remains worth considering separately: **a confidence floor on
+CIN labelling**. The cookie article was labelled `Civic information` at 0.429 and
+promoted to `labeled` with nothing objecting. That wrong label will no longer
+reach BigQuery, but it is still wrong, still stored, and still visible to anyone
+reading the database directly.
 
 ```
 city_municipality        40      regional      17      statewide     12
@@ -347,20 +369,37 @@ registration.
 Every row records the model id, the backfield commit, and the prompt preset
 version, so a reprocessing decision can be scoped to exactly what changed.
 
-`enriched_at` on `articles` is the idempotency key. Re-running the job never
-re-bills an article that has already succeeded.
+`status='enriched'` is both the export criterion and the idempotency key.
+Re-running the job never re-bills an article that has already succeeded, because
+enriched articles are no longer candidates. `enriched_at` records when, and the
+recorded model and prompt versions scope any future reprocessing.
 
 ## 8. Failure handling
 
+Because export now depends on this stage, its failure modes are export failure
+modes.
+
 - One article failing must not fail a batch. Errors are recorded per article with
-  the exception type and the step that failed; the article stays unenriched and
+  the exception type and the step that failed; the article stays at `labeled` and
   is retried on the next run.
 - A batch is committed per article, not per run, so a job killed mid-way loses
   nothing already paid for.
 - Cost is recorded per article. A daily spend ceiling stops the job rather than
   discovering the overrun on an invoice.
-- Enrichment failure never blocks export. An article with `enriched_at IS NULL`
-  still replicates to BigQuery with its existing fields.
+- **Failure and rejection must be distinguishable.** An article rejected as not
+  being a story is terminal and should take the existing `not_article` or
+  `paywall` status. An article that failed a call is transient and stays at
+  `labeled` for retry. Collapsing the two either loses junk into the retry queue
+  forever or silently discards real stories.
+- **The backlog is now visible or it is invisible.** Articles stuck at `labeled`
+  are articles missing from BigQuery. This needs an alert on the age of the
+  oldest unenriched candidate, not a dashboard nobody opens. An OpenRouter outage,
+  a rate-limit change or an expired key now stops the export feed, which was not
+  true before.
+- **A bypass is required.** If enrichment is broken or too expensive to run,
+  there must be a supported way to promote `labeled` articles to `enriched`
+  without enrichment, so a vendor problem cannot indefinitely withhold the
+  corpus.
 
 ## 9. Open decisions
 

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -378,22 +378,94 @@ window — which removes most of the operational risk from the first real run.
 The job is I/O-bound on the API, not CPU-bound, so one or two existing spot nodes
 are sufficient. Concurrency is limited by OpenRouter rate limits, not by us.
 
-## 6. Running it on GCP
+## 6. Containerisation and resource footprint
 
 | | |
 |---|---|
 | Compute | Kubernetes `CronJob` on the existing `mizzou-cluster`, spot pool |
 | Database | The crawler's existing Cloud SQL — new tables, no new instance |
-| Image | Crawler base plus backfield's packages, pinned to a backfield commit |
-| Secrets | OpenRouter key, and a geocoder key if step 4 is enabled |
+| Secrets | OpenRouter key; a geocoder key only if step 4 is enabled |
 | Redis, Celery, backfield APIs | Not used |
 
-Incremental infrastructure cost is a few dollars per month of spot compute plus
-storage. There is no new managed service.
+### Base image alignment
 
-Backfield is pre-1.0 and its own documentation says self-hosting is unsupported.
-Pin an exact commit, treat upgrades as deliberate work, and keep the node calls
-behind a thin adapter so a breaking change touches one module.
+Backfield requires Python 3.11. `Dockerfile.base` is
+`python:3.11-slim-bookworm`. They align, and the enrichment image builds from the
+crawler base.
+
+**Not from `Dockerfile.processor`.** The processor derives from the ML base and
+carries spacy, transformers, scikit-learn and their model weights. Enrichment
+performs no local inference — it makes HTTP calls to OpenRouter — so none of that
+is reachable code. Building from the processor image would multiply the image for
+no benefit.
+
+Measured: importing the four extraction nodes pulls in `backfield_db`,
+`backfield_entities`, `sqlalchemy` and `litellm`, and does **not** pull in
+`torch` or `transformers`.
+
+### What is shared and what is added
+
+Already present in the crawler base and reused unchanged:
+
+`sqlalchemy`, `requests`, `pydantic`, `structlog`, `psycopg2-binary`,
+`cloud-sql-python-connector` — plus the crawler's own session handling, config
+loading, telemetry and the `articles` model.
+
+Added by backfield, measured from site-packages:
+
+| Package | Size | Needed for |
+|---|---|---|
+| `litellm` | 84 MB | Every model call |
+| `pycountry` | 22 MB | Place normalisation |
+| `openai` | 10 MB | litellm provider shim |
+| `anthropic` | 9 MB | litellm provider shim |
+| `shapely` | 6 MB | Geometry |
+| `h3`, `langgraph` | 3 MB each | Cell index; agent graph |
+| `geopy`, `usaddress`, `overpy`, `us`, `duckduckgo-search`, `boto3` | 1–2 MB each | Geocoding paths |
+
+Roughly **150 MB added** over the crawler base.
+
+`boto3` and `duckduckgo-search` are declared dependencies of `backfield-agate`
+but are reachable only from the S3 input/output nodes and web-search fallback,
+which this design does not call. They are installed because they are hard
+dependencies, not because they are used.
+
+### Minimising the footprint
+
+1. **Build from `Dockerfile.base`, not `Dockerfile.processor`.** This is the
+   single largest saving and requires no other change.
+2. **Multi-stage build**, copying only the finished `site-packages` into the
+   runtime stage, as `Dockerfile.base` already does.
+3. **Do not install `requirements-processor.txt`.** Enrichment needs no ML stack.
+4. **Pin backfield to a commit**, installed as packages rather than a checkout.
+5. **Import lazily where possible.** `litellm` is 84 MB and dominates both image
+   size and import time.
+
+### Runtime resources
+
+Measured: importing the four nodes reaches **306 MB RSS** before any article is
+processed, essentially all of it `litellm` and its provider shims.
+
+| | |
+|---|---|
+| Memory request | 512 Mi |
+| Memory limit | 1 Gi |
+| CPU request | 250 m |
+
+The work is I/O-bound on the OpenRouter API. Concurrency is achieved with threads
+inside one pod rather than more pods, so a single small pod at concurrency 10–50
+is the whole deployment. Scaling out costs memory per replica for no throughput
+gain, since the limit is the API, not the CPU.
+
+Spot nodes are appropriate: the job is interruptible and idempotent, and a killed
+run loses only the articles in flight.
+
+### Version pinning
+
+Backfield is pre-1.0 and its documentation states that self-hosting is
+unsupported. Pin an exact commit, treat upgrades as deliberate work, and keep the
+node calls behind a thin adapter module so a breaking change touches one file.
+The adapter is also the seam the tests in §11 exercise.
 
 ## 7. Per-dataset enrichment profiles
 
@@ -509,11 +581,192 @@ WHERE NOT ('people' = ANY(e.steps_applied))
 A profile change should report its estimated cost and article count before it is
 applied, for the same reason the job carries a spend ceiling.
 
-## 9. Data written
+## 9. Schema
 
 New tables in the crawler database, all keyed on `article_id`. Datastream
 replicates them to BigQuery automatically — no export code, no schema
 registration.
+
+All samples below are real output from
+`openrouter/deepseek/deepseek-v3.2` on one article: *"Meet Diane Grimes,
+candidate for Warren County Ambulance District Board of Directors"*.
+
+### `articles` — two added columns
+
+```sql
+ALTER TABLE articles
+  ADD COLUMN enriched_at        timestamp,
+  ADD COLUMN enrichment_attempts smallint NOT NULL DEFAULT 0;
+```
+
+`status` gains `enriched` and `enrichment_skipped`. `enrichment_attempts` bounds
+retries before `failed_max_attempts` (§10).
+
+### `article_enrichment` — one row per article
+
+```sql
+CREATE TABLE article_enrichment (
+  article_id            text PRIMARY KEY REFERENCES articles(id) ON DELETE CASCADE,
+
+  -- provenance and reprocessing control
+  profile_version       integer NOT NULL,
+  steps_applied         text[]  NOT NULL,
+  skip_reason           text,              -- profile_none | dataset_disabled |
+                                           -- operator_bypass | failed_max_attempts
+  backfield_commit      text    NOT NULL,
+  model                 text    NOT NULL,
+  prompt_versions       jsonb   NOT NULL,
+  cost_usd              numeric(10,6),
+  enriched_at           timestamptz NOT NULL DEFAULT now(),
+
+  -- content gate
+  is_news_content       boolean,
+  content_gate_reason   text,
+
+  -- one column per metadata preset, each with its confidence
+  scope                 text,  scope_confidence      real,
+  subject               text,  subject_confidence    real,
+  topic                 text,  topic_confidence      real,
+  format                text,  format_confidence     real,
+  timeframe             text,  timeframe_confidence  real,
+  user_need             text,  user_need_confidence  real,
+  rationales            jsonb,             -- preset -> rationale text
+
+  -- resolved location, when scope is point-level
+  point_place           text,
+  point_method          text,              -- single_city | publication_city | geocoded
+  point_lat             double precision,
+  point_lon             double precision,
+  point_gnis            text
+);
+CREATE INDEX ON article_enrichment USING gin (steps_applied);
+CREATE INDEX ON article_enrichment (profile_version);
+```
+
+Sample values:
+
+| Column | Value |
+|---|---|
+| `scope` | `city_municipality` |
+| `subject` | `election` (0.95) |
+| `topic` | `local_government_politics` (0.95) |
+| `format` | `profile` (0.95) |
+| `timeframe` | `future` (0.90) |
+| `user_need` | `show_me_the_community` (0.85) |
+| `steps_applied` | `{content_gate,scope,places,people,organizations,subject,topic,format,timeframe,user_need}` |
+| `point_method` | `publication_city` |
+
+### `article_places` — one row per extracted location
+
+```sql
+CREATE TABLE article_places (
+  id            bigserial PRIMARY KEY,
+  article_id    text NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+  full_name     text,
+  place_type    text,          -- city | place | street_road | county | state | ...
+  city          text,
+  county        text,
+  state         text,
+  address       text,
+  description   text,          -- why the place is in the story
+  mention_text  text,          -- the sentence it came from
+  is_point      boolean,       -- did this become the article's resolved point
+  lat           double precision,
+  lon           double precision,
+  geocoder      text
+);
+CREATE INDEX ON article_places (article_id);
+CREATE INDEX ON article_places (city, state);
+```
+
+Sample row:
+
+```json
+{
+  "full_name": "Warrenton, MO",
+  "place_type": "city",
+  "city": "Warrenton",
+  "state": "MO",
+  "description": "City where the Warren County Ambulance District is based.",
+  "mention_text": "Warren County Ambulance District Board of Directors",
+  "is_point": true
+}
+```
+
+A mean of **6.5 rows per article** (648 across the 100-article sample). Most
+articles produce several; 11 of 100 produced none.
+
+### `article_people` — one row per person
+
+```sql
+CREATE TABLE article_people (
+  id            bigserial PRIMARY KEY,
+  article_id    text NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+  name          text NOT NULL,
+  sort_key      text,
+  title         text,
+  affiliation   text,
+  person_type   text,          -- elected_official | resident | expert | ...
+  role_in_story text,
+  nature        text,          -- subject | source | mentioned
+  public_figure boolean,
+  mention_count integer,
+  quotes        jsonb          -- quoted passages attributed to this person
+);
+CREATE INDEX ON article_people (article_id);
+CREATE INDEX ON article_people (sort_key);
+```
+
+Sample row:
+
+```json
+{
+  "name": "Diane Grimes",
+  "sort_key": "grimes",
+  "title": "Finance administrator/business owner",
+  "person_type": "elected_official",
+  "role_in_story": "Candidate for Warren County Ambulance District Board of Directors",
+  "nature": "subject",
+  "public_figure": false
+}
+```
+
+### `article_organizations` — one row per organization
+
+```sql
+CREATE TABLE article_organizations (
+  id            bigserial PRIMARY KEY,
+  article_id    text NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+  name          text NOT NULL,
+  org_type      text,          -- public_services | business | nonprofit | ...
+  boundary      text,
+  role_in_story text,
+  nature        text,
+  mention_count integer
+);
+CREATE INDEX ON article_organizations (article_id);
+```
+
+Sample row:
+
+```json
+{
+  "name": "Warren County Ambulance District",
+  "org_type": "public_services",
+  "role_in_story": "Governing body for ambulance services in the county",
+  "nature": "subject"
+}
+```
+
+### Notes on the shape
+
+- `sort_key` and `name` are the join keys a future canonicalization step would
+  use. Storing them now costs nothing and avoids reprocessing later.
+- `quotes` is `jsonb` rather than a table because quotes are only ever read with
+  their person.
+- Confidence is stored for every classification. Nothing downstream currently
+  filters on it, but the cookie-text defect (§3) is the argument for keeping it.
+- No embeddings. `pgvector` is available on Cloud SQL if that changes.
 
 | Table | Grain |
 |---|---|
@@ -562,7 +815,66 @@ modes.
   `skip_reason='operator_bypass'`, never `enriched`, so an outage is later
   distinguishable from a policy decision and from real enrichment.
 
-## 11. Open decisions
+## 11. Testing
+
+The adapter module is the seam. Backfield's nodes are third-party code and are
+not retested here; what is tested is our use of them, our decisions, and our
+writes.
+
+### Unit tests — no database, no network
+
+Model calls are stubbed with recorded fixtures captured from real runs.
+
+| Area | Assertions |
+|---|---|
+| Profile resolution | All / some / none produce the right step list; unknown keys rejected; missing profile falls back to the default |
+| Status transitions | Full profile → `enriched`; empty profile → `enrichment_skipped` + `profile_none`; gate rejection → `not_article`; call failure → stays `labeled` and increments attempts; attempts exhausted → `enrichment_skipped` + `failed_max_attempts` |
+| Point resolution | One city → that city; several cities + publication city among them → publication city; several cities without it → unresolved; zero cities → unresolved |
+| Scope gating | `regional`, `statewide`, `national`, `international`, `other` never reach place extraction |
+| Content gate | Cookie-text fixture rejected; a normal article passes; the gate reads only the truncated prefix |
+| Reprocessing candidacy | Older `profile_version` selects; equal does not; `steps_applied` yields only the missing steps |
+| Response parsing | Malformed JSON, absent `category`, confidence out of range, and unexpected category values all fail the article rather than writing a bad row |
+| Cost accounting | Recorded cost matches token counts; the ceiling halts the run |
+
+Point resolution and status transitions carry the most consequence and no
+external dependency, so they should be table-driven with the real cases from the
+100-article sample as fixtures.
+
+### Integration tests — real Postgres, stubbed models
+
+Run against the existing test Postgres, in the pattern already used by the
+crawler suite.
+
+| Area | Assertions |
+|---|---|
+| Writes | All four tables populate; `article_places` yields multiple rows for one article; cascade delete removes children |
+| Idempotency | A second run selects nothing and writes nothing |
+| Export criterion | Only `enriched` and `enrichment_skipped` match; `labeled` and `not_article` do not |
+| **Reprocessing does not withdraw rows** | An article exportable before a profile bump is exportable at every point during and after reprocessing. This is the failure mode in §8 and the one test that must never be skipped. |
+| Explicit id list | Non-candidate ids are reported and skipped; the run total accounts for every id supplied |
+| Partial failure | One article failing leaves the others committed |
+| Migration | The migration applies to a copy of the production schema and rolls back |
+
+### Contract tests — real API, run on demand
+
+Not in CI on every branch; on demand and before a backfield version bump.
+
+- Each node returns the fields the adapter reads, against a live model call.
+- A backfield upgrade is validated by re-running the 100-article sample and
+  diffing categories, not merely by the suite passing.
+
+The second is the one that catches a prompt change upstream. Editing a preset's
+few-shot examples changed 2 of 4 classifications in testing (§11), so backfield
+changing its own prompts can move labels without any error surfacing.
+
+### Fixtures worth committing
+
+The 100-article sample already produced the awkward cases: a 27,372-character
+cookie-text article, an article yielding 41 locations, 11 yielding none, and the
+8 point-scope articles that stayed ambiguous. These are the fixtures, and they
+are real rather than invented.
+
+## 12. Open decisions
 
 **Backfield's CIN does not replace ours. Decided.** Our classifier stays
 authoritative. The `information_needs` preset is excluded from the production
@@ -588,6 +900,18 @@ the property required of an audit.
 Used this way it is an audit instrument for our taxonomy rather than a
 replacement classifier. Cost is one call per sampled article, $0.00078.
 
+**Rationale phrasing.** Rationales open with "The article is/describes/profiles"
+in almost every case. Three options, measured:
+
+| Approach | Effect | Cost |
+|---|---|---|
+| `BACKFIELD_PROJECT_SYSTEM_PROMPT` | Shortens rationales; **does not** remove the opening — the preset's few-shot examples anchor it | None |
+| Fork the preset with rewritten examples | Removed the opening in 2 of 4, **and changed 2 of 4 classifications** | Maintaining a copy of the prompt; requires re-validation |
+| Strip the preamble after the fact | Deterministic, cannot affect labels | A regex to maintain |
+
+Forking is not a cosmetic change: it moves labels. Post-processing is the only
+option that alters presentation without altering classification.
+
 **"Civic Life" versus "Civic information".** Both exist in our taxonomy, both map
 to the same concept, and six of the 37 disagreements are churn between them. This
 should be resolved regardless of what happens with backfield.
@@ -607,7 +931,7 @@ the h3 finding in §2 starts to matter. Deferrable, expensive to retrofit.
 Some are legitimate — a Branson paper covering Springfield. Rule 2 would place
 them wrongly. Worth reading before the backfill.
 
-## 12. Suggested sequence
+## 13. Suggested sequence
 
 1. Tune the boilerplate heuristic and the content gate against known-bad
    articles, and measure the rejection rate on a fresh sample drawn without the

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -102,15 +102,35 @@ Qualifying articles per month, by publish date:
 The spread is crawler throughput, not seasonality — extraction has been stopped
 for parts of this period. Plan against the busy months: **12,000–17,500**.
 
-### The backfill is March only
+### Two input modes
 
-**Scope of the initial backfill is roughly 15,000 articles from March 2026**, not
-the 99,418 historical total. March has 17,441 qualifying articles, so the target
-is a subset of one month.
+**Steady state is the primary mode.** Every article collected from here on passes
+through this stage before export. The recurring figures in §4 and §5 are the ones
+that govern the decision; the backfill is a one-off.
 
-The remaining ~82,000 historical articles are deliberately out of scope. They can
-be added later without rework: `enriched_at` is the idempotency key, so widening
-the window is a query change, and nothing already enriched is re-billed.
+**Backfill takes an explicit article list.** The set is supplied as article ids,
+not derived from a date range. March 2026 is the working scale — 17,441 articles
+qualify, and the list is expected to be roughly 15,000 — but selection is not a
+`publish_date` predicate and should not be implemented as one.
+
+| Mode | Selection |
+|---|---|
+| Steady state | The candidate query, on a schedule |
+| Backfill | A supplied list of article ids |
+
+A supplied list is a selection, not an override. Listed articles pass through the
+same content gate and the same dataset profile as any other: an article on the
+list that is cookie text is still rejected, and one whose dataset profile is
+`none` is still skipped. The list decides *which* articles are considered, not
+*what happens to them*.
+
+Ids on the list that are not candidates — already enriched, never labelled, wire
+— are reported and skipped rather than silently dropped, so a list of 15,000 that
+processes 12,000 says why.
+
+The remaining historical articles are out of scope for now and require no rework
+to add later: candidacy is the version comparison in §8, and nothing already
+processed is re-billed.
 
 Enrichment adds no new *entry* rule — everything that qualifies today becomes a
 candidate. What it adds is an exit rule: an article exports when it has been
@@ -315,14 +335,14 @@ authoritative and backfield's runs only in development — see §9.
 
 | | |
 |---|---|
-| **Backfill, ~15,000 from March** | **$100–113** one-time |
+| **Backfill, a ~15,000-article list** | **$100–113** one-time |
 | Ongoing, busy month (12,000–17,500) | **$80–131** |
 | Ongoing, slow month (1,000–5,300) | **$7–40** |
 | For reference: all 99,418 historical | $666–745, not planned |
 
-At this size the backfill costs about the same as one busy month of ongoing
-enrichment. The recurring figure, not the backfill, is the number that matters
-for the decision.
+The backfill costs about the same as one busy month. Since every article
+collected from here on passes through this stage, the recurring figure is the one
+that governs the decision.
 
 Two levers not yet applied, each worth measuring before the backfill:
 
@@ -347,7 +367,7 @@ A full 9–10 call pipeline is roughly 3 seconds per article at that concurrency
 
 | | At 10 workers | At 50 workers |
 |---|---|---|
-| **Backfill, ~15,000 from March** | **~12 hours** | **~2.5 hours** |
+| **Backfill, a ~15,000-article list** | **~12 hours** | **~2.5 hours** |
 | Busy month, incremental (~580/day) | ~27 minutes/day | — |
 | For reference: all 99,418 | ~3.2 days | ~15 hours |
 
@@ -596,10 +616,10 @@ them wrongly. Worth reading before the backfill.
    The rule is validated; the output is not.
 3. Measure prompt caching and preset consolidation on 100 articles.
 4. Build the adapter and the four tables; run 1,000 articles end to end.
-5. Backfill March, rate-limited, with the spend ceiling armed — one overnight run,
-   ~$100.
-6. Enable the `CronJob` for incremental articles.
-7. Decide later whether to widen the window beyond March. Nothing in the design
-   forecloses it.
+5. Enable the `CronJob` for new collection. This is the steady state and the
+   reason for the work.
+6. Run the supplied backfill list, rate-limited, with the spend ceiling armed —
+   one overnight run, ~$100.
+7. Decide later whether to process the remaining history. Nothing forecloses it.
 
 Steps 1 to 3 cost a few cents each and should gate the rest.

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -21,8 +21,11 @@ discover → extract → clean → wire check → CIN label → ENRICH → Datas
 ```
 
 **The export criterion changes.** Today BigQuery takes
-`status='labeled' AND wire_check_status='complete'`. It will instead take
-`status='enriched'`, applied only after this stage completes successfully.
+`status='labeled' AND wire_check_status='complete'`. It will instead take:
+
+```sql
+status IN ('enriched', 'enrichment_skipped')
+```
 
 Enrichment stops being an optional trailer on the pipeline and becomes the last
 required step. `labeled` becomes a candidate state, not an exportable one.
@@ -33,16 +36,39 @@ The stage selects its work as:
 status = 'labeled' AND wire_check_status = 'complete'
 ```
 
-and on success sets `status = 'enriched'`.
+### Status vocabulary
 
-`enriched` means **every step configured for that article's dataset has
-completed** — not that every possible step ran. See §7.
+`enriched` means backfield ran. It does not mean "eligible for export", because
+conflating those two makes the corpus unable to answer "which articles were
+actually enriched?" — a question that matters as soon as profiles differ between
+datasets.
+
+| Status | Set when | Exports | Terminal |
+|---|---|---|---|
+| `labeled` | Candidate, or enrichment failed and will retry | No | No |
+| `enriched` | Backfield ran every step the dataset's profile asked for | **Yes** | Yes |
+| `enrichment_skipped` | No backfield call was made — see `skip_reason` | **Yes** | Yes |
+| `not_article`, `paywall` | Content gate rejected the text | No | Yes |
+
+A dataset running *some* enrichments still yields `enriched`; the steps actually
+applied are recorded on the row (§7). Only a complete absence of backfield work
+yields `enrichment_skipped`, with the reason recorded:
+
+| `skip_reason` | Meaning |
+|---|---|
+| `profile_none` | The dataset asked for no enrichment |
+| `dataset_disabled` | Enrichment is off for this dataset entirely |
+| `operator_bypass` | Promoted by hand during an outage — see §9 |
+
+Distinguishing these matters because two of them are policy and one is an
+incident. A month of `operator_bypass` articles is a gap in the data that someone
+should be able to find later without reading deploy logs.
 
 Three consequences worth being explicit about:
 
-- **Junk cannot export.** An article rejected by the content gate in §3 never
-  becomes `enriched`, so it never reaches BigQuery, whatever CIN label it was
-  given. The cookie-text defect closes by construction rather than by adding a
+- **Junk cannot export.** An article rejected by the content gate in §3 takes a
+  terminal `not_article` or `paywall` status, which is in neither exportable
+  state, whatever CIN label it was given. The cookie-text defect closes by construction rather than by adding a
   check earlier in the pipeline.
 - **Enrichment failure withholds export.** An article that errors stays at
   `labeled` and does not appear in BigQuery until it succeeds. This is the
@@ -383,11 +409,15 @@ The profile is held on the dataset, defaulted, and versioned:
 |---|---|
 | **All** | Every step in §3 runs |
 | **Some** | Only the named steps run; the rest are skipped, not failed |
-| **None** | No backfield call is made; the article is marked `enriched` immediately and exports |
+| **None** | No backfield call is made; the article is marked `enrichment_skipped` with `skip_reason='profile_none'` and exports |
 
 A `none` profile still produces an `article_enrichment` row, recording that the
 profile was empty. An article must never be stranded at `labeled` because its
 dataset asked for nothing.
+
+Note the asymmetry: *some* yields `enriched`, *none* yields `enrichment_skipped`.
+The line is whether backfield was called at all, so that `enriched` always means
+the same thing regardless of which dataset an article came from.
 
 ### Absent and disabled are not the same
 
@@ -426,7 +456,7 @@ registration.
 
 | Table | Grain |
 |---|---|
-| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, **profile version and steps applied**, model and prompt versions, cost, `enriched_at` |
+| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, **profile version, steps applied, `skip_reason` where relevant**, model and prompt versions, cost, `enriched_at` |
 | `article_places` | One row per extracted location, with components, resolution method, and coordinates when resolved |
 | `article_people` | One row per person mention, with quotes |
 | `article_organizations` | One row per organization mention |
@@ -434,9 +464,8 @@ registration.
 Every row records the model id, the backfield commit, and the prompt preset
 version, so a reprocessing decision can be scoped to exactly what changed.
 
-`status='enriched'` is both the export criterion and the idempotency key.
-Re-running the job never re-bills an article that has already succeeded, because
-enriched articles are no longer candidates. `enriched_at` records when, and the
+Idempotency comes from the candidate query: only `labeled` articles are picked
+up, so anything already `enriched` or `enrichment_skipped` is never re-billed. `enriched_at` records when, and the
 recorded model and prompt versions scope any future reprocessing.
 
 ## 9. Failure handling
@@ -462,9 +491,10 @@ modes.
   a rate-limit change or an expired key now stops the export feed, which was not
   true before.
 - **A bypass is required.** If enrichment is broken or too expensive to run,
-  there must be a supported way to promote `labeled` articles to `enriched`
-  without enrichment, so a vendor problem cannot indefinitely withhold the
-  corpus.
+  there must be a supported way to release `labeled` articles without enriching
+  them. That path sets `enrichment_skipped` with
+  `skip_reason='operator_bypass'`, never `enriched`, so an outage is later
+  distinguishable from a policy decision and from real enrichment.
 
 ## 10. Open decisions
 

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -38,10 +38,9 @@ status = 'labeled' AND wire_check_status = 'complete'
 
 ### Status vocabulary
 
-`enriched` means backfield ran. It does not mean "eligible for export", because
-conflating those two makes the corpus unable to answer "which articles were
-actually enriched?" — a question that matters as soon as profiles differ between
-datasets.
+`enriched` means backfield ran; it does not mean eligible for export. Conflating
+the two leaves the corpus unable to distinguish enriched articles from skipped
+ones once dataset profiles differ.
 
 | Status | Set when | Exports | Terminal |
 |---|---|---|---|
@@ -61,11 +60,11 @@ yields `enrichment_skipped`, with the reason recorded:
 | `operator_bypass` | Released by hand during an outage — see §10 |
 | `failed_max_attempts` | Enrichment failed repeatedly; released so it still exports |
 
-Distinguishing these matters because two of them are policy and one is an
-incident. A month of `operator_bypass` articles is a gap in the data that someone
-should be able to find later without reading deploy logs.
+Two of these are policy and two are incidents. The distinction must survive in
+the data: a period of `operator_bypass` articles is a gap that has to be
+identifiable later without reference to deploy logs.
 
-Three consequences worth being explicit about:
+Consequences:
 
 - **Junk cannot export.** An article rejected by the content gate in §3 takes a
   terminal `not_article` or `paywall` status, which is in neither exportable
@@ -194,16 +193,10 @@ KQTV — "Taylor Crouse", 27,372 characters of cookie descriptions
    cookie descriptions and technical settings."
 ```
 
-**This is a labelling defect, not a nuisance.** There is no story in that text,
-so there is nothing for a CIN label to describe. The classifier produced one
-anyway, at 0.43 confidence, and that low confidence stopped nothing: the article
-was promoted to `status='labeled'` and is exportable today. Two gaps meet here —
-no check that the text is a story, and no confidence floor on the promotion.
-
-Both belong **before CIN labelling**, not before enrichment. If junk never gets
-labelled it never reaches `status='labeled'`, never exports, and never costs an
-enrichment call. Placing the gate in this stage would catch it one step too late:
-the wrong label would already exist and would already have replicated.
+This is a labelling defect. The text contains no story, so no CIN label
+describes it. The classifier produced one at 0.429 confidence and the article was
+promoted to `status='labeled'`. Two gaps produce this: no check that the text is
+a story, and no confidence floor on the promotion.
 
 Two layers, cheapest first:
 
@@ -220,11 +213,10 @@ tokens, about $0.0001. It answers one question: is this the text of a news story
 
 Rejected articles are flagged and skip every subsequent step.
 
-**Be clear about what this is worth.** The frequency measured was 1 in 100, and
-the sample was drawn from articles at or above median length — junk of this kind
-is long, so the true corpus rate is probably lower. The cost saving is real but
-small: the gate costs about $1.50 per 15,000 articles and saves a comparable
-amount. The reasons to do it are the other two:
+Measured frequency was 1 in 100, on a sample drawn from articles at or above
+median length. Junk of this kind is long, so the corpus rate is likely lower. The
+gate costs roughly $1.50 per 15,000 articles and saves a comparable amount; the
+cost case is neutral. The two operative reasons:
 
 - **Label correctness.** A CIN label on text containing no story is wrong, and it
   is currently indistinguishable in BigQuery from a label on a real article. It
@@ -416,14 +408,13 @@ A `none` profile still produces an `article_enrichment` row, recording that the
 profile was empty. An article must never be stranded at `labeled` because its
 dataset asked for nothing.
 
-Note the asymmetry: *some* yields `enriched`, *none* yields `enrichment_skipped`.
-The line is whether backfield was called at all, so that `enriched` always means
-the same thing regardless of which dataset an article came from.
+A partial profile yields `enriched`; only the absence of any backfield call
+yields `enrichment_skipped`. The criterion is whether backfield was called, so
+`enriched` carries the same meaning across datasets.
 
 ### Absent and disabled are not the same
 
-This is the part that will bite downstream if it is not carried into the data. A
-missing place list can mean three different things:
+A missing place list has three possible meanings:
 
 | | Meaning |
 |---|---|
@@ -431,20 +422,19 @@ missing place list can mean three different things:
 | Step ran, found nothing | A real, negative finding |
 | Step failed | Unknown; the article should not be `enriched` at all |
 
-So every enrichment row records the profile version and the steps actually
-applied, and BigQuery consumers filter on those rather than on `NULL`. Without
-it, "no people were found" and "we did not look for people" are the same query
-result, and any analysis over a mixed-profile corpus is wrong in a way nobody
-will notice.
+Every enrichment row therefore records the profile version and the steps
+actually applied, and BigQuery consumers filter on those rather than on `NULL`.
+Without this, "no people were found" and "people were not extracted" are the same
+query result, and any analysis spanning datasets with different profiles is
+incorrect.
 
-### The content gate is switchable, and that has a cost
+### The content gate is switchable
 
-`content_gate` is listed separately because it is the one step whose absence
-changes what reaches BigQuery rather than how much is known about it. A dataset
-running `none` exports its cookie-text articles, as happens today. That may be
-the right call for a dataset being ingested for volume rather than analysis, but
-it should be a decision recorded in the profile, not a side effect of turning
-enrichment off.
+`content_gate` is separately switchable because it changes what reaches BigQuery
+rather than what is known about it. A dataset running `none` exports cookie-text
+articles, as happens today. That may be correct for a dataset ingested for volume
+rather than analysis, but it is recorded in the profile rather than implied by
+disabling enrichment.
 
 Recommended default for a new dataset: `content_gate` on, everything else off.
 Cheap, and it stops the known defect without committing to any spend.
@@ -457,13 +447,12 @@ or that failed. This is a first-class requirement, not a migration script.
 
 ### Candidacy is a version comparison, not a status change
 
-**Do not re-queue by setting articles back to `labeled`.** They would stop
-matching the export criterion, and Datastream would withdraw them from BigQuery
-while they waited — briefly removing already-published rows because we decided to
-add a field to them.
+Re-queuing by setting articles back to `labeled` would stop them matching the
+export criterion, and Datastream would withdraw already-published rows from
+BigQuery for the duration of reprocessing.
 
-Instead the profile carries a version, each enrichment row records the version it
-was produced under, and candidacy is the comparison:
+The profile therefore carries a version, each enrichment row records the version
+it was produced under, and candidacy is a comparison:
 
 ```sql
 -- never processed
@@ -473,9 +462,8 @@ OR (status IN ('enriched', 'enrichment_skipped')
     AND e.profile_version < d.profile_version)
 ```
 
-Status is untouched throughout. An article stays exportable while it waits, while
-it is reprocessed, and afterwards. Enabling `people` on a dataset in October does
-not remove September's articles from BigQuery for an afternoon.
+Status is unchanged throughout. An article remains exportable while queued,
+during reprocessing, and afterwards.
 
 ### Only the delta is paid for
 
@@ -572,13 +560,13 @@ worth keeping for that purpose:
 | Upheld a deliberately wrong label (control) | 5 of 100 |
 | Same verdict regardless of the label shown | 92 of 100 |
 
-The disagreements are mostly ours: "Civic Life" absorbed a movie review, a
-holiday store-hours listing and a real-estate promo. The control run matters more
-than the agreement rate — a model that ratifies whatever it is shown would be
-useless as a check, and this one does not.
+Most disagreements are errors in our labels: "Civic Life" was applied to a movie
+review, a holiday store-hours listing and a real-estate promotion. The control
+run establishes that the model does not ratify the label it is shown, which is
+the property required of an audit.
 
-Used this way it is an audit instrument for our taxonomy, not a replacement
-classifier. Cost is negligible: one call per sampled article, $0.00078.
+Used this way it is an audit instrument for our taxonomy rather than a
+replacement classifier. Cost is one call per sampled article, $0.00078.
 
 **"Civic Life" versus "Civic information".** Both exist in our taxonomy, both map
 to the same concept, and six of the 37 disagreements are churn between them. This

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -112,7 +112,9 @@ one. Measured on the 100-article sample.
 
 | Step | Runs on | Calls | Purpose |
 |---|---|---|---|
-| 1. `geographic_scope` | every article | 1 | Decides whether a point location is meaningful at all |
+| 0a. Boilerplate heuristic | every article | 0 | Free; rejects text that is plainly not a story |
+| 0b. Content gate | survivors | 1 (truncated) | Rejects what the heuristic misses |
+| 1. `geographic_scope` | real stories only | 1 | Decides whether a point location is meaningful at all |
 | 2. `place_extract` | point-scope articles only (46%) | 1 | Mentions, with parsed components |
 | 3. Resolve the point | point-scope articles | 0 | Single city, else the publication's city — see below |
 | 4. `geocode_agent` | unresolved POI-level only (~8%) | many | Backfield's agentic geocoder |
@@ -121,6 +123,53 @@ one. Measured on the 100-article sample.
 
 **Step 1 before step 2 is the main saving.** Scope costs one call and excludes
 54% of articles from place extraction entirely.
+
+### Step 0: reject text that is not a story
+
+Articles that are entirely cookie notices, consent tables or paywall furniture
+still reach `status='labeled'` despite the boilerplate work already done. One
+appeared in the 100-article sample:
+
+```
+"Taylor Crouse" — 27,372 characters
+  "The provided text is not a news article; it is a list of website
+   cookie descriptions and technical settings."   — backfield's rationale
+  locations extracted: 0
+  cost to process: $0.018, or 2.6x a typical article
+```
+
+That article carries a CIN label and exports to BigQuery today.
+
+Two layers, cheapest first:
+
+**0a. A deterministic heuristic, free.** Density of cookie, consent, privacy
+policy, vendor list and advertising-partner terms. Five or more occurrences
+identified exactly the one junk article in the sample and nothing else. This runs
+in Python with no API call and should be tuned against known-bad articles before
+it is trusted to reject anything.
+
+**0b. A truncated LLM gate for what the heuristic misses.** Cookie and paywall
+text is identifiable from the opening few hundred characters, so this call sends
+**the first ~800 characters, not the article** — roughly 250 input and 30 output
+tokens, about $0.0001. It answers one question: is this the text of a news story?
+
+Rejected articles are flagged and skip every subsequent step.
+
+**Be clear about what this is worth.** The frequency measured was 1 in 100, and
+the sample was drawn from articles at or above median length — junk of this kind
+is long, so the true corpus rate is probably lower. The cost saving is real but
+small: the gate costs about $1.50 per 15,000 articles and saves a comparable
+amount. The reasons to do it are the other two:
+
+- **Corpus quality.** A cookie table should not carry a CIN label, contribute to
+  county coverage statistics, or reach BigQuery as a story.
+- **Regression detection.** The rejection rate is a monitor on the boilerplate
+  stripping. A sudden rise means cleaning has broken upstream, and that is worth
+  knowing on the day it happens rather than in a quarterly review.
+
+This overlaps existing statuses — `not_article` (1,051) and `paywall` (2,161)
+already exist — so the gate should feed the same vocabulary rather than invent a
+parallel one.
 
 ```
 city_municipality        40      regional      17      statewide     12
@@ -183,6 +232,7 @@ cost per call             $0.00078   (DeepSeek V3.1 rates: $0.25/M in, $0.95/M o
 
 | | Per article |
 |---|---|
+| Content gate, truncated input | $0.0001 |
 | `geographic_scope` | $0.0008 |
 | Metadata, 5 remaining presets | $0.0039 |
 | `place_extract` on 46% of articles | $0.0004 |
@@ -333,14 +383,17 @@ them wrongly. Worth reading before the backfill.
 
 ## 10. Suggested sequence
 
-1. Confirm the resolved points on the 100-article sample are actually correct.
+1. Tune the boilerplate heuristic and the content gate against known-bad
+   articles, and measure the rejection rate on a fresh sample drawn without the
+   length bias in this one.
+2. Confirm the resolved points on the 100-article sample are actually correct.
    The rule is validated; the output is not.
-2. Measure prompt caching and preset consolidation on 100 articles.
-3. Build the adapter and the four tables; run 1,000 articles end to end.
-4. Backfill March, rate-limited, with the spend ceiling armed — one overnight run,
+3. Measure prompt caching and preset consolidation on 100 articles.
+4. Build the adapter and the four tables; run 1,000 articles end to end.
+5. Backfill March, rate-limited, with the spend ceiling armed — one overnight run,
    ~$100.
-5. Enable the `CronJob` for incremental articles.
-6. Decide later whether to widen the window beyond March. Nothing in the design
+6. Enable the `CronJob` for incremental articles.
+7. Decide later whether to widen the window beyond March. Nothing in the design
    forecloses it.
 
-Steps 1 and 2 cost a few cents each and should gate the rest.
+Steps 1 to 3 cost a few cents each and should gate the rest.

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -35,6 +35,9 @@ status = 'labeled' AND wire_check_status = 'complete'
 
 and on success sets `status = 'enriched'`.
 
+`enriched` means **every step configured for that article's dataset has
+completed** — not that every possible step ran. See §7.
+
 Three consequences worth being explicit about:
 
 - **Junk cannot export.** An article rejected by the content gate in §3 never
@@ -44,7 +47,7 @@ Three consequences worth being explicit about:
 - **Enrichment failure withholds export.** An article that errors stays at
   `labeled` and does not appear in BigQuery until it succeeds. This is the
   intended behaviour, and it makes the enrichment backlog an export backlog —
-  see §8.
+  see §9.
 - **The existing gate stays as the entry condition.** Nothing that fails wire
   checking or labelling becomes a candidate in the first place.
 
@@ -353,7 +356,69 @@ Backfield is pre-1.0 and its own documentation says self-hosting is unsupported.
 Pin an exact commit, treat upgrades as deliberate work, and keep the node calls
 behind a thin adapter so a breaking change touches one module.
 
-## 7. Data written
+## 7. Per-dataset enrichment profiles
+
+Datasets differ in what they are for. A dataset must be able to run all of the
+enrichments, some of them, or none — and reach BigQuery either way. Enrichment is
+a required *step*, not a required *result*.
+
+The profile is held on the dataset, defaulted, and versioned:
+
+```jsonc
+// datasets.metadata -> "enrichment_profile"
+{
+  "version": 1,
+  "content_gate": true,          // independently switchable, on by default
+  "scope": true,
+  "places": true,
+  "geocode": false,              // needs a geocoder key
+  "people": true,
+  "organizations": true,
+  "metadata_presets": ["subject", "topic", "format",
+                       "temporal_orientation", "user_need"]
+}
+```
+
+| Profile | Behaviour |
+|---|---|
+| **All** | Every step in §3 runs |
+| **Some** | Only the named steps run; the rest are skipped, not failed |
+| **None** | No backfield call is made; the article is marked `enriched` immediately and exports |
+
+A `none` profile still produces an `article_enrichment` row, recording that the
+profile was empty. An article must never be stranded at `labeled` because its
+dataset asked for nothing.
+
+### Absent and disabled are not the same
+
+This is the part that will bite downstream if it is not carried into the data. A
+missing place list can mean three different things:
+
+| | Meaning |
+|---|---|
+| Step disabled for the dataset | Not attempted; absence carries no information |
+| Step ran, found nothing | A real, negative finding |
+| Step failed | Unknown; the article should not be `enriched` at all |
+
+So every enrichment row records the profile version and the steps actually
+applied, and BigQuery consumers filter on those rather than on `NULL`. Without
+it, "no people were found" and "we did not look for people" are the same query
+result, and any analysis over a mixed-profile corpus is wrong in a way nobody
+will notice.
+
+### The content gate is switchable, and that has a cost
+
+`content_gate` is listed separately because it is the one step whose absence
+changes what reaches BigQuery rather than how much is known about it. A dataset
+running `none` exports its cookie-text articles, as happens today. That may be
+the right call for a dataset being ingested for volume rather than analysis, but
+it should be a decision recorded in the profile, not a side effect of turning
+enrichment off.
+
+Recommended default for a new dataset: `content_gate` on, everything else off.
+Cheap, and it stops the known defect without committing to any spend.
+
+## 8. Data written
 
 New tables in the crawler database, all keyed on `article_id`. Datastream
 replicates them to BigQuery automatically — no export code, no schema
@@ -361,7 +426,7 @@ registration.
 
 | Table | Grain |
 |---|---|
-| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, model and prompt versions, cost, `enriched_at` |
+| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, **profile version and steps applied**, model and prompt versions, cost, `enriched_at` |
 | `article_places` | One row per extracted location, with components, resolution method, and coordinates when resolved |
 | `article_people` | One row per person mention, with quotes |
 | `article_organizations` | One row per organization mention |
@@ -374,7 +439,7 @@ Re-running the job never re-bills an article that has already succeeded, because
 enriched articles are no longer candidates. `enriched_at` records when, and the
 recorded model and prompt versions scope any future reprocessing.
 
-## 8. Failure handling
+## 9. Failure handling
 
 Because export now depends on this stage, its failure modes are export failure
 modes.
@@ -401,7 +466,7 @@ modes.
   without enrichment, so a vendor problem cannot indefinitely withhold the
   corpus.
 
-## 9. Open decisions
+## 10. Open decisions
 
 **Backfield's CIN does not replace ours. Decided.** Our classifier stays
 authoritative. The `information_needs` preset is excluded from the production
@@ -446,7 +511,7 @@ the h3 finding in §2 starts to matter. Deferrable, expensive to retrofit.
 Some are legitimate — a Branson paper covering Springfield. Rule 2 would place
 them wrongly. Worth reading before the backfill.
 
-## 10. Suggested sequence
+## 11. Suggested sequence
 
 1. Tune the boilerplate heuristic and the content gate against known-bad
    articles, and measure the rejection rate on a fresh sample drawn without the

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -54,6 +54,16 @@ Qualifying articles per month, by publish date:
 The spread is crawler throughput, not seasonality — extraction has been stopped
 for parts of this period. Plan against the busy months: **12,000–17,500**.
 
+### The backfill is March only
+
+**Scope of the initial backfill is roughly 15,000 articles from March 2026**, not
+the 99,418 historical total. March has 17,441 qualifying articles, so the target
+is a subset of one month.
+
+The remaining ~82,000 historical articles are deliberately out of scope. They can
+be added later without rework: `enriched_at` is the idempotency key, so widening
+the window is a query change, and nothing already enriched is re-billed.
+
 Enrichment adds no new qualification rule. If an article is fit to export, it is
 fit to enrich.
 
@@ -185,9 +195,14 @@ authoritative and backfield's runs only in development — see §9.
 
 | | |
 |---|---|
-| Backfill 99,418 | **$666–745** one-time |
+| **Backfill, ~15,000 from March** | **$100–113** one-time |
 | Ongoing, busy month (12,000–17,500) | **$80–131** |
 | Ongoing, slow month (1,000–5,300) | **$7–40** |
+| For reference: all 99,418 historical | $666–745, not planned |
+
+At this size the backfill costs about the same as one busy month of ongoing
+enrichment. The recurring figure, not the backfill, is the number that matters
+for the decision.
 
 Two levers not yet applied, each worth measuring before the backfill:
 
@@ -212,8 +227,13 @@ A full 9–10 call pipeline is roughly 3 seconds per article at that concurrency
 
 | | At 10 workers | At 50 workers |
 |---|---|---|
-| Backfill 99,418 | ~3.2 days | ~15 hours |
+| **Backfill, ~15,000 from March** | **~12 hours** | **~2.5 hours** |
 | Busy month, incremental (~580/day) | ~27 minutes/day | — |
+| For reference: all 99,418 | ~3.2 days | ~15 hours |
+
+A March-only backfill is a single overnight run at modest concurrency. It does not
+need the higher concurrency tier, and it does not need to survive a multi-day
+window — which removes most of the operational risk from the first real run.
 
 The job is I/O-bound on the API, not CPU-bound, so one or two existing spot nodes
 are sufficient. Concurrency is limited by OpenRouter rate limits, not by us.
@@ -317,7 +337,10 @@ them wrongly. Worth reading before the backfill.
    The rule is validated; the output is not.
 2. Measure prompt caching and preset consolidation on 100 articles.
 3. Build the adapter and the four tables; run 1,000 articles end to end.
-4. Backfill, rate-limited, with the spend ceiling armed.
+4. Backfill March, rate-limited, with the spend ceiling armed — one overnight run,
+   ~$100.
 5. Enable the `CronJob` for incremental articles.
+6. Decide later whether to widen the window beyond March. Nothing in the design
+   forecloses it.
 
 Steps 1 and 2 cost a few cents each and should gate the rest.

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -106,7 +106,7 @@ one. Measured on the 100-article sample.
 | 2. `place_extract` | point-scope articles only (46%) | 1 | Mentions, with parsed components |
 | 3. Resolve the point | point-scope articles | 0 | Single city, else the publication's city — see below |
 | 4. `geocode_agent` | unresolved POI-level only (~8%) | many | Backfield's agentic geocoder |
-| 5. Remaining metadata presets | every article | 5–6 | subject, topic, format, timeframe, user need, and CIN if adopted |
+| 5. Remaining metadata presets | every article | 5 | subject, topic, format, timeframe, user need |
 | 6. `person_extract`, `organization_extract` | every article | 2 | People with quotes; organizations |
 
 **Step 1 before step 2 is the main saving.** Scope costs one call and excludes
@@ -173,26 +173,29 @@ cost per call             $0.00078   (DeepSeek V3.1 rates: $0.25/M in, $0.95/M o
 
 | | Per article |
 |---|---|
-| Metadata, 6 presets | $0.0047 |
-| Metadata, 7 presets (with CIN) | $0.0055 |
+| `geographic_scope` | $0.0008 |
+| Metadata, 5 remaining presets | $0.0039 |
 | `place_extract` on 46% of articles | $0.0004 |
 | `person_extract` + `organization_extract` | $0.0016 |
 | Geocoding on ~8% | <$0.0002 |
-| **Total** | **≈$0.007–0.008** |
+| **Total** | **≈$0.0067–0.0075** |
+
+`information_needs` is **not** in this total. Our CIN classifier remains
+authoritative and backfield's runs only in development — see §9.
 
 | | |
 |---|---|
-| Backfill 99,418 | **$700–795** one-time |
-| Ongoing, busy month (12,000–17,500) | **$84–140** |
-| Ongoing, slow month (1,000–5,300) | **$7–42** |
+| Backfill 99,418 | **$666–745** one-time |
+| Ongoing, busy month (12,000–17,500) | **$80–131** |
+| Ongoing, slow month (1,000–5,300) | **$7–40** |
 
 Two levers not yet applied, each worth measuring before the backfill:
 
-- **Prompt caching.** The preset prompts total ~11,000 tokens and are identical
+- **Prompt caching.** The six production prompts total ~9,000 tokens and are identical
   across every article; roughly 74% of each call's input is this stable prefix.
   DeepSeek bills cache reads at $0.13/M against $0.25/M. Putting the article last
   in the message should cut input cost materially.
-- **Preset consolidation.** Seven presets send the article seven times. Combining
+- **Preset consolidation.** Six presets send the article six times. Combining
   them into fewer calls would send it once, at some risk to per-category quality.
   Worth an A/B on 100 articles before adopting.
 
@@ -265,15 +268,29 @@ re-bills an article that has already succeeded.
 
 ## 9. Open decisions
 
-**Whether backfield's CIN replaces ours.** Tested on 100 articles: 51% exact
-agreement, 65% allowing our alternate label or their multi-label set. The
-disagreements are mostly ours being wrong — "Civic Life" is a catch-all that
-absorbed a movie review, a holiday store-hours listing and a real-estate promo.
-A control run that showed the model deliberately wrong labels had it uphold only
-5 of 100, and it reached the same verdict regardless of the label it was shown in
-92 of 100 cases, so it is not merely ratifying whatever it is given. Adopting it
-costs one extra call per article; running both and storing them side by side
-costs the same and defers the decision.
+**Backfield's CIN does not replace ours. Decided.** Our classifier stays
+authoritative. The `information_needs` preset is excluded from the production
+path, which is why the step table lists five remaining presets rather than six
+and why the cost figures above do not include it.
+
+It stays available for development and testing behind a flag, run on samples
+rather than the corpus. What the 100-article test established, and why it is
+worth keeping for that purpose:
+
+| | |
+|---|---|
+| Exact agreement with our primary label | 51% |
+| Allowing our alternate or their 1–3 set | 65% |
+| Upheld a deliberately wrong label (control) | 5 of 100 |
+| Same verdict regardless of the label shown | 92 of 100 |
+
+The disagreements are mostly ours: "Civic Life" absorbed a movie review, a
+holiday store-hours listing and a real-estate promo. The control run matters more
+than the agreement rate — a model that ratifies whatever it is shown would be
+useless as a check, and this one does not.
+
+Used this way it is an audit instrument for our taxonomy, not a replacement
+classifier. Cost is negligible: one call per sampled article, $0.00078.
 
 **"Civic Life" versus "Civic information".** Both exist in our taxonomy, both map
 to the same concept, and six of the 37 disagreements are churn between them. This

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -1,0 +1,306 @@
+# Backfield enrichment before BigQuery export
+
+Proposal for a final pipeline stage that extracts places, people, organizations
+and article metadata using [backfield](https://github.com/localangle/backfield),
+writing to the crawler's own database so the results replicate to BigQuery
+through the existing Datastream CDC.
+
+Every figure below was measured on 20 August 2026 — against the production
+database, and by running backfield's nodes on 100 real articles. Nothing here is
+a vendor claim or an estimate where a measurement was possible.
+
+---
+
+## 1. Where it fits
+
+```
+discover → extract → clean → wire check → CIN label → [ENRICH] → Datastream → BigQuery
+                                              ↓
+                                    status = 'labeled'
+```
+
+The stage runs on articles that already satisfy the export gate and have not yet
+been enriched:
+
+```sql
+status = 'labeled' AND wire_check_status = 'complete' AND enriched_at IS NULL
+```
+
+That gate is the existing one — `src/cli/commands/extraction.py` documents
+BigQuery as exporting `status='labeled' AND wire_check_status='complete'`.
+
+**Scope is the `Mizzou-Missouri-State` dataset.** The other datasets in the
+database (VT Community News, WSU Washington State) are out of scope for this
+proposal; including them would add roughly 3,700 articles.
+
+| | Count |
+|---|---|
+| Mizzou articles, all statuses | 159,932 |
+| At `status='labeled'` | 100,257 |
+| **Qualifying for export** | **99,418** |
+
+Qualifying articles per month, by publish date:
+
+| Month | Qualifying |
+|---|---|
+| 2026-01 | 12,120 |
+| 2026-02 | 13,283 |
+| 2026-03 | 17,441 |
+| 2026-04 | 5,185 |
+| 2026-05 | 1,042 |
+| 2026-06 | 2,754 |
+| 2026-07 | 5,308 |
+
+The spread is crawler throughput, not seasonality — extraction has been stopped
+for parts of this period. Plan against the busy months: **12,000–17,500**.
+
+Enrichment adds no new qualification rule. If an article is fit to export, it is
+fit to enrich.
+
+## 2. Why backfield runs as a library, not a platform
+
+Backfield ships nine Compose services and states that production self-hosting
+from its checkout is unsupported. None of that is required here. Its extraction
+nodes are ordinary functions:
+
+```python
+run_article_metadata(params, inputs) -> dict
+run_place_extract(params, inputs)    -> dict
+run_person_extract(params, inputs)   -> dict
+run_organization_extract(params, inputs) -> dict
+```
+
+`default_context()` reads three environment variables and opens no database. The
+model is a plain parameter, so `openrouter/deepseek/deepseek-v3.2` is passed per
+call. `db_output` is a separate node we do not call — results are written to our
+own tables.
+
+Consequences: **no backfield Postgres, no PostGIS, no pgvector, no Redis, no
+Celery, no APIs, no UIs.** One container image, one job.
+
+### The extension that would have forced a self-managed database
+
+Backfield's schema requires `postgis`, `vector`, `pg_trgm` and `h3`. Checked
+against `mizzou-db-prod`:
+
+```
+postgis   3.6.0   available
+vector    0.8.5   available
+pg_trgm   1.6     available
+h3        —       not available on Cloud SQL
+```
+
+This does not affect us, because h3 is only used by SQL in backfield's public
+geo-cell browsing endpoints, which we do not run. Writing h3 cells happens in
+Python into plain text columns. Recorded here because it does block adopting
+backfield's own schema on Cloud SQL, should that ever be proposed.
+
+## 3. Order of operations, and why
+
+The stage is ordered so that the cheapest call can prevent the most expensive
+one. Measured on the 100-article sample.
+
+| Step | Runs on | Calls | Purpose |
+|---|---|---|---|
+| 1. `geographic_scope` | every article | 1 | Decides whether a point location is meaningful at all |
+| 2. `place_extract` | point-scope articles only (46%) | 1 | Mentions, with parsed components |
+| 3. Resolve the point | point-scope articles | 0 | Single city, else the publication's city — see below |
+| 4. `geocode_agent` | unresolved POI-level only (~8%) | many | Backfield's agentic geocoder |
+| 5. Remaining metadata presets | every article | 5–6 | subject, topic, format, timeframe, user need, and CIN if adopted |
+| 6. `person_extract`, `organization_extract` | every article | 2 | People with quotes; organizations |
+
+**Step 1 before step 2 is the main saving.** Scope costs one call and excludes
+54% of articles from place extraction entirely.
+
+```
+city_municipality        40      regional      17      statewide     12
+neighborhood_community    6      national      10      international  2
+                                 other         13
+```
+
+A story spanning three counties is `regional`. It should not receive a pin, and
+under this order it never enters the geocoding path.
+
+### Step 3 resolves most points for nothing
+
+`place_extract` returns every mention — a mean of **6.5 locations per article**,
+648 across the sample. Only 27 articles mention exactly one city, so extraction
+alone does not identify where a story happened.
+
+Two rules, applied in order, need no API and no model:
+
+1. If the article mentions exactly one city, use it.
+2. Otherwise use the **publication's city** from `sources.city`, when it appears
+   among the mentions.
+
+Measured on the 46 point-scope articles:
+
+```
+publication city among the extracted mentions   34
+publication city not among them                 11
+no publication city on record                    1
+
+resolved to a single point                      38 of 46
+still ambiguous                                  8 of 46
+```
+
+**38% of articles get a defensible point with no geocoding service and no extra
+model call.** City-level points then resolve to coordinates from a GNIS or Census
+gazetteer file held locally — exact, free, no rate limit. The same GNIS file is
+already loaded for the LNIC source directory.
+
+### Step 4 is the expensive one, which is why it is last and narrow
+
+Backfield's geocoder runs **four LLM models per location** — evaluation,
+geographic reasoning, geographic estimation, and a router — plus a geocoder API.
+It supports Pelias (Geocode Earth) and Geocodio; Nominatim is wired only for
+natural features such as rivers and parks, so it cannot stand in.
+
+Under this design it runs on roughly 8% of articles, for POI- and street-level
+locations the free rules could not resolve. At that volume a Geocodio key at
+$0.50/1,000 costs single-digit dollars per month. Without the scope gate it would
+run on roughly 646,000 locations for the backfill.
+
+## 4. Cost
+
+Measured per call, reading token counts off the responses on articles at or above
+the corpus median length:
+
+```
+mean per metadata call    2,693 input, 113 output tokens
+cost per call             $0.00078   (DeepSeek V3.1 rates: $0.25/M in, $0.95/M out)
+```
+
+| | Per article |
+|---|---|
+| Metadata, 6 presets | $0.0047 |
+| Metadata, 7 presets (with CIN) | $0.0055 |
+| `place_extract` on 46% of articles | $0.0004 |
+| `person_extract` + `organization_extract` | $0.0016 |
+| Geocoding on ~8% | <$0.0002 |
+| **Total** | **≈$0.007–0.008** |
+
+| | |
+|---|---|
+| Backfill 99,418 | **$700–795** one-time |
+| Ongoing, busy month (12,000–17,500) | **$84–140** |
+| Ongoing, slow month (1,000–5,300) | **$7–42** |
+
+Two levers not yet applied, each worth measuring before the backfill:
+
+- **Prompt caching.** The preset prompts total ~11,000 tokens and are identical
+  across every article; roughly 74% of each call's input is this stable prefix.
+  DeepSeek bills cache reads at $0.13/M against $0.25/M. Putting the article last
+  in the message should cut input cost materially.
+- **Preset consolidation.** Seven presets send the article seven times. Combining
+  them into fewer calls would send it once, at some risk to per-category quality.
+  Worth an A/B on 100 articles before adopting.
+
+## 5. Time
+
+Measured throughput at 10 concurrent workers:
+
+```
+7 metadata presets   100 articles in 28s per preset
+place_extract        100 articles in 122s
+```
+
+A full 9–10 call pipeline is roughly 3 seconds per article at that concurrency.
+
+| | At 10 workers | At 50 workers |
+|---|---|---|
+| Backfill 99,418 | ~3.2 days | ~15 hours |
+| Busy month, incremental (~580/day) | ~27 minutes/day | — |
+
+The job is I/O-bound on the API, not CPU-bound, so one or two existing spot nodes
+are sufficient. Concurrency is limited by OpenRouter rate limits, not by us.
+
+## 6. Running it on GCP
+
+| | |
+|---|---|
+| Compute | Kubernetes `CronJob` on the existing `mizzou-cluster`, spot pool |
+| Database | The crawler's existing Cloud SQL — new tables, no new instance |
+| Image | Crawler base plus backfield's packages, pinned to a backfield commit |
+| Secrets | OpenRouter key, and a geocoder key if step 4 is enabled |
+| Redis, Celery, backfield APIs | Not used |
+
+Incremental infrastructure cost is a few dollars per month of spot compute plus
+storage. There is no new managed service.
+
+Backfield is pre-1.0 and its own documentation says self-hosting is unsupported.
+Pin an exact commit, treat upgrades as deliberate work, and keep the node calls
+behind a thin adapter so a breaking change touches one module.
+
+## 7. Data written
+
+New tables in the crawler database, all keyed on `article_id`. Datastream
+replicates them to BigQuery automatically — no export code, no schema
+registration.
+
+| Table | Grain |
+|---|---|
+| `article_enrichment` | One row per article: scope, subject, topic, format, timeframe, user need, resolved point, model and prompt versions, cost, `enriched_at` |
+| `article_places` | One row per extracted location, with components, resolution method, and coordinates when resolved |
+| `article_people` | One row per person mention, with quotes |
+| `article_organizations` | One row per organization mention |
+
+Every row records the model id, the backfield commit, and the prompt preset
+version, so a reprocessing decision can be scoped to exactly what changed.
+
+`enriched_at` on `articles` is the idempotency key. Re-running the job never
+re-bills an article that has already succeeded.
+
+## 8. Failure handling
+
+- One article failing must not fail a batch. Errors are recorded per article with
+  the exception type and the step that failed; the article stays unenriched and
+  is retried on the next run.
+- A batch is committed per article, not per run, so a job killed mid-way loses
+  nothing already paid for.
+- Cost is recorded per article. A daily spend ceiling stops the job rather than
+  discovering the overrun on an invoice.
+- Enrichment failure never blocks export. An article with `enriched_at IS NULL`
+  still replicates to BigQuery with its existing fields.
+
+## 9. Open decisions
+
+**Whether backfield's CIN replaces ours.** Tested on 100 articles: 51% exact
+agreement, 65% allowing our alternate label or their multi-label set. The
+disagreements are mostly ours being wrong — "Civic Life" is a catch-all that
+absorbed a movie review, a holiday store-hours listing and a real-estate promo.
+A control run that showed the model deliberately wrong labels had it uphold only
+5 of 100, and it reached the same verdict regardless of the label it was shown in
+92 of 100 cases, so it is not merely ratifying whatever it is given. Adopting it
+costs one extra call per article; running both and storing them side by side
+costs the same and defers the decision.
+
+**"Civic Life" versus "Civic information".** Both exist in our taxonomy, both map
+to the same concept, and six of the 37 disagreements are churn between them. This
+should be resolved regardless of what happens with backfield.
+
+**Whether to keep our existing entity extraction.** `article_entities` is already
+populated for 133,100 articles by `src/pipeline/entity_extraction.py`. Backfield
+would produce a second, richer answer. Running both indefinitely means two
+answers to the same question.
+
+**Entity canonicalization.** In library mode, "Mayor Smith" in 40 stories is 40
+mention rows, not one person. Backfield's Stylebook resolves this but is
+DB-resident — `substrate_*` and `stylebook_*_canonical` tables, alias lookup and
+a review queue — and adopting it means running backfield's schema, which is where
+the h3 finding in §2 starts to matter. Deferrable, expensive to retrofit.
+
+**The 11 point-scope articles where the publication's city was not mentioned.**
+Some are legitimate — a Branson paper covering Springfield. Rule 2 would place
+them wrongly. Worth reading before the backfill.
+
+## 10. Suggested sequence
+
+1. Confirm the resolved points on the 100-article sample are actually correct.
+   The rule is validated; the output is not.
+2. Measure prompt caching and preset consolidation on 100 articles.
+3. Build the adapter and the four tables; run 1,000 articles end to end.
+4. Backfill, rate-limited, with the spend ceiling armed.
+5. Enable the `CronJob` for incremental articles.
+
+Steps 1 and 2 cost a few cents each and should gate the rest.


### PR DESCRIPTION
## Summary

`docs/BACKFIELD_ENRICHMENT.md` — design for a final pipeline stage that extracts
places, people, organizations and article metadata using
[backfield](https://github.com/localangle/backfield), writing to the crawler's own
tables. Results reach BigQuery through existing Datastream replication.

Documentation only. Measurements taken 2026-08-20 against production and by
running backfield's nodes on 100 articles.

## Export criterion

Current: `status='labeled' AND wire_check_status='complete'`
Proposed: `status IN ('enriched', 'enrichment_skipped')`

`enriched` means backfield ran. It does not mean exportable.

| Status | Condition | Exports | Terminal |
|---|---|---|---|
| `labeled` | Candidate, or failed and awaiting retry | No | No |
| `enriched` | Every step in the dataset's profile completed | Yes | Yes |
| `enrichment_skipped` | No backfield call made | Yes | Yes |
| `not_article` / `paywall` | Content gate rejected the text | No | Yes |

A partial profile yields `enriched`. Only the absence of any backfield call
yields `enrichment_skipped`.

| `skip_reason` | Class |
|---|---|
| `profile_none`, `dataset_disabled` | Policy |
| `operator_bypass`, `failed_max_attempts` | Incident |

## Scope and input modes

`Mizzou-Missouri-State`. 99,418 articles qualify; 17,441 published March 2026.

| Mode | Selection |
|---|---|
| Steady state — primary | Candidate query, on a schedule. All new collection passes through this stage before export. |
| Backfill — one-off | A supplied list of article ids. Expected scale ~15,000. Not a `publish_date` predicate. |

A supplied list is a selection, not an override: listed articles pass the same
content gate and dataset profile. Ids that are not candidates are reported and
skipped, not dropped silently.

The recurring cost governs the decision, not the backfill.

## Deployment

Backfield's extraction nodes are functions taking `params` and `inputs`.
`default_context()` reads three environment variables and opens no database. The
model is a plain parameter.

Required: one image, one CronJob on the existing cluster, the existing Cloud SQL.
Not required: backfield's Postgres, PostGIS, pgvector, Redis, Celery, APIs, UIs.

Backfield's own schema requires `h3`. Cloud SQL provides `postgis` 3.6.0,
`vector` 0.8.5 and `pg_trgm` 1.6, and does not provide `h3`. This blocks adopting
that schema, not this design.

## Step order

| Step | Runs on | Calls |
|---|---|---|
| 0a. Boilerplate heuristic | All | 0 |
| 0b. Content gate, truncated input | Survivors | 1 |
| 1. `geographic_scope` | Survivors | 1 |
| 2. `place_extract` | Point-scope only (46%) | 1 |
| 3. Point resolution | Point-scope | 0 |
| 4. `geocode_agent` | ~8% | Multiple |
| 5. Remaining presets | All | 5 |
| 6. person, organization | All | 2 |

Scope precedes place extraction and excludes 54% of articles — those with
regional or wider impact — from the geocoding path. `geocode_agent` runs four LLM
models per location and requires a paid geocoder.

Point resolution costs no calls. `place_extract` returns a mean of 6.5 locations
per article; 27 of 100 articles mention one city. Two rules apply in order: use
the single city if there is one, otherwise the publication's city from
`sources.city` when it appears among the mentions.

```
point-scope articles      46 of 100
  resolved                38
  ambiguous                8
```

City-level points resolve from a local GNIS or Census gazetteer. No API, no rate
limit.

## Per-dataset profiles

Profiles are held on the dataset, versioned, and name the steps to run. All,
some, or none. A `none` profile writes an enrichment row and sets
`enrichment_skipped`.

Absent and disabled produce identical NULLs:

| Condition | Meaning |
|---|---|
| Step disabled | Not attempted |
| Step ran, no result | Negative finding |
| Step failed | Unknown; article is not `enriched` |

Each row records `profile_version` and `steps_applied`. Consumers filter on those
rather than on NULL.

`content_gate` is switchable independently: it changes what reaches BigQuery
rather than what is known about it.

## Reprocessing

Setting articles back to `labeled` would stop them matching the export criterion
and withdraw published rows from BigQuery during reprocessing. Candidacy is a
version comparison instead, leaving status unchanged:

```sql
status = 'labeled'
OR (status IN ('enriched', 'enrichment_skipped')
    AND e.profile_version < d.profile_version)
```

`steps_applied` limits work to the delta. A profile gaining one step runs one call
per article. The cost of a proposed profile change is a count of articles lacking
the new step.

## Failure handling

Export depends on this stage; its failures are export failures.

- Rejection is terminal, failure is retryable. The statuses must differ.
- Articles at `labeled` are absent from BigQuery. The age of the oldest
  unenriched candidate requires an alert.
- Bypass sets `enrichment_skipped` / `operator_bypass`.
- After bounded attempts, failures set `enrichment_skipped` /
  `failed_max_attempts` and export.

## Schema

Two columns added to `articles` (`enriched_at`, `enrichment_attempts`) and four
new tables: `article_enrichment` (one row per article), `article_places`,
`article_people`, `article_organizations`. Full DDL with indexes in §9, plus
sample values from a real run rather than invented ones — e.g. `subject=election`
(0.95), `topic=local_government_politics` (0.95), `format=profile` (0.95),
`timeframe=future` (0.90), `user_need=show_me_the_community` (0.85).

`article_places` averages 6.5 rows per article.

## Containerisation

Backfield requires Python 3.11; `Dockerfile.base` is `python:3.11-slim-bookworm`.
The enrichment image builds from the crawler base.

**Not from `Dockerfile.processor`** — that derives from the ML base and carries
spacy, transformers and scikit-learn. Enrichment performs no local inference.
Measured: importing the four nodes pulls `backfield_db`, `backfield_entities`,
`sqlalchemy` and `litellm`, and does not pull `torch` or `transformers`.

| | |
|---|---|
| Shared unchanged | sqlalchemy, requests, pydantic, structlog, psycopg2-binary, cloud-sql-python-connector, plus crawler session/config/telemetry |
| Added | ~150 MB — `litellm` 84 MB, `pycountry` 22 MB, `openai` 10 MB, `anthropic` 9 MB, `shapely` 6 MB, rest 1–3 MB |
| Runtime | 306 MB RSS after import; request 512 Mi, limit 1 Gi, 250m CPU |

`boto3` and `duckduckgo-search` are hard dependencies of `backfield-agate` but
reachable only from nodes this design does not call.

The work is I/O-bound, so concurrency belongs in threads inside one pod rather
than replicas.

## Testing

Unit tests stub the model and cover profile resolution, status transitions, point
resolution, scope gating, the content gate, reprocessing candidacy, response
parsing and cost accounting. Integration tests run against real Postgres for
writes, idempotency, the export criterion, partial failure and migration.

The test that must not be skipped: **an exportable article remains exportable at
every point during and after reprocessing** — the withdrawal failure mode above.

Contract tests run on demand against the live API. A backfield version bump is
validated by diffing categories across the 100-article sample, because upstream
prompt changes move labels without raising errors — editing a preset's few-shot
examples changed 2 of 4 classifications in testing.

## Cost

```
per metadata call    2,693 input, 113 output tokens = $0.00078
per article          $0.0067 – $0.0075
```

| | |
|---|---|
| Backfill, ~15,000 | $100–113 |
| Busy month (12,000–17,500) | $80–131 |
| Slow month (1,000–5,300) | $7–40 |
| Backfill runtime | ~12h at 10 workers, ~2.5h at 50 |

Untested levers: prompt caching (74% of call input is a stable prefix, $0.13/M
against $0.25/M) and preset consolidation.

## Backfield CIN

Not adopted. Our classifier remains authoritative. `information_needs` is
excluded from the production path and from the costs above, and available for
development on samples.

| Measure | Result |
|---|---|
| Exact agreement with our primary label | 51% |
| Upheld a deliberately wrong label (control) | 5 of 100 |
| Same verdict regardless of label shown | 92 of 100 |

The control run establishes that the model does not ratify the label it is given.

The test identified a labelling defect: a 27,372-character KQTV article
consisting of cookie descriptions, labelled `Civic information` at 0.429
confidence, exportable under the current criterion. Under this design it does not
export. A confidence floor on labelling is a separate change.

## Open

- Overlap with `article_entities`, populated for 133,100 articles.
- Entity canonicalization, unavailable in library mode. Stylebook is DB-resident.
- 11 point-scope articles where the publication-city rule resolves incorrectly.

## Implementation specification

`docs/BACKFIELD_IMPLEMENTATION.md` — module layout (`adapter.py` is the only
file that may import backfield, test-enforced), frozen interfaces, profile
validation, and seven phases, each one PR with exit criteria and a rollback:

| Phase | Delivers |
|---|---|
| 0 | Measurement spikes: caching, consolidation, gate tuning, point verification |
| 1 | Schema (alembic, rides the existing migrator job) |
| 2 | Export criterion widened to the three-status superset; four new per-table scheduled queries |
| 3 | Adapter + recorded fixtures |
| 4 | Orchestrator, gate, resolution, profiles — the §11 unit table |
| 5 | Repository + `news-crawler enrich` CLI + integration tests |
| 6 | Steady state on one dataset, gate+scope only, seven-day soak |
| 7 | Full profile, backfill list, criterion tightened to two statuses |

## Corrections from checking live infrastructure

Verifying every assumption against the live project found three errors, now
fixed in both documents:

- **The export mechanism is not Datastream** — no streams exist. It is four
  BigQuery scheduled queries; "Sync Articles from Cloud SQL" runs daily 07:00 UTC
  as a **full refresh** filtered on `status='labeled'` alone. The
  `wire_check_status` condition in code comments is not deployed.
- **The withdrawal hazard is a certainty, not an edge case**: a full refresh
  drops any article whose status changes, at the next run. Hence Phase 2 widens
  the transfer config's filter before anything is enriched.
- **New tables do not replicate automatically** — each needs its own scheduled
  query, created in Phase 2, syncing zero rows until Phase 5 writes.

Also corrected from the repo: the CLI binary is `news-crawler`; spot scheduling
follows `lehigh-extraction-job.yaml`; DB access is the Cloud SQL connector with
the `cloudsql-db-credentials` secret; and the deploy workflow's path filters must
gain `src/enrichment/`, since unlisted paths are silently skipped.

## Verification

Counts from `mizzou-db-prod`. Token counts read from API responses. Content gate,
scope, place, CIN and control runs executed on a 100-article sample. Supporting
CSVs are local and not committed.
