### PR TITLE
Record who owns a dataset, so a published visual can say so

### DIFF
--- a/alembic/versions/d86ffabfebe9_dataset_owner_contact.py
+++ b/alembic/versions/d86ffabfebe9_dataset_owner_contact.py
@@ -1,0 +1,47 @@
+"""Record who owns a dataset, so a published visual can say so.
+
+A visual built on this corpus is embedded in somebody else's article, and
+the page carries no attribution beyond free text somebody typed into the
+chart's own config -- "LNIC research corpus", written by hand, meaning
+nothing to a reader who wants to check it or ask about it.
+
+Attribution has to come from the dataset rather than the chart, because
+the dataset is what the claim is about. `datasets` has no field for it:
+`name` and `description` describe the data, and nothing names a person.
+
+Two columns, both nullable. Nullable because they are unknown for every
+row that exists today and inventing a steward for a dataset is worse than
+admitting there is not one recorded -- a published contact that reaches
+nobody is a worse answer than no contact.
+
+Deliberately not derived from the console's grants. A grant says who may
+read a dataset, which is access control; publishing it as attribution
+would put staff account addresses into a JSON feed anybody can fetch.
+These are the address a dataset chooses to publish, which is a different
+thing that happens to look similar.
+
+Revision ID: d86ffabfebe9
+Revises: 28a393d67304
+
+The identifier is a digest of what the migration does rather than a hand
+picked string, after an invented one collided with a merge revision and
+alembic answered with two heads where there is one chain.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d86ffabfebe9"
+down_revision = "28a393d67304"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("datasets", sa.Column("owner_name", sa.Text(), nullable=True))
+    op.add_column("datasets", sa.Column("owner_email", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("datasets", "owner_email")
+    op.drop_column("datasets", "owner_name")

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -576,6 +576,12 @@ class Dataset(Base):
         server_default=text("CURRENT_TIMESTAMP"),
     )
     ingested_by = Column(String)
+    # Who to credit and who to ask, for a dataset whose charts get embedded
+    # in other people's pages. Deliberately not the console's grants: those
+    # say who may read this, which is access control, and publishing them
+    # as attribution would put staff addresses into a public feed.
+    owner_name = Column(Text)
+    owner_email = Column(Text)
     # `metadata` is a reserved attribute on Declarative classes; store JSON
     # in the DB column named 'metadata' but expose it as `meta` on the model.
     meta = Column("metadata", JSON)


### PR DESCRIPTION
Two nullable columns on `datasets`: `owner_name`, `owner_email`.

## Why

A chart built on this corpus gets embedded in somebody else's article, and the page carries no attribution beyond free text typed into the chart's own config — `Source: LNIC research corpus`, written by hand, meaning nothing to a reader who wants to check it or ask about it.

Attribution belongs on the dataset rather than the chart, because the dataset is what the claim is about. `datasets` had no field for it: `name` and `description` describe the data, and nothing names a person.

## Not derived from the console's grants

Datadesk already knows who has access to a dataset — `Grant(user, scope, role)`. That is access control, and publishing it as attribution would put staff account addresses into a JSON feed anybody can fetch. These columns are the address a dataset *chooses* to publish, which only looks like the same thing.

## Nullable

Unknown for every row that exists, and a published contact that reaches nobody is a worse answer than no contact recorded. Datadesk will show attribution where it exists and stay quiet where it does not.

## Verified

Against Postgres with rows already in the table, not an empty one — the empty case cannot show the failures that matter:

```
rows before migration: 2
INFO  Running upgrade 28a393d67304 -> d86ffabfebe9
  lehigh: name=<null> email=<null>
  mizzou: name=<null> email=<null>
after a write:
  mizzou: Damon Kiesow
```

Downgrade drops both columns cleanly and re-apply is clean. Single head, `d86ffabfebe9` — the identifier is a digest of what the migration does, after an earlier hand-picked one collided with a merge revision and produced two heads where there is one chain.

Full suite matches the baseline on main exactly (13 failed / 20 errors, all pre-existing; the Postgres integration errors are the credential issue #471 and #472 address — confirmed identical with the change stashed).

## Ordering, for whoever deploys

This migration must be **applied** before datadesk's `Dataset` model names the columns. That model is `managed = False` against this database, so it selects whatever fields it declares — naming them first means every dataset query in the console asks for a column that does not exist.
