### PR TITLE
Reconcile the image tags, and stop opening a PR per deploy

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -879,19 +879,36 @@ jobs:
           # last step -- leaving versions.env stale for a permissions reason
           # after the earlier logic bug was fixed. This repo lands changes by
           # PR, so open one.
-          BRANCH="chore/image-tags-${SHORT}"
+          # One branch, not one per commit.
+          #
+          # This was chore/image-tags-${SHORT}, which opened a new PR every
+          # deploy. Each was branched from main as it stood at the time, so
+          # none contained any other's changes and all four rewrote the same
+          # lines. By 2026-08-23 there were four open -- 8c60223, 86a73ec,
+          # d2b5008, db99260 -- mutually conflicting, none of them current,
+          # and versions.env on main a fortnight behind the cluster. The job
+          # meant to prevent that drift was producing it.
+          #
+          # A fixed branch, rebuilt from main each run and force-pushed, means
+          # exactly one open PR that always says what is deployed right now.
+          BRANCH="chore/image-tags"
           git add k8s/versions.env k8s/argo/base-pipeline-workflow.yaml
           git commit -m "chore: update image tags (${SHORT}) [skip ci]"
-          # --force so a re-run of the same SHA updates its branch rather than
-          # failing on a non-fast-forward.
           git push --force origin "HEAD:refs/heads/${BRANCH}"
 
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            echo "PR for ${BRANCH} already open; branch updated."
+            gh pr edit "$BRANCH" \
+              --title "chore: update image tags (${SHORT})" \
+              --body "Automated by the update-versions-env job after a successful build of ${SHORT}. Records the image tags now deployed, so k8s/versions.env (used by envsubst for the manifests) and the repo Argo template match production. Bookkeeping only -- the images are already built and rolled out.
+
+            This PR is rewritten by every deploy. Merging it records the tags as of that moment; leaving it open means the next deploy replaces its contents rather than opening a second one."
+            echo "Updated the open PR for ${BRANCH}."
           else
             gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "chore: update image tags (${SHORT})" \
-              --body "Automated by the update-versions-env job after a successful build of ${SHORT}. Records the image tags now deployed, so k8s/versions.env (used by envsubst for the manifests) and the repo Argo template match production. Bookkeeping only -- the images are already built and rolled out."
+              --body "Automated by the update-versions-env job after a successful build of ${SHORT}. Records the image tags now deployed, so k8s/versions.env (used by envsubst for the manifests) and the repo Argo template match production. Bookkeeping only -- the images are already built and rolled out.
+
+            This PR is rewritten by every deploy. Merging it records the tags as of that moment; leaving it open means the next deploy replaces its contents rather than opening a second one."
           fi

--- a/k8s/argo/base-pipeline-workflow.yaml
+++ b/k8s/argo/base-pipeline-workflow.yaml
@@ -165,7 +165,7 @@ spec:
         factor: 2
         maxDuration: "20m"
     container:
-      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:23a5c04
+      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:d2b5008
       imagePullPolicy: IfNotPresent
       command:
         - python
@@ -266,7 +266,7 @@ spec:
         factor: 2
         maxDuration: "20m"
     container:
-      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:23a5c04
+      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:d2b5008
       imagePullPolicy: IfNotPresent
       command:
         - python
@@ -381,7 +381,7 @@ spec:
         # would have had.
         maxDuration: "6h"
     container:
-      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:23a5c04
+      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/crawler:d2b5008
       imagePullPolicy: IfNotPresent
       command: ["/bin/bash", "-c"]
       args:
@@ -499,7 +499,7 @@ spec:
         workflow-name: "{{workflow.name}}"
         workflow-uid: "{{workflow.uid}}"
     container:
-      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/processor:6e7a8d9
+      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/processor:db99260
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh","-c"]
       args:
@@ -585,7 +585,7 @@ spec:
         workflow-name: "{{workflow.name}}"
         workflow-uid: "{{workflow.uid}}"
     container:
-      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/processor:6e7a8d9
+      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/processor:db99260
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh","-c"]
       args:
@@ -679,7 +679,7 @@ spec:
         workflow-name: "{{workflow.name}}"
         workflow-uid: "{{workflow.uid}}"
     container:
-      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/processor:6e7a8d9
+      image: us-central1-docker.pkg.dev/mizzou-news-crawler/mizzou-crawler/processor:db99260
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh", "-c"]
       args:

--- a/k8s/versions.env
+++ b/k8s/versions.env
@@ -16,6 +16,6 @@
 # Values below were read off the live cluster on 2026-07-28 (all three services
 # built and rolled out together at 169bb4c) rather than copied from a build log,
 # so they describe what is actually running.
-export PROCESSOR_TAG=6e7a8d9
-export CRAWLER_TAG=23a5c04
-export API_TAG=cb9d283
+export PROCESSOR_TAG=db99260
+export CRAWLER_TAG=d2b5008
+export API_TAG=db99260


### PR DESCRIPTION
Not stale — wrong. The repo has been a fortnight behind the cluster, and the job that exists to prevent that is what caused it.

## What is actually deployed

Read from the live `production` namespace:

| | `k8s/versions.env` said | Cluster is running |
|---|---|---|
| processor | `6e7a8d9` | **`db99260`** — `mizzou-processor`, `mizzou-cli`, Argo `news-pipeline-template` |
| crawler | `23a5c04` | **`d2b5008`** — `work-queue`, `mizzou-crawler` cronjob, Argo template |
| api | `cb9d283` | **`db99260`** — `mizzou-api` |

The committed Argo template was equally stale. This PR sets both to the live values.

## Why four PRs piled up

```
BRANCH="chore/image-tags-${SHORT}"
```

One branch per commit. Every deploy opened a **new** PR, each branched from `main` as it stood at that moment — so none contained any other's changes, and all four rewrote the same lines in `base-pipeline-workflow.yaml`. They conflict with each other by construction.

| PR | Opened | Sets | |
|---|---|---|---|
| #451 | 08-11 | all three → `8c60223` | superseded |
| #454 | 08-12 | crawler → `86a73ec` | superseded |
| #456 | 08-12 | all three → `d2b5008` | crawler right, other two stale |
| #463 | 08-23 | processor+api → `db99260` | right, but leaves crawler at `23a5c04` |

**No single one of them is correct.** Merging #463 — the newest — would still have left `CRAWLER_TAG` two weeks behind. That is why this is a reconciliation rather than merging the latest.

## The fix

`BRANCH="chore/image-tags"`, fixed. Rebuilt from `main` each run and force-pushed, so there is exactly one open PR and it always says what is deployed right now. Merge it and the next deploy opens a fresh one; leave it and the next deploy replaces its contents instead of adding to a pile.

`gh pr edit` now updates the title and body too, so an unmerged PR does not keep announcing an old SHA.

## After merging

Close #451, #454, #456 and #463 — all superseded by this.

## Noted, not fixed here

Two images in the cluster are off the tracked set and outside this PR's scope:

- `mizzou-housekeeping` runs `processor:0b28478` while `mizzou-processor` runs `db99260`
- `mizzou-enrichment` runs `enrichment:4add1cb`, and `enrichment` is not in `versions.env` at all
- `proxy-health-monitor` and `proxy-health-all-nodes` run `api:latest`, which `validate-k8s-workflows` already warns about
