### PR TITLE
Resolve the project instead of reading a secret that does not exist

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -633,19 +633,51 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # Every other job here reaches Google Cloud on the default project the
+      # auth step derives from the service-account key. This job asked for
+      # `secrets.GCP_PROJECT_ID`, which is not a secret on this repository, so
+      # it expanded to an empty string: `gcloud builds describe --project=`
+      # failed on every poll, the `|| echo UNKNOWN` below swallowed it, and the
+      # loop ran the full fifteen minutes against a build that had already
+      # succeeded. The rendered image reference would have been wrong too.
+      #
+      # Resolve it once, from the credentials, and fail loudly if it is absent
+      # rather than carrying an empty string into a URL.
+      - name: Resolve the project
+        run: |
+          PROJECT="$(gcloud config get-value project 2>/dev/null)"
+          if [ -z "$PROJECT" ] || [ "$PROJECT" = "(unset)" ]; then
+            echo "::error::gcloud has no default project; the service-account" \
+                 "key should supply one."
+            exit 1
+          fi
+          echo "PROJECT=$PROJECT" >> "$GITHUB_ENV"
+          echo "project: $PROJECT"
 
       - name: Wait for the migrator image
         env:
           BUILD_ID: ${{ needs.build-migrator.outputs.build_id }}
-          PROJECT: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          echo "Waiting for migrator build $BUILD_ID"
+          echo "Waiting for migrator build $BUILD_ID in $PROJECT"
           ELAPSED=0
+          ERRORS=0
           while [ $ELAPSED -lt 900 ]; do
-            STATUS=$(gcloud builds describe "$BUILD_ID" \
-              --project="$PROJECT" --format="value(status)" 2>/dev/null || echo UNKNOWN)
+            # Separate "the poll failed" from "the build is still running".
+            # Conflating them is what turned a broken --project flag into a
+            # fifteen-minute wait instead of an immediate error.
+            if ! STATUS=$(gcloud builds describe "$BUILD_ID" \
+                 --project="$PROJECT" --format="value(status)" 2>/tmp/poll.err); then
+              ERRORS=$((ERRORS + 1))
+              echo "poll failed ($ERRORS): $(tail -1 /tmp/poll.err)"
+              if [ $ERRORS -ge 3 ]; then
+                echo "::error::Could not read the build status three times running."
+                exit 1
+              fi
+              STATUS=UNKNOWN
+            else
+              ERRORS=0
+            fi
             case "$STATUS" in
               SUCCESS)
                 echo "Migrator image built"
@@ -667,13 +699,12 @@ jobs:
         run: |
           gcloud container clusters get-credentials mizzou-cluster \
             --zone=us-central1-a \
-            --project=${{ secrets.GCP_PROJECT_ID }}
+            --project="$PROJECT"
 
       - name: Render the migration job
         env:
           IMAGE_TAG: ${{ github.sha }}
           JOB_NAME: alembic-migration-${{ github.run_id }}-${{ github.run_attempt }}
-          PROJECT: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           # Mirrors the manifest in run-migrations.yml, which stays as the
           # manual path for staging and for replaying a specific SHA.

--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -45,8 +45,20 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # `secrets.GCP_PROJECT_ID` is not a secret on this repository, so
+      # every reference to it expanded to an empty string and the image
+      # path this workflow checked had no project segment. The auth step
+      # already sets a default project from the service-account key.
+      - name: Resolve the project
+        run: |
+          PROJECT="$(gcloud config get-value project 2>/dev/null)"
+          if [ -z "$PROJECT" ] || [ "$PROJECT" = "(unset)" ]; then
+            echo "::error::gcloud has no default project."
+            exit 1
+          fi
+          echo "PROJECT=$PROJECT" >> "$GITHUB_ENV"
+          echo "project: $PROJECT"
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
@@ -54,7 +66,7 @@ jobs:
         run: |
           gcloud container clusters get-credentials mizzou-cluster \
             --zone=us-central1-a \
-            --project=${{ secrets.GCP_PROJECT_ID }}
+            --project="$PROJECT"
 
       - name: Determine image tag
         id: image-tag
@@ -67,7 +79,7 @@ jobs:
 
       - name: Check migrator image exists
         run: |
-          IMAGE="us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/mizzou-crawler/migrator:${{ steps.image-tag.outputs.tag }}"
+          IMAGE="us-central1-docker.pkg.dev/${PROJECT}/mizzou-crawler/migrator:${{ steps.image-tag.outputs.tag }}"
           echo "Checking if image exists: $IMAGE"
 
           gcloud artifacts docker images describe "$IMAGE" || {
@@ -107,7 +119,7 @@ jobs:
                 restartPolicy: Never
                 containers:
                   - name: alembic-migrate
-                    image: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/mizzou-crawler/migrator:${IMAGE_TAG}
+                    image: us-central1-docker.pkg.dev/${PROJECT}/mizzou-crawler/migrator:${IMAGE_TAG}
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: USE_CLOUD_SQL_CONNECTOR


### PR DESCRIPTION
`Run Migrations` failed on the 2e35e2a deploy — the one that shipped #460 — after waiting fifteen minutes for a build that had already succeeded. The log gives it away in one line:

```
PROJECT:
Waiting for migrator build 02fdd989-83c0-4f9e-aa9a-68e0bb54b1b0
Migrator build did not finish within 15 minutes
```

## The cause

`secrets.GCP_PROJECT_ID` **is not a secret on this repository.** `gh secret list` returns `CLAUDE_CODE_OAUTH_TOKEN`, `GCP_SA_KEY`, `MEDIACLOUD_API_TOKEN`, `UNBLOCK_PROXY_PASS`, `UNBLOCK_PROXY_USER` — and nothing else. Every reference expanded to an empty string.

So `gcloud builds describe --project=` failed on every poll, the trailing `|| echo UNKNOWN` turned that failure into "still running", and the loop ran to its timeout. Two mistakes stacked: reading a secret that wasn't there, and writing a poll that couldn't tell a failed request from a running build.

Worse, had the wait succeeded the render step would still have produced:

```
us-central1-docker.pkg.dev//mizzou-crawler/migrator:<sha>
```

— an image path with an empty project segment.

## The fix

Every other job in this file reaches Google Cloud on the default project the auth step derives from the service-account key. This job now does the same:

```yaml
- name: Resolve the project
  run: |
    PROJECT="$(gcloud config get-value project 2>/dev/null)"
    if [ -z "$PROJECT" ] || [ "$PROJECT" = "(unset)" ]; then
      echo "::error::gcloud has no default project..."
      exit 1
    fi
    echo "PROJECT=$PROJECT" >> "$GITHUB_ENV"
```

Resolved once, and an absent value fails immediately rather than being carried into a URL.

The poll no longer conflates "the request failed" with "the build is still running" — three consecutive failures end the job with the last error instead of waiting out the clock. That is the part that turned a one-line mistake into a fifteen-minute one.

## `run-migrations.yml` has never worked

The manual path had the same four references, including both the image it checks for and the image it deploys. Both had an empty project segment, so it could not have succeeded on any run. Same fix applied.

## Verification

`gcloud config get-value project` → `mizzou-news-crawler`, and the guard fires on both an empty value and the literal `(unset)`.

Workflow-only, so the pre-push hook's own rule (`grep -vE '^(\.github/workflows/|docs/)'`) skips the test suite — there is nothing local to run.

## Production is unaffected

`alembic_version` reads `9e4c7a1b2d8f`, matching repo head. The migration job never ran, but it had nothing to do: the schema was stamped before the deploy started.
