### PR TITLE
Split a dash-joined byline, and drop what follows it when it is an outlet

### DIFF
--- a/src/utils/byline_cleaner.py
+++ b/src/utils/byline_cleaner.py
@@ -473,6 +473,69 @@ class BylineCleaner:
         " + ",
     ]
 
+    # A dash or tilde in a byline means one of two things and the tail
+    # decides which. "Matthew Defranks - Nathan Mills" is two reporters;
+    # "John Garlock - Ktvo" is a reporter and the station that employs
+    # him. Neither was handled: both arrived in the column whole, so the
+    # first counted as one author with a strange name and the second
+    # carried an outlet into a name field.
+    #
+    # Tilde and "//" already split correctly. Dash did not, which is why
+    # 24 distinct bylines held several reporters in one string and 37
+    # held a name with an outlet appended.
+    # Dashes only. Tilde and "//" are already split correctly by the
+    # existing logic, which then drops the outlet against the publication
+    # list -- taking them over here replaced a working path with one that
+    # keeps "Standard Democrat" as a co-author wherever that list is not
+    # loaded.
+    _DASH_SPLIT = re.compile(r"\s+(?:-{1,2}|–|—)\s+")
+
+    # Trailing punctuation left where a separator had nothing after it:
+    # "Cecilia Velazquez -", "Courtney Waters --".
+    _TRAILING_SEPARATOR = re.compile(r"[\s]*(?:-{1,3}|–|—|:|,)\s*$")
+
+    # Name shape, used only to tell a co-author from an outlet. Particles
+    # may lead or repeat: "de la Cruz", "Maria de los Angeles Rodriguez".
+    _PARTICLE = (
+        r"(?:de|del|della|der|den|des|van|von|la|las|le|les|los|du|da|das|"
+        r"dos|bin|ibn|al|el|st|ter|te|di|do)"
+    )
+    _NAME_WORD = r"[A-Z][\w'\u2019.-]*"
+    _NAME_SHAPE = re.compile(
+        rf"^(?:{_PARTICLE}\s+)*{_NAME_WORD}"
+        rf"(?:\s+(?:{_PARTICLE}\s+)*{_NAME_WORD}){{1,5}}$",
+        re.UNICODE,
+    )
+
+    @classmethod
+    def _looks_like_a_person(cls, value: str) -> bool:
+        """Two or more name-shaped words, allowing particles and initials."""
+        return bool(cls._NAME_SHAPE.match((value or "").strip()))
+
+    @classmethod
+    def normalise_dash_separators(cls, byline: str) -> str:
+        """Rewrite dash-joined bylines so the rest of the pipeline sees them.
+
+        Returns a comma-joined string of the parts that look like people.
+        A part that does not -- a station, a section, a job title -- is
+        dropped, which is what the source-removal step would have done had
+        the outlet arrived in a field of its own.
+
+        Left alone when no part looks like a person, so a byline this
+        cannot read reaches the existing logic unchanged rather than being
+        emptied by a rule that did not understand it.
+        """
+        if not byline:
+            return byline
+        text = cls._TRAILING_SEPARATOR.sub("", byline).strip()
+        parts = [p.strip() for p in cls._DASH_SPLIT.split(text) if p and p.strip()]
+        if len(parts) < 2:
+            return text
+        people = [p for p in parts if cls._looks_like_a_person(p)]
+        if not people:
+            return text
+        return ", ".join(people)
+
     def __init__(self, enable_telemetry: bool = True):
         """Initialize the byline cleaner."""
         # Compile regex patterns for efficiency
@@ -548,6 +611,9 @@ class BylineCleaner:
 
             # Store source name for wire service filtering
             self._current_source_name = source_canonical_name or source_name
