### PR TITLE
Run the migration job when a deploy builds the migrator

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -547,6 +547,101 @@ jobs:
           echo "✅ Migrator build triggered (build ID: $BUILD_ID)"
           echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
 
+  run-migrations:
+    name: Run Migrations
+    # Deliberately NOT behind wait-for-builds. The migrator builds in parallel
+    # with base -> ml-base -> processor -> api -> crawler, and the cloudbuild
+    # configs for those images deploy them as their last step. Waiting would
+    # apply the schema change after the code that depends on it was already
+    # serving traffic. This waits only for the migrator's own build.
+    needs: [detect-changes, build-migrator]
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.detect-changes.outputs.migrator == 'true' &&
+      needs.build-migrator.outputs.build_id != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Wait for the migrator image
+        env:
+          BUILD_ID: ${{ needs.build-migrator.outputs.build_id }}
+          PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          echo "Waiting for migrator build $BUILD_ID"
+          ELAPSED=0
+          while [ $ELAPSED -lt 900 ]; do
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project="$PROJECT" --format="value(status)" 2>/dev/null || echo UNKNOWN)
+            case "$STATUS" in
+              SUCCESS)
+                echo "Migrator image built"
+                exit 0
+                ;;
+              FAILURE|TIMEOUT|CANCELLED|EXPIRED|INTERNAL_ERROR)
+                echo "Migrator build finished as $STATUS"
+                echo "https://console.cloud.google.com/cloud-build/builds/$BUILD_ID"
+                exit 1
+                ;;
+            esac
+            sleep 20
+            ELAPSED=$((ELAPSED + 20))
+          done
+          echo "Migrator build did not finish within 15 minutes"
+          exit 1
+
+      - name: Configure kubectl
+        run: |
+          gcloud container clusters get-credentials mizzou-cluster \
+            --zone=us-central1-a \
+            --project=${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Render the migration job
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+          JOB_NAME: alembic-migration-${{ github.run_id }}-${{ github.run_attempt }}
+          PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          # Mirrors the manifest in run-migrations.yml, which stays as the
+          # manual path for staging and for replaying a specific SHA.
+          sed \
+            -e "s|__JOB_NAME__|${JOB_NAME}|g" \
+            -e "s|__IMAGE__|us-central1-docker.pkg.dev/${PROJECT}/mizzou-crawler/migrator:${IMAGE_TAG}|g" \
+            -e "s|__RUN_ID__|${{ github.run_id }}|g" \
+            k8s/deploy-migration-job.tpl.yaml > /tmp/migration-job.yaml
+          cat /tmp/migration-job.yaml
+
+      - name: Apply and wait
+        env:
+          JOB_NAME: alembic-migration-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          kubectl apply -f /tmp/migration-job.yaml
+
+          kubectl wait --for=condition=complete --timeout=600s \
+            "job/${JOB_NAME}" -n production && RESULT=0 || RESULT=1
+
+          echo "--- migration log ---"
+          kubectl logs "job/${JOB_NAME}" -n production --tail=200 || true
+
+          if [ $RESULT -ne 0 ]; then
+            echo "::error::Migration job did not complete. The images for this commit are built and deploying; the schema they expect is not in place."
+            kubectl describe "job/${JOB_NAME}" -n production || true
+            exit 1
+          fi
+
+          echo "Migrations applied at ${{ github.sha }}"
+
   wait-for-builds:
     name: Wait for Cloud Builds
     needs: [detect-changes, build-base, build-ml-base, build-processor, build-api, build-crawler, build-migrator]

--- a/k8s/deploy-migration-job.tpl.yaml
+++ b/k8s/deploy-migration-job.tpl.yaml
@@ -1,0 +1,67 @@
+# Template for the migration Job the deploy workflow runs after building the
+# migrator image for a commit that changed alembic/.
+#
+# `k8s/migration-job.yaml` beside this file pins an image tag for a manual
+# `kubectl apply`. This one is rendered per run, so the tag is always the
+# commit being deployed. build-and-deploy-services.yml substitutes:
+#
+#   __JOB_NAME__  a name unique to the workflow run and attempt
+#   __IMAGE__     migrator:<the merged commit SHA>
+#   __RUN_ID__    the GitHub Actions run, for tracing a job back to its deploy
+#
+# The env block matches run-migrations.yml so the manual and automatic paths
+# reach the database identically.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __JOB_NAME__
+  namespace: production
+  labels:
+    app: migrator
+    component: database
+    triggered-by: deploy
+    run-id: "__RUN_ID__"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: migrator
+        component: database
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: alembic-migrate
+          image: __IMAGE__
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: USE_CLOUD_SQL_CONNECTOR
+              value: "true"
+            - name: CLOUD_SQL_INSTANCE
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: instance-connection-name
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: password
+            - name: DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: database
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+  ttlSecondsAfterFinished: 86400


### PR DESCRIPTION
Follow-on to #464. That PR built the migrator image when a migration changed; nothing ran it. Applying a merged migration still meant dispatching `run-migrations.yml` by hand, and a migration nobody remembered to dispatch stayed unapplied while the deploy carrying it reported success — which is how #462's index sat unapplied after a green `Build and Deploy Services`.

## The job

When `detect-changes` sets `migrator`, a new `run-migrations` job:

1. waits for that image's Cloud Build to reach `SUCCESS` (15 min cap, fails on `FAILURE`/`TIMEOUT`/`CANCELLED`/`EXPIRED`/`INTERNAL_ERROR`),
2. renders a Job from `k8s/deploy-migration-job.tpl.yaml` at the merged SHA,
3. applies it to the `production` namespace and waits 10 minutes for completion,
4. prints the alembic log either way, and fails the deploy if the job failed.

It runs only on `refs/heads/main`, and only when a migrator build actually happened.

## Why it does not wait for `wait-for-builds`

```
needs: [detect-changes, build-migrator]
```

The migrator builds alongside `base → ml-base → processor → api → crawler`, and the cloudbuild config for each of those images deploys it as its last step. Waiting on `wait-for-builds` would apply the schema change *after* the code that expects it was already serving traffic. Waiting only on the migrator's own build puts the schema in place while the application images are still building.

## The manifest

The Job spec moves to `k8s/deploy-migration-job.tpl.yaml` rather than a heredoc inside the workflow, so the rendered Job can be read and diffed. Three placeholders — `__JOB_NAME__`, `__IMAGE__`, `__RUN_ID__` — are substituted by `sed`; the workflow substitutes exactly the set the template uses.

The env block matches `run-migrations.yml` so the manual and automatic paths reach the database identically. `run-migrations.yml` is unchanged and stays as the manual path for staging and for replaying a specific SHA, keeping its `production-migrations` approval gate for those uses.

`k8s/migration-job.yaml` is also unchanged — it pins a tag for a manual `kubectl apply` and is not on this path.

## Note on current production state

Production's `alembic_version` holds `e4a7b8c9d0f1`, a revision in no commit on any ref of this repository. `alembic upgrade head` fails on it before doing anything, so the first run of this job will fail until that pointer is corrected to `e7a1c2b3d4f5` — the revision the schema actually matches, verified against the effects of the last five migrations. That correction is happening out of band.
