### PR TITLE
Point the build, the alerts and the function at the SSD instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MizzouNewsCrawler is a cloud-native news discovery and processing pipeline that 
 
 - **Deployment**: Google Kubernetes Engine (GKE) cluster `mizzou-cluster` in `us-central1-a`
 
-- **Database**: Cloud SQL PostgreSQL (`mizzou-db-prod`) with Cloud SQL Connector
+- **Database**: Cloud SQL PostgreSQL (`mizzou-db-prod-ssd`) with Cloud SQL Connector
 
 - **Orchestration**: Argo Workflows with CronWorkflow scheduling for pipeline automation
 
@@ -31,7 +31,7 @@ MizzouNewsCrawler is a cloud-native news discovery and processing pipeline that 
 
 - **GKE Cluster**: `mizzou-cluster` in `us-central1-a` zone
 
-- **Database**: Cloud SQL PostgreSQL instance `mizzou-db-prod`
+- **Database**: Cloud SQL PostgreSQL instance `mizzou-db-prod-ssd`
 
 - **Connection Pattern**: Cloud SQL Connector (no proxy sidecar required)
 
@@ -1808,7 +1808,7 @@ DATABASE_ENGINE=postgresql+psycopg2
 DATABASE_HOST=127.0.0.1  # Cloud SQL Connector local endpoint
 DATABASE_PORT=5432
 USE_CLOUD_SQL_CONNECTOR=true
-CLOUD_SQL_INSTANCE=mizzou-news-crawler:us-central1:mizzou-db-prod
+CLOUD_SQL_INSTANCE=mizzou-news-crawler:us-central1:mizzou-db-prod-ssd
 
 # Pipeline Step Feature Flags (Issue #77 refactoring)
 ENABLE_DISCOVERY=false      # Moved to Argo workflows

--- a/docs/BACKFIELD_ENRICHMENT.md
+++ b/docs/BACKFIELD_ENRICHMENT.md
@@ -168,7 +168,7 @@ Celery, no APIs, no UIs.** One container image, one job.
 ### The extension that would have forced a self-managed database
 
 Backfield's schema requires `postgis`, `vector`, `pg_trgm` and `h3`. Checked
-against `mizzou-db-prod`:
+against `mizzou-db-prod-ssd`:
 
 ```
 postgis   3.6.0   available

--- a/docs/TESTING_OPERATIONS_DASHBOARD.md
+++ b/docs/TESTING_OPERATIONS_DASHBOARD.md
@@ -155,7 +155,7 @@ If you want to run the **entire stack locally** (API + Frontend):
 # https://cloud.google.com/sql/docs/mysql/sql-proxy
 
 # Run proxy (replace with your instance connection name)
-cloud-sql-proxy mizzou-news-crawler:us-central1:mizzou-db-prod \
+cloud-sql-proxy mizzou-news-crawler:us-central1:mizzou-db-prod-ssd \
     --port 5432
 ```
 

--- a/docs/root-md/WEEKLY_HEALTH_CHECK_CHECKLIST.md
+++ b/docs/root-md/WEEKLY_HEALTH_CHECK_CHECKLIST.md
@@ -23,7 +23,7 @@
 - [ ] Cloud Build API enabled: `gcloud services enable cloudbuild.googleapis.com`
 - [ ] Secret Manager API enabled: `gcloud services enable secretmanager.googleapis.com`
 - [ ] Cloud Scheduler API enabled: `gcloud services enable cloudscheduler.googleapis.com`
-- [ ] Cloud SQL instance exists: `mizzou-db-prod` in `us-central1`
+- [ ] Cloud SQL instance exists: `mizzou-db-prod-ssd` in `us-central1`
 - [ ] GCS bucket exists: `gs://mizzou-news-crawler-reports` (or create one)
 
 ### Gmail Setup
@@ -38,7 +38,7 @@
 - [ ] Note the GCP project ID: `mizzou-news-crawler`
 - [ ] Identify recipient email address for reports
 - [ ] Verify service account `default@mizzou-news-crawler.iam.gserviceaccount.com` exists
-- [ ] Confirm Cloud SQL connection name: `mizzou-news-crawler:us-central1:mizzou-db-prod`
+- [ ] Confirm Cloud SQL connection name: `mizzou-news-crawler:us-central1:mizzou-db-prod-ssd`
 
 ---
 
@@ -89,7 +89,7 @@ gcloud functions deploy weekly-source-health-check \
   --allow-unauthenticated \
   --memory 512MB \
   --timeout 540 \
