### PR TITLE
Let the migration job reach the cluster

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -633,6 +633,13 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
+        with:
+          # kubectl authenticates with nothing without this, and every command
+          # fails on "Install gke-gcloud-auth-plugin ... exit code 1" -- a message
+          # naming a missing plugin rather than a missing permission, raised after
+          # the images have built. The deploy goes green and the schema does not
+          # move. Two other workflows here already install it; these did not.
+          install_components: 'gke-gcloud-auth-plugin'
 
       # Every other job here reaches Google Cloud on the default project the
       # auth step derives from the service-account key. This job asked for

--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -45,6 +45,13 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
+        with:
+          # kubectl authenticates with nothing without this, and every command
+          # fails on "Install gke-gcloud-auth-plugin ... exit code 1" -- a message
+          # naming a missing plugin rather than a missing permission, raised after
+          # the images have built. The deploy goes green and the schema does not
+          # move. Two other workflows here already install it; these did not.
+          install_components: 'gke-gcloud-auth-plugin'
 
       # `secrets.GCP_PROJECT_ID` is not a secret on this repository, so
       # every reference to it expanded to an empty string and the image

--- a/tests/test_dockerfile_and_workflows.py
+++ b/tests/test_dockerfile_and_workflows.py
@@ -16,3 +16,43 @@ def test_test_chromedriver_workflow_contains_diag_step():
 def test_staging_rollout_workflow_exists():
     wf = open(".github/workflows/staging-rollout.yml").read()
     assert "Build and push image" in wf or "staging" in wf
+
+
+def test_every_job_that_uses_kubectl_installs_the_auth_plugin():
+    """kubectl cannot authenticate to GKE without gke-gcloud-auth-plugin.
+
+    Without it every command fails on "Install gke-gcloud-auth-plugin ...
+    exit code 1" -- a message naming a missing plugin rather than a
+    missing permission, raised after the images have already built. So the
+    deploy reports success, the migration job is never applied, and the
+    schema silently stays behind the code.
+
+    Two workflows had it and two did not, including run-migrations.yml,
+    which is the manual fallback for when the automatic one fails.
+    """
+    import pathlib
+
+    import yaml
+
+    offenders = []
+    for path in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+        spec = yaml.safe_load(path.read_text())
+        for name, job in (spec.get("jobs") or {}).items():
+            steps = job.get("steps") or []
+            body = yaml.safe_dump(steps)
+            # Only jobs that actually talk to a cluster. Several workflows
+            # merely grep for the string "kubectl" while validating others.
+            if "get-credentials" not in body:
+                continue
+            installs = any(
+                "gke-gcloud-auth-plugin"
+                in str((step.get("with") or {}).get("install_components", ""))
+                for step in steps
+            )
+            if not installs:
+                offenders.append(f"{path.name}:{name}")
+
+    assert not offenders, (
+        "these jobs reach a GKE cluster without the auth plugin, so kubectl "
+        f"fails after the build succeeds: {offenders}"
+    )


### PR DESCRIPTION
**Every deploy that carried an alembic change has failed to apply it, and reported success.**

## What happens

`kubectl` cannot authenticate to GKE without `gke-gcloud-auth-plugin`. The Run Migrations job installs gcloud without it:

```
Install gke-gcloud-auth-plugin for use with kubectl by following ...
##[error]Process completed with exit code 1
```

The message names a missing *plugin* rather than a missing *permission*, and it lands after every image has already built — so the run reads as a successful build with one red job at the end, and the schema silently stays behind the code.

## How long

Every run of that job has failed. The rest were skipped because the commit touched no migrations:

```
2026-08-24 19:35  89707451  failure     ← dataset owner_name/owner_email (#473)
2026-08-24 18:29  72ce98e3  skipped
2026-08-24 18:28  f1a1ce6e  skipped
2026-08-24 18:15  400a4386  failure     ← content_gate_verdict (#469)
2026-08-23 17:11  2e35e2af  failure     ← five geo migrations
```

Between them those three carry seven migrations the automatic path never applied.

## The manual fallback was broken too

`run-migrations.yml` has the same gap — the workflow somebody would reach for when the automatic one fails. Both paths to applying a migration were broken simultaneously, which is likely why this went unnoticed: the failure mode is identical whichever you try.

## Why this was missable

`production-smoke-tests.yml` and `staging-rollout.yml` already install the plugin, and one of them carries a comment about this exact error. So it was known, fixed twice, and missed twice.

The test added here walks every job that fetches cluster credentials and fails if it cannot authenticate. Removing the fix, it names both offenders:

```
these jobs reach a GKE cluster without the auth plugin, so kubectl fails
after the build succeeds:
['build-and-deploy-services.yml:run-migrations', 'run-migrations.yml:run-migrations']
```

It skips jobs that merely mention `kubectl` while validating other files — `pre-deployment-validation.yml` greps for the string and never touches a cluster.

## Scope

Only the two jobs that talk to a cluster. The other seven jobs in the deploy workflow never run `kubectl` and shouldn't pay to install a component they don't call.

## After this merges

The schema still needs catching up — merging this fixes the path, it doesn't retroactively apply what was missed. Worth confirming the database's current alembic revision against the repo head before assuming the next deploy will do the right thing.
