### PR TITLE
Give the migration pod an identity that can reach the database

### DIFF
--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -131,6 +131,10 @@ jobs:
                   app: migrator
                   component: database
               spec:
+                # Workload Identity. Without it the pod runs as `default`,
+                # which is bound to no Google identity, and the Cloud SQL
+                # connector gets a 403 asking for connect settings.
+                serviceAccountName: mizzou-app
                 restartPolicy: Never
                 containers:
                   - name: alembic-migrate

--- a/k8s/deploy-migration-job.tpl.yaml
+++ b/k8s/deploy-migration-job.tpl.yaml
@@ -29,6 +29,19 @@ spec:
         app: migrator
         component: database
     spec:
+      # Workload Identity, without which the pod runs as the cluster's
+      # `default` service account, which is bound to no Google identity at
+      # all. The Cloud SQL connector then asks for connect settings with no
+      # credentials and the API answers 403:
+      #
+      #   boss::NOT_AUTHORIZED: Possibly missing permission
+      #   cloudsql.instances.get on resource instances/mizzou-db-prod
+      #
+      # Nothing needs granting: mizzou-app maps to mizzou-k8s-sa, which
+      # already holds roles/cloudsql.client, and every other workload here
+      # already runs as it. k8s/migration-job.yaml -- the hand-applied copy
+      # beside this one -- has always set it. The rendered ones did not.
+      serviceAccountName: mizzou-app
       restartPolicy: Never
       containers:
         - name: alembic-migrate

--- a/k8s/jobs/run-alembic-migrations-with-smoke-test.yaml
+++ b/k8s/jobs/run-alembic-migrations-with-smoke-test.yaml
@@ -14,6 +14,7 @@ spec:
         app: migrator
         component: database
     spec:
+      serviceAccountName: mizzou-app
       restartPolicy: Never
       # Use init container for migration, main container for smoke test
       initContainers:

--- a/k8s/jobs/run-alembic-migrations.yaml
+++ b/k8s/jobs/run-alembic-migrations.yaml
@@ -14,6 +14,7 @@ spec:
         app: migrator
         component: database
     spec:
+      serviceAccountName: mizzou-app
       restartPolicy: Never
       containers:
         - name: alembic-migrate

--- a/tests/test_dockerfile_and_workflows.py
+++ b/tests/test_dockerfile_and_workflows.py
@@ -124,3 +124,50 @@ def test_no_workflow_strands_a_with_key_inside_a_shell_script():
                         offenders.append(f"{path.name}:{name}: {key}")
 
     assert not offenders, f"action inputs stranded inside a shell script: {offenders}"
+
+
+def test_every_migration_manifest_names_a_service_account():
+    """A pod with no serviceAccountName runs as the cluster's `default`,
+    which is bound to no Google identity. The Cloud SQL connector then
+    asks for connect settings unauthenticated and the API answers:
+
+        boss::NOT_AUTHORIZED: Possibly missing permission
+        cloudsql.instances.get on resource instances/mizzou-db-prod
+
+    Nothing needs granting -- mizzou-app maps to mizzou-k8s-sa, which
+    already holds roles/cloudsql.client. The hand-applied manifest always
+    set it and the two rendered ones did not, so migrations failed only on
+    the paths nobody ran by hand.
+    """
+    import pathlib
+
+    import yaml
+
+    offenders = []
+    for path in sorted(pathlib.Path("k8s").rglob("*.yaml")):
+        text = path.read_text()
+        if "alembic" not in text and "migrator" not in text:
+            continue
+        for doc in yaml.safe_load_all(text.replace("<COMMIT_SHA>", "x")):
+            if not isinstance(doc, dict) or doc.get("kind") != "Job":
+                continue
+            spec = doc["spec"]["template"]["spec"]
+            if not spec.get("serviceAccountName"):
+                offenders.append(str(path))
+
+    assert not offenders, (
+        "these migration jobs run as the default service account and cannot "
+        f"reach Cloud SQL: {offenders}"
+    )
+
+
+def test_the_manual_workflow_writes_a_manifest_with_an_identity():
+    """It builds its Job inline rather than rendering a file, so the check
+    above cannot see it."""
+    text = open(".github/workflows/run-migrations.yml").read()
+    start = text.index("cat > /tmp/migration-job.yaml")
+    # Past the heredoc opener on that same line, or the window closes on
+    # the "EOF" that opens it and the assertion below is vacuous.
+    body = text[text.index("\n", start) :]
+    manifest = body[: body.index("EOF")]
+    assert "serviceAccountName: mizzou-app" in manifest


### PR DESCRIPTION
Third layer of the same journey. The workflow now authenticates (#475) and reaches the cluster (#474), creates the Job — and the pod dies:

```
aiohttp.client_exceptions.ClientResponseError: 403,
  boss::NOT_AUTHORIZED: Not authorized to access resource.
  Possibly missing permission cloudsql.instances.get
  on resource instances/mizzou-db-prod
```

## Cause

No `serviceAccountName`, so the pod ran as the cluster's `default`, which is bound to no Google identity. The Cloud SQL connector asked for connect settings with no credentials and the API refused. The Job retried once, failed the same way, and `kubectl wait` timed out after ten minutes:

```
job.batch/alembic-migration-1787612995   Failed   0/1   14m
pod/alembic-migration-1787612995-m6pkl   0/1   Error
pod/alembic-migration-1787612995-v9hbt   0/1   Error
```

## Nothing needed granting

`mizzou-app` maps to `mizzou-k8s-sa`, which already holds:

```
roles/cloudsql.client
roles/secretmanager.secretAccessor
roles/bigquery.dataEditor
roles/bigquery.jobUser
roles/datastore.user
```

Every other workload in that namespace already runs as it — including `work-queue`, which talks to this same instance through a proxy sidecar. And `k8s/migration-job.yaml`, the copy applied by hand, **has always set it**.

The four that are rendered or generated did not. That is the pattern across all three of these PRs: the paths somebody runs by hand work, and the automated ones were never exercised end to end.

## Tests

One walks the Job manifests in `k8s/`; one covers the manual workflow, which builds its Job inline where the first cannot see it. Reverted, they name all four:

```
these migration jobs run as the default service account and cannot reach Cloud SQL:
['k8s/deploy-migration-job.tpl.yaml',
 'k8s/jobs/run-alembic-migrations-with-smoke-test.yaml',
 'k8s/jobs/run-alembic-migrations.yaml']
```

The manifest walker found the fourth (`-with-smoke-test`) that I had missed by hand.

The inline-manifest test also had a bug of its own worth noting: its window ran from `cat > /tmp/migration-job.yaml` to the first `EOF`, which is the heredoc opener **on that same line** — so the window was empty and the assertion passed vacuously. It now starts after that line.

## After merging

Re-run with the same inputs. Seven migrations are still outstanding.