-  --set-env-vars "CLOUD_SQL_CONNECTION_NAME=$PROJECT_ID:$REGION:mizzou-db-prod" \
+  --set-env-vars "CLOUD_SQL_CONNECTION_NAME=$PROJECT_ID:$REGION:mizzou-db-prod-ssd" \
   --ingress-settings internal-only
 ```
 

--- a/docs/root-md/WEEKLY_HEALTH_CHECK_DEPLOYMENT.md
+++ b/docs/root-md/WEEKLY_HEALTH_CHECK_DEPLOYMENT.md
@@ -104,15 +104,15 @@ The function needs to connect to Cloud SQL. Update the `--set-env-vars` command 
 
 ```bash
 # Get connection string format
-gcloud sql instances describe mizzou-db-prod --format="value(connectionName)"
-# Output: mizzou-news-crawler:us-central1:mizzou-db-prod
+gcloud sql instances describe mizzou-db-prod-ssd --format="value(connectionName)"
+# Output: mizzou-news-crawler:us-central1:mizzou-db-prod-ssd
 
 # Update function environment variable
 gcloud functions deploy weekly-source-health-check \
   --gen2 \
   --runtime python311 \
   --region us-central1 \
-  --set-env-vars CLOUD_SQL_CONNECTION_NAME="mizzou-news-crawler:us-central1:mizzou-db-prod"
+  --set-env-vars CLOUD_SQL_CONNECTION_NAME="mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"
 ```
 
 ### Step 5: Grant Service Account Permissions
@@ -288,7 +288,7 @@ Note: SMTP/app passwords are no longer used. The system sends via Gmail API (ser
 
 1. Check Cloud SQL connection:
    ```bash
-   gcloud sql connect mizzou-db-prod --user mizzou_user
+   gcloud sql connect mizzou-db-prod-ssd --user mizzou_user
    ```
 
 2. Verify service account has `cloudsql.client` role:

--- a/docs/troubleshooting/BIGQUERY_EXPORT_DB_CONFIG_FIXES.md
+++ b/docs/troubleshooting/BIGQUERY_EXPORT_DB_CONFIG_FIXES.md
@@ -110,7 +110,7 @@ Created `scripts/test-bigquery-export.sh` to verify:
 For Cloud SQL Connector mode (production):
 ```bash
 USE_CLOUD_SQL_CONNECTOR=true
-CLOUD_SQL_INSTANCE=mizzou-news-crawler:us-central1:mizzou-db-prod
+CLOUD_SQL_INSTANCE=mizzou-news-crawler:us-central1:mizzou-db-prod-ssd
 DATABASE_USER=<from secret>
 DATABASE_PASSWORD=<from secret>
 DATABASE_NAME=<from secret>

--- a/gcp/cloudbuild/cloudbuild.yaml
+++ b/gcp/cloudbuild/cloudbuild.yaml
@@ -92,12 +92,12 @@ steps:
                 - name: USE_CLOUD_SQL_CONNECTOR
                   value: "true"
                 - name: CLOUD_SQL_INSTANCE
-                  value: "${PROJECT_ID}:us-central1:mizzou-db-prod"
+                  value: "${PROJECT_ID}:us-central1:mizzou-db-prod-ssd"
               - name: cloud-sql-proxy
                 image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
                 args:
                   - "--port=5432"
-                  - "${PROJECT_ID}:us-central1:mizzou-db-prod"
+                  - "${PROJECT_ID}:us-central1:mizzou-db-prod-ssd"
                 securityContext:
                   runAsNonRoot: true
         EOF

--- a/gcp_functions/weekly_source_health_check/README.md
+++ b/gcp_functions/weekly_source_health_check/README.md
@@ -170,12 +170,12 @@ Schedule formats (cron):
   - `DB_NAME` (the exact PostgreSQL database name in your Cloud SQL instance)
   - `DB_USER` and `DB_PASSWORD` (credentials with access to that DB)
   - or provide a full `DATABASE_URL` (e.g., `postgresql://user:pass@/your_db_name`) which the function will parse.
-  - `CLOUDSQL_INSTANCE` (connection name, e.g., `mizzou-news-crawler:us-central1:mizzou-db-prod`)
+  - `CLOUDSQL_INSTANCE` (connection name, e.g., `mizzou-news-crawler:us-central1:mizzou-db-prod-ssd`)
 
 List databases (to confirm the exact name):
 
 ```bash
-gcloud sql databases list --instance=mizzou-db-prod
+gcloud sql databases list --instance=mizzou-db-prod-ssd
 ```
 
 Set database env vars on deploy:
