### PR TITLE
Point every consumer at the SSD database instance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ BigQuery Export → analytics datasets
 
 ### Infrastructure
 
-- **Database**: Cloud SQL PostgreSQL (`mizzou-db-prod`) via Cloud SQL Connector (no proxy sidecar)
+- **Database**: Cloud SQL PostgreSQL (`mizzou-db-prod-ssd`) via Cloud SQL Connector (no proxy sidecar)
 - **Container Registry**: Artifact Registry (`us-central1-docker.pkg.dev/mizzou-news-crawler`)
 - **Build System**: Cloud Build with selective service detection (only rebuilds changed services)
 - **Orchestration**: Argo Workflows with dataset-specific CronWorkflows
@@ -39,7 +39,7 @@ BigQuery Export → analytics datasets
 
 ### 1. **NEVER look for production data in the local database**
 - The local database is EMPTY or STALE
-- Production data is ONLY in Cloud SQL (mizzou-db-prod)
+- Production data is ONLY in Cloud SQL (mizzou-db-prod-ssd)
 - Always access production data via `kubectl exec` into a production pod
 - If you try to test against local data, you're wasting everyone's time
 

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
         - name: PORT
           value: "8000"
         resources:

--- a/k8s/argo/base-pipeline-workflow.yaml
+++ b/k8s/argo/base-pipeline-workflow.yaml
@@ -216,7 +216,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       # Proxy configuration
       - name: PROXY_PROVIDER
         value: "squid"
@@ -314,7 +314,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       # Proxy configuration
       - name: PROXY_PROVIDER
         value: "squid"
@@ -426,7 +426,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       # Work queue coordination
       - name: USE_WORK_QUEUE
         value: "true"
@@ -571,7 +571,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
 
   # Wait template: poll DB until a minimum number of verified articles exist
   - name: wait-for-verified
@@ -669,7 +669,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
 
   # Calculate optimal extraction workers based on backlog
   - name: calculate-extraction-workers
@@ -775,4 +775,4 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"

--- a/k8s/argo/minnesota-processing-workflow.yaml
+++ b/k8s/argo/minnesota-processing-workflow.yaml
@@ -73,7 +73,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       - name: DATASET_FILTER
         value: "minnesota-news-sources"
   
@@ -114,7 +114,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       - name: DATASET_FILTER
         value: "minnesota-news-sources"
   
@@ -155,6 +155,6 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "true"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       - name: DATASET_FILTER
         value: "minnesota-news-sources"

--- a/k8s/cli-deployment.yaml
+++ b/k8s/cli-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
 
         # Database configuration
         - name: DATABASE_ENGINE

--- a/k8s/crawler-cronjob.yaml
+++ b/k8s/crawler-cronjob.yaml
@@ -45,7 +45,7 @@ spec:
             - name: USE_CLOUD_SQL_CONNECTOR
               value: "true"
             - name: CLOUD_SQL_INSTANCE
-              value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+              value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/k8s/deploy-migration-job.tpl.yaml
+++ b/k8s/deploy-migration-job.tpl.yaml
@@ -35,7 +35,7 @@ spec:
       # credentials and the API answers 403:
       #
       #   boss::NOT_AUTHORIZED: Possibly missing permission
-      #   cloudsql.instances.get on resource instances/mizzou-db-prod
+      #   cloudsql.instances.get on resource instances/mizzou-db-prod-ssd
       #
       # Nothing needs granting: mizzou-app maps to mizzou-k8s-sa, which
       # already holds roles/cloudsql.client, and every other workload here

--- a/k8s/enrichment-cronjob.yaml
+++ b/k8s/enrichment-cronjob.yaml
@@ -65,7 +65,7 @@ spec:
                 - name: USE_CLOUD_SQL_CONNECTOR
                   value: "true"
                 - name: CLOUD_SQL_INSTANCE
-                  value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+                  value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
                 - name: DATABASE_USER
                   valueFrom:
                     secretKeyRef:

--- a/k8s/housekeeping-cronjob.yaml
+++ b/k8s/housekeeping-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             - name: USE_CLOUD_SQL_CONNECTOR
               value: "true"
             - name: CLOUD_SQL_INSTANCE
-              value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+              value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/k8s/lehigh-extraction-job.yaml
+++ b/k8s/lehigh-extraction-job.yaml
@@ -73,7 +73,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
         # Proxy configuration
         - name: PROXY_PROVIDER
           value: "squid"

--- a/k8s/migration-job.yaml
+++ b/k8s/migration-job.yaml
@@ -51,7 +51,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
 
         resources:
           requests:

--- a/k8s/minnesota-processor-deployment.yaml
+++ b/k8s/minnesota-processor-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
         - name: DATASET_FILTER
           value: "minnesota-news-sources"
         - name: MEDIACLOUD_ENABLED

--- a/k8s/mizzou-discovery-job.yaml
+++ b/k8s/mizzou-discovery-job.yaml
@@ -79,7 +79,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
         # Proxy configuration
         - name: PROXY_PROVIDER
           value: "squid"

--- a/k8s/mizzou-extraction-job.yaml
+++ b/k8s/mizzou-extraction-job.yaml
@@ -79,7 +79,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
         # Proxy configuration
         - name: PROXY_PROVIDER
           value: "squid"

--- a/k8s/processor-cronjob.yaml
+++ b/k8s/processor-cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             - name: USE_CLOUD_SQL_CONNECTOR
               value: "true"
             - name: CLOUD_SQL_INSTANCE
-              value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+              value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:

--- a/k8s/processor-deployment.yaml
+++ b/k8s/processor-deployment.yaml
@@ -61,7 +61,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: "true"
         - name: CLOUD_SQL_INSTANCE
