### PR TITLE
Say which dataset paid for an LLM call

### DIFF
--- a/src/enrichment/adapter.py
+++ b/src/enrichment/adapter.py
@@ -199,6 +199,14 @@ def run_content_gate(
             max_tokens=60,
             timeout=DEFAULT_TIMEOUT_S,
             response_format={"type": "json_object"},
+            # Which dataset paid for this call. LiteLLM forwards `user`
+            # to OpenRouter, which records it as `external_user` on the
+            # generation, so the billed cost can be split the way the
+            # recorded cost already is. Without it every trace we have
+            # collected says only that the money was spent -- the cost
+            # page shows a per-dataset figure for the recorded side and
+            # nothing at all for the billed one.
+            user=article.dataset_slug,
         )
         raw = response.choices[0].message.content or ""
         # Some providers wrap JSON in a code fence despite response_format.
@@ -257,6 +265,7 @@ def run_focus(article: ArticleInput, model: str) -> StepResult:
             timeout=DEFAULT_TIMEOUT_S,
             temperature=0,
             response_format={"type": "json_object"},
+            user=article.dataset_slug,
         )
         raw = response.choices[0].message.content or ""
         raw = re.sub(r"^```(json)?|```$", "", raw.strip(), flags=re.M).strip()

--- a/tests/enrichment/test_adapter.py
+++ b/tests/enrichment/test_adapter.py
@@ -146,6 +146,23 @@ class TestContentGate:
         response.usage = Usage()
         return response
 
+    def test_the_call_says_which_dataset_paid_for_it(self, litellm_stub):
+        """LiteLLM forwards `user` to OpenRouter, which records it as
+        `external_user` on the generation. Without it a trace says only
+        that money was spent: every trace collected up to 2026-08-22 has
+        `external_user` null, so the cost page can split the recorded side
+        per dataset and not the billed one."""
+        response = self._fake_response('{"verdict": "news", "reason": "x"}')
+        seen = {}
+
+        def capture(**kw):
+            seen.update(kw)
+            return response
+
+        litellm_stub.completion = capture
+        adapter.run_content_gate(ARTICLE, MODEL)
+        assert seen["user"] == "Mizzou-Missouri-State"
+
     def test_valid_verdict_passes(self, litellm_stub):
         response = self._fake_response('{"verdict": "news", "reason": "story present"}')
         litellm_stub.completion = lambda **kw: response


### PR DESCRIPTION
LiteLLM forwards `user` to OpenRouter, which records it as `external_user` on
the generation. **Every trace collected up to 2026-08-22 has it null**, so the
datadesk cost page can split the recorded side per dataset and the billed side
not at all — and the billed side is the accurate one, about a third lower once
the cache discount lands.

## Change

Enrichment already runs one dataset at a time: the repository selects
`d.slug AS dataset_slug` and every `ArticleInput` carries it. The two calls this
module makes directly now pass it.

## What this does not cover

The node-based steps (`scope`, `places`, `people`, `organizations`, presets) go
through `agate_runtime` → `agate_nodes`, which makes its own requests. Those
stay unlabelled until that package forwards a `user`; the hook would be
`packages/backfield-agate/src/agate_nodes/extraction/shared_llm.py` in the
backfield repo.

So this labels the content gate and focus, not the whole bill. Partial
attribution is visible as partial — the unlabelled spend stays in the
unattributed column rather than being silently reassigned.

## Checks

Ran the hook's steps against this branch: ruff, black, isort, mypy (125 files),
the main suite (3213 passed) and the Postgres suite against a throwaway
migrated database (286 passed).

Three failures in `tests/alembic/` were my environment — the venv not on PATH
for their subprocess calls — and pass when it is, on this branch and on `main`
alike.