@@ -186,7 +186,7 @@ gcloud functions deploy weekly-source-health-check \
   --source gcp_functions/weekly_source_health_check \
   --entry-point weekly_source_health_check \
   --trigger-http --memory 512MB --timeout 540 \
-  --set-env-vars DB_NAME=YOUR_DB_NAME,DB_USER=YOUR_USER,CLOUDSQL_INSTANCE=mizzou-news-crawler:us-central1:mizzou-db-prod \
+  --set-env-vars DB_NAME=YOUR_DB_NAME,DB_USER=YOUR_USER,CLOUDSQL_INSTANCE=mizzou-news-crawler:us-central1:mizzou-db-prod-ssd \
   --set-env-vars GMAIL_DELEGATED_USER=sender@example.com \
   --set-env-vars GMAIL_CREDENTIALS_JSON=$(cat path/to/sa.json | base64)
 ```

--- a/gcp_functions/weekly_source_health_check/main.py
+++ b/gcp_functions/weekly_source_health_check/main.py
@@ -80,7 +80,7 @@ def weekly_source_health_check(request):
         db_user = os.getenv("DB_USER", "mizzou_user")
         db_pass = os.getenv("DB_PASSWORD")
         db_name = os.getenv("DB_NAME")
-        instance = os.getenv("CLOUDSQL_INSTANCE", "mizzou-news-crawler:us-central1:mizzou-db-prod")
+        instance = os.getenv("CLOUDSQL_INSTANCE", "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd")
         if database_url:
             try:
                 url = make_url(database_url)

--- a/manifests/fresh-extraction-test.yaml
+++ b/manifests/fresh-extraction-test.yaml
@@ -123,7 +123,7 @@ spec:
           - {name: DATABASE_URL, value: "$(DATABASE_ENGINE)://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)"}
           - {name: TELEMETRY_DATABASE_URL, value: "$(DATABASE_ENGINE)://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)"}
           - {name: USE_CLOUD_SQL_CONNECTOR, value: "true"}
-          - {name: CLOUD_SQL_INSTANCE, value: "mizzou-news-crawler:us-central1:mizzou-db-prod"}
+          - {name: CLOUD_SQL_INSTANCE, value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"}
           - {name: PROXY_PROVIDER, value: "squid"}
           - name: SQUID_PROXY_URL
             valueFrom: {secretKeyRef: {name: squid-proxy-credentials, key: squid-proxy-url}}
@@ -169,7 +169,7 @@ spec:
           - {name: DATABASE_URL, value: "$(DATABASE_ENGINE)://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)"}
           - {name: TELEMETRY_DATABASE_URL, value: "$(DATABASE_ENGINE)://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)"}
           - {name: USE_CLOUD_SQL_CONNECTOR, value: "true"}
-          - {name: CLOUD_SQL_INSTANCE, value: "mizzou-news-crawler:us-central1:mizzou-db-prod"}
+          - {name: CLOUD_SQL_INSTANCE, value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"}
           - {name: PROXY_PROVIDER, value: "squid"}
           - name: SQUID_PROXY_URL
             valueFrom: {secretKeyRef: {name: squid-proxy-credentials, key: squid-proxy-url}}
@@ -215,7 +215,7 @@ spec:
           - {name: DATABASE_URL, value: "$(DATABASE_ENGINE)://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)"}
           - {name: TELEMETRY_DATABASE_URL, value: "$(DATABASE_ENGINE)://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(DATABASE_NAME)"}
           - {name: USE_CLOUD_SQL_CONNECTOR, value: "true"}
-          - {name: CLOUD_SQL_INSTANCE, value: "mizzou-news-crawler:us-central1:mizzou-db-prod"}
+          - {name: CLOUD_SQL_INSTANCE, value: "mizzou-news-crawler:us-central1:mizzou-db-prod-ssd"}
           - {name: PROXY_PROVIDER, value: "squid"}
           - name: SQUID_PROXY_URL
             valueFrom: {secretKeyRef: {name: squid-proxy-credentials, key: squid-proxy-url}}

--- a/monitoring/create-alerts.sh
+++ b/monitoring/create-alerts.sh
@@ -117,7 +117,7 @@ conditions:
     conditionThreshold:
       filter: |
         resource.type = "cloudsql_database"
-        AND resource.labels.database_id = "mizzou-news-crawler:mizzou-db-prod"
+        AND resource.labels.database_id = "mizzou-news-crawler:mizzou-db-prod-ssd"
         AND metric.type = "cloudsql.googleapis.com/database/cpu/utilization"
       aggregations:
         - alignmentPeriod: "300s"
@@ -145,7 +145,7 @@ conditions:
     conditionThreshold:
       filter: |
         resource.type = "cloudsql_database"
-        AND resource.labels.database_id = "mizzou-news-crawler:mizzou-db-prod"
+        AND resource.labels.database_id = "mizzou-news-crawler:mizzou-db-prod-ssd"
         AND metric.type = "cloudsql.googleapis.com/database/memory/utilization"
       aggregations:
         - alignmentPeriod: "300s"

--- a/tests/test_no_retired_db_instance.py
+++ b/tests/test_no_retired_db_instance.py
@@ -1,0 +1,56 @@
+"""Nothing that gets deployed may name the retired database instance.
+
+The database moved from PD_HDD to PD_SSD. Cloud SQL cannot change
+storage type in place, so it meant a new instance under a new name, and
+`mizzou-db-prod` is being deleted.
+
+A runtime change does not survive a deploy. Both datadesk Cloud Run
+services were pointed at the new instance by hand and the next merge to
+main put them back, because the connection name is written into the
+deploy workflow and the Cloud Build substitutions. The service kept
+serving the whole time -- against the wrong database. That is the class
+of failure this guards: silent, and invisible from the outside.
+
+Historical records under docs/ are deliberately not covered. They
+describe what was true when they were written.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+RETIRED = "mizzou-db-prod"
+
+#: Everything whose contents reach a running system.
+DEPLOYED = (
+    "k8s/*.yaml",
+    "k8s/templates/*.yaml",
+    "k8s/argo/*.yaml",
+    "gcp/cloudbuild/*.yaml",
+    "manifests/*.yaml",
+    "monitoring/*.sh",
+    "gcp_functions/**/*.py",
+    "scripts/*.py",
+)
+
+
+def _offending_lines(path):
+    return [
+        line.strip()
+        for line in path.read_text(errors="ignore").splitlines()
+        if RETIRED in line and f"{RETIRED}-ssd" not in line
+    ]
+
+
+@pytest.mark.parametrize("pattern", DEPLOYED)
+def test_no_deployed_file_names_the_retired_instance(pattern):
+    offenders = {}
+    for path in REPO.glob(pattern):
+        lines = _offending_lines(path)
+        if lines:
+            offenders[str(path.relative_to(REPO))] = lines
+    assert not offenders, (
+        f"These are deployed and still name {RETIRED}, which is being "
+        f"deleted: {offenders}"
+    )


### PR DESCRIPTION
## Summary

PR #485 moved the k8s manifests, but I searched only `k8s/`, `.github/`, `scripts/` and `src/`. Four things outside those paths still named the retired instance, and each reaches a running system.

**`gcp/cloudbuild/cloudbuild.yaml`** writes `CLOUD_SQL_INSTANCE` into the deployed workloads, so the next build would have undone the migration. This is not hypothetical — datadesk's deploy silently reverted both its Cloud Run services to the old instance nine minutes after they were moved by hand, and the retired instance started taking fresh connections again while it was believed idle.

**`monitoring/create-alerts.sh`** filters on `database_id`, so the alert policies were watching an instance that is being deleted. They would have gone quiet rather than fired.

**`gcp_functions/weekly_source_health_check/main.py`** carries the connection name as the default when `CLOUDSQL_INSTANCE` is unset.

**`manifests/fresh-extraction-test.yaml`** would launch test pods against it.

## Changes

- Those four, plus `README.md` and the how-to documents that contain runnable commands.
- `tests/test_no_retired_db_instance.py` asserts nothing under `k8s/`, `gcp/`, `manifests/`, `monitoring/`, `gcp_functions/` or `scripts/` names the retired instance.

Dated records under `docs/` are deliberately excluded from the test and left unchanged — `PHASE_2.4_CLOUD_SQL_COMPLETE.md` and similar describe what was true when they were written.

## Verification

- YAML and Python parse; `create-alerts.sh` passes `bash -n`.
- No reference to the retired instance remains in any deployed path.
- Full pre-push suite green.

## Note on the cluster

The #485 merge built images but did not apply the manifests, so all seven live workloads were still pointing at the old instance afterwards. They have been patched directly with `kubectl set env` and the pods rolled cleanly; this PR keeps the repository and the cluster in agreement.