### PR TITLE
Build gazetteers in the right state, and stop matching names that are not names

### DIFF
--- a/scripts/populate_gazetteer.py
+++ b/scripts/populate_gazetteer.py
@@ -495,8 +495,18 @@ def enrich_publisher_osm_data(
 
     # Use the existing geocoding and OSM processing logic
     # [This would call the same logic as the bulk processor but for one source]
+    dataset_default_state = ""
+    ds_row = session.get(Dataset, dataset_id)
+    if ds_row is not None:
+        dataset_default_state = ((ds_row.meta or {}).get("default_state") or "").strip()
+
     success = _process_single_source_osm(
-        session, src, dataset_id, radius_miles, dry_run=False
+        session,
+        src,
+        dataset_id,
+        radius_miles,
+        dry_run=False,
+        dataset_default_state=dataset_default_state,
     )
 
     if success:
@@ -507,7 +517,25 @@ def enrich_publisher_osm_data(
     return success
 
 
-def _process_single_source_osm(session, src, dataset_id, radius_miles, dry_run=False):
+def resolve_source_state(src, dataset_default=""):
+    """The state a source is actually in -- never a guess.
+
+    A dataset is a coverage list, not a location: the Mizzou dataset
+    holds KC-metro publishers that sit in Kansas, and a Vermont upload
+    arrives with no state at all. Defaulting the state to the dataset's
+    own state geocodes those publishers into the wrong state, and
+    "Mission, Johnson, MO" does not fail loudly -- the Census lookup
+    misses, Nominatim fuzzy-matches, and the gazetteer is built around a
+    point eight miles from the newsroom. Return "" and let the caller
+    skip with a reason instead.
+    """
+    state = (src.get("metadata") or {}).get("state") or ""
+    return (state or dataset_default or "").strip()
+
+
+def _process_single_source_osm(
+    session, src, dataset_id, radius_miles, dry_run=False, dataset_default_state=""
+):
     """
     Process OSM data for a single source. Extracted for reuse between
     bulk processing and on-demand enrichment.
@@ -548,10 +576,14 @@ def _process_single_source_osm(session, src, dataset_id, radius_miles, dry_run=F
         latlon = None
 
         # First try full address if we have street address info
-        state = src.get("metadata") and src.get("metadata", {}).get("state")
-        # Default to Missouri for news sources if state not specified
+        state = resolve_source_state(src, dataset_default_state)
         if not state:
-            state = "MO"
+            print(
+                "      Skipping: no state on the source and none on the "
+                "dataset; a centroid guessed from the wrong state is worse "
+                "than no gazetteer"
+            )
+            return False
 
         # Try to build the most complete address possible
         meta = src.get("metadata", {})
@@ -1578,6 +1610,7 @@ def main(
 
     for ds in datasets:
         print(f"Processing dataset: {ds.slug} ({ds.label})")
+        dataset_default_state = ((ds.meta or {}) or {}).get("default_state", "") or ""
 
         # Get mapped sources for this dataset from dataset_sources join
         meta = MetaData()
@@ -1636,9 +1669,14 @@ def main(
             # (offline, deterministic, and the same source our FIPS ladder
             # uses), then ZIP, then Nominatim as a last resort.
             latlon = None
-            src_state = (
-                src.get("metadata") and src.get("metadata", {}).get("state")
-            ) or "MO"
+            src_state = resolve_source_state(src, dataset_default_state)
+            if not src_state:
+                print(
+                    "    Skipping: no state on the source and none on the "
+                    "dataset; a centroid guessed from the wrong state is "
+                    "worse than no gazetteer"
+                )
+                continue
             if src.get("city"):
                 census_hit = census_place_geoid(src.get("city"), src_state)
                 if census_hit is not None and census_hit.lat is not None:

--- a/scripts/populate_gazetteer.py
+++ b/scripts/populate_gazetteer.py
@@ -210,6 +210,7 @@ def geocode_address_nominatim(address: str) -> dict[str, float] | None:
 # Import ORM models after ensuring `src` is on sys.path
 from src.enrichment.fips import place_geoid as census_place_geoid  # noqa: E402
 from src.models import Dataset, GeocodeCache  # noqa: E402
+from src.utils.gazetteer_names import is_matchable_gazetteer_name  # noqa: E402
 
 # Expose create_engine at module level so tests can monkeypatch/import it
 # Tests expect scripts.populate_gazetteer.create_engine to exist.
@@ -843,7 +844,10 @@ def _process_single_source_osm(
             for el in elements:
                 tags = el.get("tags", {}) or {}
                 name = tags.get("name")
-                if not name:
+                if not is_matchable_gazetteer_name(name):
+                    # Lettered bus stops and numbered ball fields are real
+                    # map data and useless as text; keeping them out here
+                    # keeps them out of every match downstream.
                     continue
 
                 osm_type = el.get("type")
@@ -1771,7 +1775,7 @@ def main(
                 for el in elements:
                     tags = el.get("tags", {}) or {}
                     name = tags.get("name")
-                    if not name:
+                    if not is_matchable_gazetteer_name(name):
                         continue
                     osm_type = el.get("type")
                     osm_id = str(el.get("id"))

--- a/src/pipeline/entity_extraction.py
+++ b/src/pipeline/entity_extraction.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from src.models import Gazetteer
 from src.models.database import safe_session_execute
 from src.pipeline.text_cleaning import decode_rot47_segments
+from src.utils.gazetteer_names import is_matchable_gazetteer_name
 
 logger = logging.getLogger(__name__)
 
@@ -136,12 +137,18 @@ class ArticleEntityExtractor:
                         norm_name,
                         (osm_category, osm_subcategory),
                     )
+                if not is_matchable_gazetteer_name(name):
+                    # A POI called "A" becomes a pattern that fires on
+                    # every "a" in the article. See src/utils/gazetteer_names.
+                    continue
                 key = (label_override, name.lower())
                 if key not in seen_patterns:
                     pattern_entries.append((label_override, name))
                     seen_patterns.add(key)
 
                 name_norm = getattr(row, "name_norm", None)
+                if not is_matchable_gazetteer_name(name_norm):
+                    name_norm = None
                 if name_norm and name_norm.strip():
                     norm_norm = _normalize_text(name_norm)
                     if norm_norm:
@@ -316,6 +323,8 @@ def _score_match(
 
     best_match: GazetteerMatch | None = None
     for entry in candidates:
+        if not is_matchable_gazetteer_name(getattr(entry, "name", None)):
+            continue
         name_norm = getattr(entry, "name_norm", None)
         entry_norm = name_norm or _normalize_text(entry.name or "")
         if not entry_norm:
@@ -373,7 +382,10 @@ def get_gazetteer_rows(
     else:
         stmt = stmt.where(filters[0])
 
-    return list(safe_session_execute(session, stmt).scalars().all())
+    rows = list(safe_session_execute(session, stmt).scalars().all())
+    # Unmatchable names are dropped here so both the EntityRuler and the
+    # fuzzy scorer see the same corpus, however they were called.
+    return [row for row in rows if is_matchable_gazetteer_name(row.name)]
 
 
 def attach_gazetteer_matches(

--- a/src/utils/gazetteer_names.py
+++ b/src/utils/gazetteer_names.py
@@ -1,0 +1,35 @@
+"""Which gazetteer names are safe to match against article text.
+
+OSM is full of named things whose names are not names: bus stops lettered
+A through P, ball fields numbered #1 through #6, emergency access points
+called "2", building numbers like "1327". They are legitimate map data
+and useless as text.
+
+The matcher turns every gazetteer name into an EntityRuler pattern, so a
+POI called "A" becomes a pattern that fires on every "a" in an article.
+Before this guard, 68,676 of 142,282 gazetteer entity matches in the
+corpus -- 48.3%, across 27,360 articles and 60 publishers -- were on
+names of two characters or fewer: "A" alone accounted for 22,251.
+
+Two rules, drawn from the corpus rather than from taste:
+
+- Fewer than three characters is rejected. Length 1 and 2 are 68,676
+  matches over 58 distinct names, effectively all noise. The real
+  businesses in that band -- BP, QT, TA -- are unrecoverable as bare
+  tokens anyway.
+- No alphabetic character is rejected at any length, which catches
+  "1327", "1501", "1984" and "99+" that survive the length rule.
+
+Length 3 is kept: 265 matches over 26 names, nearly all real (CVS, AMC,
+IRS, DMV, Kia, Cox).
+"""
+
+
+def is_matchable_gazetteer_name(name: object) -> bool:
+    """True when this name can be matched against prose without poisoning it."""
+    if not isinstance(name, str):
+        return False
+    stripped = name.strip()
+    if len(stripped) < 3:
+        return False
+    return any(character.isalpha() for character in stripped)

--- a/tests/pipeline/test_entity_extraction.py
+++ b/tests/pipeline/test_entity_extraction.py
@@ -183,25 +183,25 @@ def test_get_gazetteer_rows_filters_by_source_or_dataset(
             id="1",
             source_id="source-1",
             dataset_id=None,
-            name="A",
+            name="Ashland Public Library",
         ),
         Gazetteer(
             id="2",
             source_id=None,
             dataset_id="dataset-1",
-            name="B",
+            name="Boone County Courthouse",
         ),
         Gazetteer(
             id="3",
             source_id="source-1",
             dataset_id="dataset-1",
-            name="C",  # Matches BOTH source AND dataset
+            name="Columbia Fire Station",  # Matches BOTH source AND dataset
         ),
         Gazetteer(
             id="4",
             source_id="source-other",
             dataset_id="dataset-other",
-            name="D",
+            name="Danville Community Center",
         ),
     ]
     in_memory_session.add_all(rows)

--- a/tests/test_gazetteer_name_guard.py
+++ b/tests/test_gazetteer_name_guard.py
@@ -1,0 +1,123 @@
+"""Names that are not names must not become text patterns.
+
+48.3% of gazetteer entity matches in the corpus -- 68,676 of 142,282,
+across 27,360 articles and 60 publishers -- were on OSM names of two
+characters or fewer: lettered bus stops, numbered ball fields, building
+numbers. The matcher compiles every gazetteer name into an EntityRuler
+pattern, so a POI called "A" fired on every "a" in every article.
+"""
+
+import pytest
+
+from src.utils.gazetteer_names import is_matchable_gazetteer_name
+
+
+def _spacy_model_available() -> bool:
+    try:
+        import spacy
+
+        spacy.load("en_core_web_sm")
+    except Exception:
+        return False
+    return True
+
+
+HAS_SPACY_MODEL = _spacy_model_available()
+
+
+@pytest.mark.parametrize("name", ["A", "I", "O", "#4", "10", "BP", "QT", "S2"])
+def test_two_characters_or_fewer_is_not_matchable(name):
+    assert is_matchable_gazetteer_name(name) is False
+
+
+@pytest.mark.parametrize("name", ["1327", "1501", "1984", "99+", "2"])
+def test_a_name_with_no_letter_is_not_matchable(name):
+    """These survive the length rule and are still not names."""
+    assert is_matchable_gazetteer_name(name) is False
+
+
+@pytest.mark.parametrize("name", ["CVS", "AMC", "IRS", "Kia", "Cox", "C-3"])
+def test_three_characters_with_a_letter_is_kept(name):
+    """265 matches over 26 names, nearly all real businesses."""
+    assert is_matchable_gazetteer_name(name) is True
+
+
+def test_real_names_are_untouched():
+    assert is_matchable_gazetteer_name("First Baptist Church of Mission")
+    assert is_matchable_gazetteer_name("RJ's Bob-be-que Shack")
+
+
+@pytest.mark.parametrize("name", ["", "   ", None, 4, b"AAA"])
+def test_absent_or_non_string_names_are_not_matchable(name):
+    assert is_matchable_gazetteer_name(name) is False
+
+
+def test_whitespace_does_not_buy_length():
+    assert is_matchable_gazetteer_name("  A  ") is False
+
+
+class _Row:
+    def __init__(self, name, category="businesses"):
+        self.name = name
+        self.name_norm = name.lower() if isinstance(name, str) else None
+        self.category = category
+
+
+@pytest.mark.skipif(not HAS_SPACY_MODEL, reason="en_core_web_sm not installed")
+def test_the_matcher_builds_no_pattern_for_a_single_letter():
+    """The end of the bug: "A" reaching the EntityRuler as a pattern.
+
+    Without the guard the gazetteer row named "A" compiles into a
+    pattern that promotes the article's opening "A" into an ORG entity.
+    Confirmed by bypassing the guard: the entity appears, labelled ORG,
+    at start_char 0.
+
+    "1327" is deliberately not asserted on. It is extracted either way,
+    by spaCy's own DATE recogniser rather than from the gazetteer, so it
+    would pass with or without the fix and prove nothing.
+    """
+    from src.pipeline.entity_extraction import ArticleEntityExtractor
+
+    rows = [_Row("A"), _Row("#4"), _Row("1327"), _Row("Sushi Karma Asian Bistro")]
+    text = "A car drove past Sushi Karma Asian Bistro at 1327 on a warm day."
+
+    found = {
+        entity["entity_text"]
+        for entity in ArticleEntityExtractor().extract(text, gazetteer_rows=rows)
+    }
+
+    assert "A" not in found
+    assert "#4" not in found
+    assert "Sushi Karma Asian Bistro" in found
+
+
+@pytest.mark.skipif(not HAS_SPACY_MODEL, reason="en_core_web_sm not installed")
+def test_without_the_guard_a_single_letter_becomes_an_entity(monkeypatch):
+    """A test that cannot fail is not a test.
+
+    This pins the defect itself, so the guard above is known to be what
+    removes it rather than something incidental about the fixture.
+    """
+    import src.pipeline.entity_extraction as entity_extraction
+
+    monkeypatch.setattr(
+        entity_extraction, "is_matchable_gazetteer_name", lambda name: True
+    )
+
+    rows = [_Row("A"), _Row("Sushi Karma Asian Bistro")]
+    text = "A car drove past Sushi Karma Asian Bistro at 1327 on a warm day."
+
+    found = {
+        entity["entity_text"]
+        for entity in entity_extraction.ArticleEntityExtractor().extract(
+            text, gazetteer_rows=rows
+        )
+    }
+
+    assert "A" in found
+
+
+def test_the_fuzzy_scorer_rejects_an_unmatchable_candidate():
+    from src.pipeline.entity_extraction import _score_match
+
+    assert _score_match("a", [_Row("A")]) is None

--- a/tests/test_gazetteer_state_resolution.py
+++ b/tests/test_gazetteer_state_resolution.py
@@ -1,0 +1,51 @@
+"""A gazetteer is only as good as the state it is built in.
+
+The Mizzou dataset is a list of publishers who *cover* Missouri, not a
+list of publishers who *sit* in Missouri: the Kansas City metro spans
+the state line, so KMBZ (Mission, KS) and Dos Mundos (Overland Park, KS)
+are legitimately in it. When the builder defaulted a missing state to
+"MO" it did not fail loudly -- the Census place lookup missed, Nominatim
+fuzzy-matched "Mission, Johnson, MO", and the gazetteer came out
+centred eight miles from the newsroom, full of the wrong town's schools
+and churches.
+
+No state at all is the more common case: 896 of 901 Vermont sources
+arrive without one. Guessing is what these tests forbid.
+"""
+
+from scripts.populate_gazetteer import resolve_source_state
+
+
+def test_the_source_state_wins():
+    src = {"metadata": {"state": "KS"}, "city": "Mission"}
+    assert resolve_source_state(src, dataset_default="MO") == "KS"
+
+
+def test_the_dataset_default_fills_a_gap():
+    src = {"metadata": {}, "city": "Columbia"}
+    assert resolve_source_state(src, dataset_default="MO") == "MO"
+
+
+def test_no_state_anywhere_resolves_to_nothing():
+    """The caller skips on "" -- it must never receive a guess."""
+    src = {"metadata": {}, "city": "Montpelier"}
+    assert resolve_source_state(src, dataset_default="") == ""
+    assert resolve_source_state({"city": "Montpelier"}, dataset_default="") == ""
+
+
+def test_a_missing_metadata_key_is_not_an_error():
+    assert resolve_source_state({}, dataset_default="WA") == "WA"
+    assert resolve_source_state({"metadata": None}, dataset_default="WA") == "WA"
+
+
+def test_the_state_is_not_defaulted_to_missouri_anywhere_in_the_builder():
+    """The specific regression: a hardcoded "MO" fallback.
+
+    It lived in two centroid paths and would have geocoded every
+    stateless Vermont source into Missouri on the next upload.
+    """
+    from pathlib import Path
+
+    src_text = Path("scripts/populate_gazetteer.py").read_text()
+    assert 'or "MO"' not in src_text
+    assert 'state = "MO"' not in src_text


### PR DESCRIPTION
Two defects in the gazetteer, found together while investigating a review-queue flag on `audacy.com`.

## 1. The centroid was guessed from the wrong state

`scripts/populate_gazetteer.py` defaulted a missing state to `"MO"` in both centroid paths. A dataset is a coverage list, not a location: the Mizzou dataset legitimately holds Kansas City metro publishers on the Kansas side of the line, and 896 of 901 Vermont sources carry no state at all.

The default did not fail loudly. For KMBZ (`audacy.com`, Mission, KS) the Census place lookup returned `None` — Missouri has no Mission — so the code fell through to Nominatim with `"Mission, Johnson, MO"`, which fuzzy-matched a point roughly eight miles east, in Kansas City, Missouri. A 4,719-entry gazetteer was built out from there with no indication anything was wrong.

```
MO / Mission         -> None
KS / Mission         -> GeoidResult(geoid='2047225', lat=39.026774, lon=-94.656962)
MO / Overland Park   -> None
KS / Overland Park   -> GeoidResult(geoid='2053775', lat=38.889042, lon=-94.690584)
```

- `resolve_source_state()` reads the source's own `metadata.state`, falls back to the dataset's `default_state`, and otherwise returns `""`.
- Both centroid paths skip a source with no resolvable state and print the reason, rather than geocoding it into a state it is not in.
- `enrich_publisher_osm_data()` looks up the dataset default and threads it into the single-source path.

Only Mizzou currently carries `default_state`, so stateless VT and WSU-Washington sources now skip with a reason instead of silently resolving to Missouri.

## 2. Half of all entity matches were on names that are not names

OSM letters bus stops A through P, numbers ball fields #1 through #6, and records building numbers like 1327. The matcher compiles every gazetteer name into an EntityRuler pattern, so a POI called "A" became a pattern firing on every "a" in every article.

**68,676 of 142,282 gazetteer entity matches — 48.3%, across 27,360 articles and 60 publishers — were on names of two characters or fewer.** "A" alone accounted for 22,251 across two categories; "I" 4,818; "#4" 3,533.

Two rules, drawn from the corpus rather than from taste:

| band | matches | distinct names | verdict |
|---|---|---|---|
| 1–2 chars | 68,676 | 58 | rejected — effectively all noise; the real ones (BP, QT, TA) are unrecoverable as bare tokens |
| no letter, any length | — | 39 | rejected — catches 1327, 1501, 1984, 99+ |
| 3 chars | 265 | 26 | kept — nearly all real: CVS, AMC, IRS, DMV, Kia, Cox |

- `src/utils/gazetteer_names.is_matchable_gazetteer_name()` holds the rule once, for both the builder and the matcher.
- Matcher guarded at four sites: EntityRuler pattern construction for both `name` and `name_norm`, `get_gazetteer_rows()`, and `_score_match()` — a caller may pass pre-loaded rows that never went through the query.
- Builder skips unmatchable names at both ingest sites.

## Verification

- `tests/test_gazetteer_state_resolution.py` (5 tests): state precedence, dataset fallback, the empty result, absent or null metadata keys, and a regression guard asserting no hardcoded `"MO"` fallback remains.
- `tests/test_gazetteer_name_guard.py` (29 tests): both rules against real corpus names, non-string and whitespace input, and an end-to-end pass showing "A" is not extracted from prose.
- `test_without_the_guard_a_single_letter_becomes_an_entity` bypasses the guard and asserts "A" **is** extracted, so the guard is provably what removes it. The first draft of that covering test asserted on a `text` key the extractor does not emit and passed either way; it was rewritten against observed output.
- `test_get_gazetteer_rows_filters_by_source_or_dataset` fixtures were renamed from single letters to real place names — they were placeholders, and `get_gazetteer_rows` now filters them before the AND logic under test is reached.
- Full pre-push suite green: 3,250 passed, PostgreSQL suite, 80% combined coverage gate.

## Applied to production separately

- KMBZ and Dos Mundos corrected to `state: KS` (I set them to MO on 2026-08-21 by bulk-filling blank states from dataset membership; Johnson County was the tell).
- `gs://mizzou-osm-extracts/poi/kansas.csv` staged, 18,324 named POIs. The KC metro spans the state line and the Missouri Geofabrik clip held only 475 of 5,182 POIs within 20 miles of Mission; adding Kansas raises that to 4,117.
- KMBZ gazetteer rebuilt on the corrected centroid: 8,802 entries, 4,092 Kansas-side. Nearest entries are now First Baptist Church of Mission and Mission Veterinary Emergency, against the old build's Wornall Road eight miles east.