### PR TITLE
Record that a publication has a paywall, and what it costs

### DIFF
--- a/alembic/versions/p1q2r3s4t5u6_add_paywall_and_subscription.py
+++ b/alembic/versions/p1q2r3s4t5u6_add_paywall_and_subscription.py
@@ -1,0 +1,81 @@
+"""Record that a publication has a paywall, and what it costs.
+
+Revision ID: p1q2r3s4t5u6
+Revises: d86ffabfebe9
+Create Date: 2026-08-28
+
+Three columns, and deliberately not a fourth.
+
+`requires_login` already exists and means something narrower than it
+reads: the extractor performs a browser login for this publisher, which
+is true of seven sources because seven are configured. Whether a
+publication *has* a paywall is a fact about the publication and true of
+many more, so it is its own column -- and the one somebody ticks on a
+record long before anybody automates the login.
+
+The subscription is an amount and the period it covers. One of each
+rather than a monthly column and an annual one: two numbers about the
+same subscription can disagree, and a yearly figure is arithmetic on a
+monthly one.
+
+No credentials here. The username and password for a paywalled publisher
+live in Secret Manager under `auth_secret_name`, which is the convention
+this table already follows and the reason `auth_config` carries the
+comment that credentials are never stored in it. A password column would
+be readable by every role holding SELECT on sources, which includes the
+read-only analytics role and every CSV anybody exports.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "p1q2r3s4t5u6"
+down_revision: Union[str, None] = "d86ffabfebe9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add has_paywall, subscription cost and the login page."""
+    # What somebody ticks on the record. Not null with a false default, so
+    # "we have not looked" and "there is no paywall" are not the same
+    # answer written the same way -- an unticked box is the second, and
+    # the review queue is where the first gets settled.
+    op.add_column(
+        "sources",
+        sa.Column(
+            "has_paywall",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # What a subscription costs, and what that buys. Numeric rather than
+    # float: money in a float is money that does not add up.
+    op.add_column(
+        "sources",
+        sa.Column("subscription_cost", sa.Numeric(10, 2), nullable=True),
+    )
+    op.add_column(
+        "sources",
+        sa.Column("subscription_period", sa.String(16), nullable=True),
+    )
+
+    # Where a person signs in. `auth_config` holds one for the publishers
+    # whose login is automated, but that column is the extractor's
+    # parameters and is null on every publisher nobody has automated --
+    # which is all of them but seven, and exactly the ones somebody
+    # reading the record needs the link for.
+    op.add_column("sources", sa.Column("login_url", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove them again."""
+    op.drop_column("sources", "login_url")
+    op.drop_column("sources", "subscription_period")
+    op.drop_column("sources", "subscription_cost")
+    op.drop_column("sources", "has_paywall")

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    Numeric,
     String,
     Text,
     UniqueConstraint,
@@ -702,6 +703,25 @@ class Source(Base):
     # Non-secret login parameters (auth0 domain/client_id/redirect_uri/scope,
     # login_url, CSS selectors, success_text). Credentials are NEVER stored here.
     auth_config = Column(JSON, nullable=True)
+
+    # Whether the publication has a paywall at all. Wider than
+    # requires_login, which says the extractor performs a browser login
+    # for this publisher and is true of the seven that are configured.
+    # This is a fact about the publication, ticked on the record long
+    # before anybody automates a login for it.
+    has_paywall = Column(
+        Boolean, default=False, nullable=False, server_default=text("FALSE")
+    )
+    # What a subscription costs, and what that buys: 'monthly' or
+    # 'annual'. One amount and one period rather than a monthly column and
+    # an annual one, because two numbers about one subscription can
+    # disagree and a yearly figure is arithmetic on a monthly one.
+    subscription_cost = Column(Numeric(10, 2), nullable=True)
+    subscription_period = Column(String(16), nullable=True)
+    # Where a person signs in. `auth_config` carries one for the
+    # publishers whose login is automated; this is for the rest, which is
+    # all of them but seven.
+    login_url = Column(Text, nullable=True)
 
     # Relationships
     broadcaster_callsigns = relationship(

--- a/tests/alembic/test_paywall_columns_postgres.py
+++ b/tests/alembic/test_paywall_columns_postgres.py
@@ -1,0 +1,105 @@
+"""The paywall columns arrive on a table that already has rows in it.
+
+`has_paywall` is NOT NULL. Adding a NOT NULL column to a populated table
+fails outright unless it carries a server default, and a test that
+migrates an empty database never finds out -- production has 1,149
+publisher records and the test database would have none.
+
+So this seeds a row first, then migrates, then reads it back.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+pytestmark = [pytest.mark.integration, pytest.mark.postgres]
+
+
+@pytest.mark.skipif(
+    not os.getenv("TEST_DATABASE_URL")
+    or "postgresql" not in os.getenv("TEST_DATABASE_URL", ""),
+    reason="PostgreSQL test database not configured",
+)
+def test_paywall_columns_land_on_a_table_that_has_rows():
+    database_url = os.getenv("TEST_DATABASE_URL")
+    project_root = Path(__file__).parent.parent.parent
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    env["USE_CLOUD_SQL_CONNECTOR"] = "false"
+
+    engine = create_engine(database_url)
+
+    # One migration short of the one under test, so the row is written
+    # before the columns exist -- which is the state production is in.
+    down = subprocess.run(
+        ["alembic", "downgrade", "d86ffabfebe9"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=project_root,
+    )
+    assert down.returncode == 0, down.stderr
+
+    host = f"paywalltest-{uuid.uuid4().hex[:8]}.example"
+    source_id = str(uuid.uuid4())
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO sources (id, host, host_norm) "
+                "VALUES (:id, :host, :host)"
+            ),
+            {"id": source_id, "host": host},
+        )
+
+    up = subprocess.run(
+        ["alembic", "upgrade", "head"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=project_root,
+    )
+    assert up.returncode == 0, up.stderr
+
+    with engine.begin() as conn:
+        row = conn.execute(
+            text(
+                "SELECT has_paywall, subscription_cost, subscription_period, "
+                "login_url FROM sources WHERE id = :id"
+            ),
+            {"id": source_id},
+        ).one()
+        # The record that was already there: not paywalled rather than
+        # null, because an unticked box is an answer and a null is not.
+        assert row.has_paywall is False
+        assert row.subscription_cost is None
+        assert row.subscription_period is None
+        assert row.login_url is None
+
+        # And the columns take what they are for.
+        conn.execute(
+            text(
+                "UPDATE sources SET has_paywall = TRUE, "
+                "subscription_cost = 12.99, subscription_period = 'monthly', "
+                "login_url = :url WHERE id = :id"
+            ),
+            {"id": source_id, "url": f"https://{host}/login"},
+        )
+        back = conn.execute(
+            text(
+                "SELECT has_paywall, subscription_cost, subscription_period "
+                "FROM sources WHERE id = :id"
+            ),
+            {"id": source_id},
+        ).one()
+        assert back.has_paywall is True
+        # Numeric, not float: money in a float is money that does not add up.
+        assert str(back.subscription_cost) == "12.99"
+        assert back.subscription_period == "monthly"
+
+        conn.execute(text("DELETE FROM sources WHERE id = :id"), {"id": source_id})


### PR DESCRIPTION
Three columns on `sources`, and deliberately not a fourth. Datadesk needs
these to surface paywalls in the console; the schema lives here, so this
lands first.

## Why not `requires_login`

It already exists and means something narrower than it reads: *the
extractor performs a browser login for this publisher*. True of seven
sources, because seven are configured — ptleader (simplecirc), tdn,
union-bulletin, yakimaherald (form), columbian (newzware),
pendoreillerivervalley (etype), spokesman (auth0).

Whether a publication **has** a paywall is a fact about the publication,
true of many more, and it is what somebody ticks on a record long before
anybody automates a login for it. So `has_paywall` is its own column.

## The three

| column | type | why |
|---|---|---|
| `has_paywall` | `Boolean NOT NULL DEFAULT false` | the fact about the publication |
| `subscription_cost` | `Numeric(10,2)` | money in a float is money that does not add up |
| `subscription_period` | `String(16)` | `monthly` or `annual` |
| `login_url` | `Text` | where a person signs in |

One amount and one period rather than a monthly column and an annual one:
two numbers about one subscription can disagree, and a yearly figure is
arithmetic on a monthly one.

`auth_config` already carries a `login_url` for the publishers whose login
is automated — but that column is the extractor's parameters and is null on
every publisher nobody has automated, which is all of them but seven, and
exactly the ones somebody reading the record needs the link for.

## No credentials

The username and password stay in Secret Manager under `auth_secret_name`,
which is what this table already does and why `auth_config` carries the
comment that credentials are never stored in it.

A password column would be readable by every role holding SELECT on
`sources` — including the read-only analytics role Datadesk connects as,
and every CSV anybody exports.

## The test

`has_paywall` is NOT NULL. **Adding a NOT NULL column to a populated table
fails outright unless it carries a server default**, and a migration test
against an empty database never finds out — production has 1,149 publisher
records.

So the test downgrades to `d86ffabfebe9`, inserts a source, upgrades, and
reads the row back: `has_paywall` is `false` rather than null, the rest are
null, and the values round-trip with `12.99` still `12.99` and not
`12.989999999`.

Verified against a real PostgreSQL 16 — the full chain applies from empty
to head with this last, and the seeded-row test passes.

Unit suite: 3356 passed, 107 skipped.