### PR TITLE
Stop asking for a review and a test cycle to record image tags

### DIFF
--- a/.github/workflows/build-and-deploy-services.yml
+++ b/.github/workflows/build-and-deploy-services.yml
@@ -1006,6 +1006,18 @@ jobs:
           BRANCH="chore/image-tags"
           git add k8s/versions.env k8s/argo/base-pipeline-workflow.yaml
           git commit -m "chore: update image tags (${SHORT}) [skip ci]"
+
+          # Nothing here is under review: the images are already built and
+          # rolled out, and these three strings only record which. Push it
+          # straight to main when the ruleset allows this actor to. The PR
+          # path below stays as the fallback, so a bypass that is absent or
+          # later revoked degrades to a PR that merges itself rather than to
+          # a job that stalls waiting for a human.
+          if git push origin HEAD:main 2>/dev/null; then
+            echo "Recorded the image tags directly on main."
+            exit 0
+          fi
+          echo "Direct push refused by the branch ruleset; opening a PR instead."
           git push --force origin "HEAD:refs/heads/${BRANCH}"
 
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
@@ -1015,6 +1027,9 @@ jobs:
 
             This PR is rewritten by every deploy. Merging it records the tags as of that moment; leaving it open means the next deploy replaces its contents rather than opening a second one."
             echo "Updated the open PR for ${BRANCH}."
+            gh pr merge "$BRANCH" --auto --squash 2>/dev/null \
+              && echo "Auto-merge armed." \
+              || echo "Auto-merge unavailable; the PR waits for a human."
           else
             gh pr create \
               --base main \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,27 @@ jobs:
           # git-hook installer counts as code. (setup-hooks.sh only defines the
           # pre-push hook — it's never imported by src/ or tests/.)
           code_files=$(echo "$changed" | grep -vE '^(\.github/workflows/|docs/|scripts/setup-hooks\.sh$)' | grep -vE '\.md$' || true)
+
+          # The image-tag bookkeeping PR is the one exception, and it is
+          # recognised by WHO opened it, not by which files it touches: the
+          # update-versions-env job records the tags already built and
+          # deployed, so the five heavy jobs would spend a full cycle
+          # validating three strings that describe images CI has no say over.
+          # A human editing the same files by hand still gets the full suite,
+          # which is why this tests the actor and the branch rather than
+          # adding the paths to the exclusion list above.
+          if [ "${{ github.event.pull_request.user.login }}" = "github-actions[bot]" ] \
+             && [ "${{ startsWith(github.head_ref, 'chore/image-tags') }}" = "true" ]; then
+            unexpected=$(echo "$changed" | grep -vE '^k8s/(versions\.env|argo/base-pipeline-workflow\.yaml)$' || true)
+            if [ -z "$unexpected" ]; then
+              echo "→ image-tag bookkeeping from the deploy job; skipping heavy test jobs."
+              echo "code=false" >> "$GITHUB_OUTPUT"
+              echo "images=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "→ bookkeeping branch touched more than the tag files; running full suite."
+          fi
+
           if [ -n "$code_files" ]; then
             echo "→ code changes present; running full suite."
             echo "code=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `update-versions-env` job records the tags of images that are already built and rolled out. Deciding nothing, it nonetheless opened a pull request (#467 being the current one) that ran five heavy jobs — lint, unit, two integration suites, mypy — to validate three strings, then waited for a human to approve it.

## Changes

`.github/workflows/build-and-deploy-services.yml`

- The job pushes the update straight to `main`.
- When the branch ruleset refuses that push, it falls back to the existing pull request and arms `gh pr merge --auto --squash`. An absent or later-revoked bypass therefore degrades to a PR that merges itself, not to a job that stalls.

`.github/workflows/ci.yml`

- The heavy jobs skip for that one PR, recognised by **who opened it and which branch it came from** — `github-actions[bot]` on `chore/image-tags` — and only when the diff contains nothing but `k8s/versions.env` and `k8s/argo/base-pipeline-workflow.yaml`.
- A person editing those files by hand still gets the full suite, as does a bookkeeping branch that touches anything else. The skip sets `code=false`, which reports success on the required checks rather than leaving them pending (the pattern already used for docs-only PRs).

## Not included

Granting the GitHub Actions app a ruleset bypass on `main`. Rulesets scope bypasses by actor, not by path, so that would let any workflow in this repository push to `main` — a wider grant than this problem needs. With the auto-merge fallback above, the bookkeeping PR lands on its own without it.