-          value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+          value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
         # Processor configuration
         - name: POLL_INTERVAL
           value: "60"

--- a/k8s/templates/dataset-discovery-job.yaml
+++ b/k8s/templates/dataset-discovery-job.yaml
@@ -84,7 +84,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: 'true'
         - name: CLOUD_SQL_INSTANCE
-          value: mizzou-news-crawler:us-central1:mizzou-db-prod
+          value: mizzou-news-crawler:us-central1:mizzou-db-prod-ssd
         - name: PROXY_PROVIDER
           value: squid
         - name: SQUID_PROXY_URL

--- a/k8s/templates/dataset-extraction-job.yaml
+++ b/k8s/templates/dataset-extraction-job.yaml
@@ -84,7 +84,7 @@ spec:
         - name: USE_CLOUD_SQL_CONNECTOR
           value: 'true'
         - name: CLOUD_SQL_INSTANCE
-          value: mizzou-news-crawler:us-central1:mizzou-db-prod
+          value: mizzou-news-crawler:us-central1:mizzou-db-prod-ssd
         - name: PROXY_PROVIDER
           value: squid
         - name: SQUID_PROXY_URL

--- a/k8s/tests/extraction-test2.yaml
+++ b/k8s/tests/extraction-test2.yaml
@@ -50,7 +50,7 @@ spec:
       - name: USE_CLOUD_SQL_CONNECTOR
         value: "false"
       - name: CLOUD_SQL_INSTANCE
-        value: "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       - name: INTER_REQUEST_MIN
         value: "2.0"
       - name: INTER_REQUEST_MAX
@@ -71,7 +71,7 @@ spec:
       args:
         - "--structured-logs"
         - "--port=5432"
-        - "mizzou-news-crawler:us-central1:mizzou-db-prod"
+        - "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
       securityContext:
         runAsNonRoot: true
       resources:

--- a/scripts/launch_dataset_job.py
+++ b/scripts/launch_dataset_job.py
@@ -238,7 +238,7 @@ def create_job_manifest(
                                 },
                                 {
                                     "name": "CLOUD_SQL_INSTANCE",
-                                    "value": "mizzou-news-crawler:us-central1:mizzou-db-prod",
+                                    "value": "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd",
                                 },
                                 # Proxy - Squid doesn't need authentication
                                 {"name": "PROXY_PROVIDER", "value": "squid"},


### PR DESCRIPTION
## Summary

The production database was `db-g1-small` on **PD_HDD** with a 15GB disk. Google's HDD persistent disks deliver about 0.75 sustained random read IOPS per GB, so that instance had roughly **11**. Against a 5.8GB database with 128MB of shared buffers, the buffer hit ratio was **54.4%** — nearly half of all block reads went to a spinning disk at 11 IOPS.

Measured on the same query (the paywalls page aggregate), same data, cold:

| | |
|---|---|
| `mizzou-db-prod` — PD_HDD | **166.1s** |
| `mizzou-db-prod-ssd` — PD_SSD | **5.6s** |

This is what made the datadesk paywalls page take 104 seconds, and it slowed everything else against the instance too.

Cloud SQL cannot change storage type in place. The API is explicit:

```
400: Invalid request: Storage type ("dataDiskType") cannot be changed.
```

So this is a new instance, and because an instance name cannot be reused for a week after deletion, it needs a new name — which every reference has to follow.

## The migration, already performed

- `mizzou-db-prod-ssd` created: POSTGRES_16, us-central1, ENTERPRISE edition, `db-g1-small`, **PD_SSD 30GB** with auto-increase, same flags (`cloudsql.logical_decoding=on`, `max_connections=100`), backups enabled.
- Restored from an on-demand backup of `mizzou-db-prod` taken immediately beforehand.
- Verified row-for-row:

| table | old | new |
|---|---|---|
| sources | 1,149 | 1,149 |
| articles | 164,570 | 164,570 |
| article_entities | 2,954,584 | 2,954,584 |
| gazetteer | 558,540 | 558,540 |
| article_enrichment | 19,454 | 19,454 |
| candidate_links | 262,137 | 262,137 |
| datasets | 4 | 4 |

- Roles `mizzou_user`, `datadesk_ro`, `datadesk_rw`, `postgres` all present.

**The instance carries three databases** — `mizzou`, `datadesk` and `directory` — so the cutover spans the crawler, datadesk and the Source Directory. All three came across in the restore.

## Changes in this PR

`CLOUD_SQL_INSTANCE` updated across 13 k8s manifests, both job templates, both Argo workflows, the test manifest and `scripts/launch_dataset_job.py`, plus documentation references so the next reader is not sent to an instance that is going away.

Every YAML file still parses, and no reference to the old instance remains under `k8s/`, `.github/`, `scripts/` or `src/`.

## Done outside this repository

- Secrets `db-instance-connection-name`, `db-connection-string`, `db-connection-string-fixed` updated (new connection name; new IP 34.27.228.250).
- Cloud Run `datadesk` and `datadesk-data` (lnic-datadesk) moved — annotation and `CLOUD_SQL_CONNECTION_NAME`. Both verified healthy against the new instance.

## Still outstanding

- **`sources-admin` (lnic-source-directory) is still on the old instance.** The update command was refused by a local permission classifier, twice. It needs the same two changes.
- These manifests take effect on the next deploy. The crawler crons are suspended, so nothing is currently connecting from GKE.
- The old instance is left running and untouched, as the rollback path. It should be deleted only after `sources-admin` moves and the cluster picks up these manifests.