+
+            # Dash-joined bylines, before anything else reads them.
+            byline = self.normalise_dash_separators(byline)
 
             if not byline or not byline.strip():
                 self.telemetry.finalize_cleaning_session(

--- a/tests/test_byline_dash_separators.py
+++ b/tests/test_byline_dash_separators.py
@@ -1,0 +1,130 @@
+"""A dash in a byline means one of two things, and the tail decides which.
+
+"Matthew Defranks - Nathan Mills" is two reporters. "John Garlock - Ktvo"
+is a reporter and the station that employs him. Neither was handled:
+both reached the column whole, so the first counted as one author with a
+strange name and the second carried an outlet into a name field.
+
+Found by reading the 177 byline values a name-shape rule rejected. 116
+of them were real names -- 24 several reporters joined by a dash, 37 a
+name with an outlet appended, 43 a name with a trailing separator and
+nothing after it. A review queue would have asked about all of them; the
+fix is computable, so it belongs here instead.
+
+Tilde and "//" already split correctly. Dash did not.
+"""
+
+import pytest
+
+from src.utils.byline_cleaner import BylineCleaner
+
+# No logging.disable here. Called at module scope it is global and lasts
+# the whole session, so caplog captured nothing in every test that ran
+# afterwards -- which is why test_extraction_loop_resilience failed in
+# the full suite and passed on its own.
+
+
+@pytest.fixture
+def cleaner():
+    return BylineCleaner(enable_telemetry=False)
+
+
+# --- several reporters ------------------------------------------------------
+
+
+def test_two_reporters_joined_by_a_dash(cleaner):
+    assert cleaner.clean_byline("Matthew Defranks - Nathan Mills") == [
+        "Matthew Defranks",
+        "Nathan Mills",
+    ]
+
+
+def test_four_reporters_joined_by_dashes(cleaner):
+    assert cleaner.clean_byline(
+        "David Carson - Christian Gooden - Liz Rymarev - Laurie Skrivan"
+    ) == ["David Carson", "Christian Gooden", "Liz Rymarev", "Laurie Skrivan"]
+
+
+# --- a name with an outlet appended -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("John Garlock - Ktvo", ["John Garlock"]),
+        ("Jorge Borges - Local", ["Jorge Borges"]),
+        ("Tom Davis - Standard", ["Tom Davis"]),
+    ],
+)
+def test_the_outlet_does_not_reach_the_name_field(cleaner, raw, expected):
+    assert cleaner.clean_byline(raw) == expected
+
+
+# --- a separator with nothing after it --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["Cecilia Velazquez -", "Courtney Waters --", "Bob Miller -", "Julia Thomas -"],
+)
+def test_a_trailing_separator_is_removed(cleaner, raw):
+    cleaned = cleaner.clean_byline(raw)
+    assert cleaned and not cleaned[0].rstrip().endswith("-")
+
+
+# --- what must not change ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Jane Smith", ["Jane Smith"]),
+        ("Jane Smith and John Doe", ["Jane Smith", "John Doe"]),
+        ("Jane Smith, John Doe", ["Jane Smith", "John Doe"]),
+    ],
+)
+def test_bylines_that_already_worked_still_work(cleaner, raw, expected):
+    assert cleaner.clean_byline(raw) == expected
+
+
+# --- the name shape, which decides co-author from outlet ---------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Melissa Hernandez de la Cruz",
+        "Juan de la Cruz",
+        "Maria de los Angeles Rodriguez",
+        "Emily van de Riet",
+        "Vincent van der Berg",
+        "Oscar de la Renta",
+    ],
+)
+def test_particles_do_not_make_a_name_unreadable(name):
+    """A rule that rejects real names is worse than no rule. `los` was
+    missing from the first draft, which would have discarded
+    'Maria de los Angeles Rodriguez' as an outlet."""
+    assert BylineCleaner._looks_like_a_person(name)
+
+
+@pytest.mark.parametrize("value", ["Ktvo", "Admin", "Standard", "Fr", ""])
+def test_a_single_word_is_not_a_person(value):
+    assert not BylineCleaner._looks_like_a_person(value)
+
+
+def test_tilde_is_left_to_the_existing_logic(cleaner):
+    """It already split these correctly and dropped the outlet against
+    the publication list. Taking them over replaced a working path with
+    one that keeps "Standard Democrat" as a co-author wherever that list
+    is not loaded."""
+    assert (
+        BylineCleaner.normalise_dash_separators("Leonna Heuring~Standard Democrat")
+        == "Leonna Heuring~Standard Democrat"
+    )
+
+
+def test_a_byline_it_cannot_read_is_left_alone(cleaner):
+    """Left for the existing logic rather than emptied by a rule that did
+    not understand it."""
+    assert BylineCleaner.normalise_dash_separators("Knem/Knmo") == "Knem/Knmo"


### PR DESCRIPTION
## Summary

A dash in a byline means one of two things, and the tail decides which:

- `Matthew Defranks - Nathan Mills` — two reporters
- `John Garlock - Ktvo` — a reporter and the station that employs him

Neither was handled. Both reached the column whole, so the first counted as one author with a strange name and the second carried an outlet into a name field.

`articles.author` is the **cleaned** value — `clean_byline` runs on the extraction write path and `_format_cleaned_authors` joins the result. So these had already been through cleaning.

## How it was found

By reading the 177 byline values that a name-shape rule rejected. **116 of the 177 were real names:**

| category | distinct | articles |
|---|---|---|
| real name, trailing separator only | 43 | 75 |
| real name plus outlet or affiliation | 37 | 42 |
| several reporters joined by a dash | 24 | 37 |
| real name with a quoted nickname | 6 | 10 |
| real name with a date appended | 6 | 6 |
| genuinely not a person | 61 | 143 |

The fix is computable, so it belongs in cleaning rather than in a review queue.

## Scope

Live defects, still occurring on the last day the pipeline ran (12 Aug): 76 dash-joined bylines, 153 with a trailing separator.

Not addressed here: 1,319 rows with a JSON list in the column (`["Admin"]`). Those are confined to 21–23 September 2025 and nothing since — legacy data needing a backfill, not a cleaning gap.

## Changes

- `normalise_dash_separators` rewrites a dash-joined byline before the rest of the pipeline reads it, keeping the parts that look like people. A byline where no part looks like a person is left alone rather than emptied by a rule that did not understand it.
- Trailing separators removed: `Cecilia Velazquez -`, `Courtney Waters --`.

**Tilde and `//` are deliberately untouched.** They already split correctly and then drop the outlet against the publication list. Taking them over replaced a working path with one that keeps `Standard Democrat` as a co-author wherever that list is not loaded — a regression the tests caught and my manual check missed, because a shared cleaner instance had already populated the cache.

The name shape used to tell a co-author from an outlet allows particles to lead and to repeat: `de la Cruz`, `Maria de los Angeles Rodriguez`. `los` was missing from the first draft, which would have discarded a real byline as an outlet.

## Verification

- `tests/test_byline_dash_separators.py`, 25 tests, including the particle forms and that bylines which already worked still do.
- All 188 existing byline tests pass; full pre-push suite green.

## A defect this PR introduced and removed

The first version of the test file called `logging.disable(logging.CRITICAL)` at module scope. That is global and lasts the whole pytest session, so `caplog` captured nothing in every test that ran afterwards, and `test_extraction_loop_resilience` failed in the full suite while passing on its own. Removed.

## Found, not fixed

`Jane Smith & John Doe` cleans to `['Jane Smith Doe']` — a word is deleted. `A B & C D` gives `A D`. Different mechanism from the separators; 34 articles across 27 distinct bylines. `AUTHOR_SEPARATORS` is also dead code: defined, never referenced.