### PR TITLE
Give the manual migration workflow its authentication back

### DIFF
--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -43,6 +43,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # Without this gcloud runs unauthenticated and with no project, so
+      # `Resolve the project` exits 1 before anything reaches the cluster.
+      # The step existed once: #468 removed its `uses:` and left the two
+      # `with:` lines behind, stranded inside the shell script below,
+      # where a YAML key is only a command that fails.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -66,8 +76,6 @@ jobs:
           fi
           echo "PROJECT=$PROJECT" >> "$GITHUB_ENV"
           echo "project: $PROJECT"
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Configure kubectl
         run: |

--- a/tests/test_dockerfile_and_workflows.py
+++ b/tests/test_dockerfile_and_workflows.py
@@ -56,3 +56,71 @@ def test_every_job_that_uses_kubectl_installs_the_auth_plugin():
         "these jobs reach a GKE cluster without the auth plugin, so kubectl "
         f"fails after the build succeeds: {offenders}"
     )
+
+
+def test_every_job_that_uses_gcloud_authenticates_first():
+    """gcloud with no credentials has no default project either, so a job
+    that skips the auth step dies at the first command that needs one --
+    "The gcloud CLI is not authenticated", then "gcloud has no default
+    project", then exit 1.
+
+    run-migrations.yml lost its auth step to an edit that removed the
+    `uses:` line and left the two `with:` lines behind, stranded inside
+    the next step's shell script where a YAML key is only a command that
+    fails. It stayed that way because nothing ran it: it is the manual
+    fallback, reached for only when the automatic path breaks.
+    """
+    import pathlib
+
+    import yaml
+
+    offenders = []
+    for path in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+        spec = yaml.safe_load(path.read_text())
+        for name, job in (spec.get("jobs") or {}).items():
+            steps = job.get("steps") or []
+            body = yaml.safe_dump(steps)
+            if "get-credentials" not in body and "gcloud " not in body:
+                continue
+            if not any(
+                "google-github-actions/auth" in str(step.get("uses", ""))
+                for step in steps
+            ):
+                offenders.append(f"{path.name}:{name}")
+
+    assert not offenders, (
+        "these jobs run gcloud without authenticating, so they fail on the "
+        f"first command that needs a project: {offenders}"
+    )
+
+
+def test_no_workflow_strands_a_with_key_inside_a_shell_script():
+    """The shape of the bug above: `service_account_key:` and
+    `export_default_credentials:` sitting in a `run:` block, which YAML
+    accepts and the shell treats as commands that fail. Nothing about it
+    looks wrong until the job runs.
+    """
+    import pathlib
+
+    import yaml
+
+    ACTION_KEYS = (
+        "service_account_key:",
+        "export_default_credentials:",
+        "credentials_json:",
+        "install_components:",
+        "workload_identity_provider:",
+    )
+    offenders = []
+    for path in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+        spec = yaml.safe_load(path.read_text())
+        for name, job in (spec.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                script = step.get("run") or ""
+                for key in ACTION_KEYS:
+                    if any(
+                        line.strip().startswith(key) for line in script.splitlines()
+                    ):
+                        offenders.append(f"{path.name}:{name}: {key}")
+
+    assert not offenders, f"action inputs stranded inside a shell script: {offenders}"


### PR DESCRIPTION
The run I fixed in #474 still failed, further along and for a different reason: run-migrations.yml has no authentication step at all.

    The gcloud CLI is not authenticated (or it is not installed).
    gcloud has no default project.
    Process completed with exit code 1

It had one. #468 removed the step's `uses:` line and left its two `with:` lines behind -- service_account_key and export_default_credentials -- which fell into the shell script of the step below, where a YAML key is only a command that fails. Valid YAML, silent, and wrong.

So both routes to applying a migration were broken, in different places: the automatic one could authenticate but not reach the cluster, and the manual one could do neither. That is why this went unnoticed for as long as it did -- the fallback was never exercised until the primary failed, and then it failed for its own reasons.

The guard added in #474 did not catch this because it asked whether a job installs the auth plugin, not whether it authenticates. Two more tests: one that every job running gcloud has an auth step, and one that no action input is stranded inside a `run:` block, which is the shape of the original mistake.